### PR TITLE
Minimal support for PVR Addon API 1.9.7

### DIFF
--- a/pvr.vuplus/addon.xml
+++ b/pvr.vuplus/addon.xml
@@ -6,7 +6,7 @@
   provider-name="Joerg Dembski">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="1.9.6"/>
+    <import addon="xbmc.pvr" version="1.9.7"/>
   </requires>
   <extension
     point="xbmc.pvrclient"

--- a/pvr.vuplus/addon.xml
+++ b/pvr.vuplus/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="1.10.5"
+  version="1.11.0"
   name="VU+ / Enigma2 Client"
   provider-name="Joerg Dembski">
   <requires>

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,3 +1,6 @@
+1.11.0
+- Updated to API v1.9.7
+
 v1.10.5
 - updated language files from Transifex
 

--- a/src/VuData.cpp
+++ b/src/VuData.cpp
@@ -145,7 +145,6 @@ void Vu::TimerUpdates()
           m_timers[i].iChannelId = newtimer[j].iChannelId;
           m_timers[i].startTime = newtimer[j].startTime;
           m_timers[i].endTime = newtimer[j].endTime;
-          m_timers[i].bRepeating = newtimer[j].bRepeating;
           m_timers[i].iWeekdays = newtimer[j].iWeekdays;
           m_timers[i].iEpgID = newtimer[j].iEpgID;
 
@@ -1031,6 +1030,10 @@ PVR_ERROR Vu::GetTimers(ADDON_HANDLE handle)
     XBMC->Log(LOG_DEBUG, "%s - Transfer timer '%s', ClientIndex '%d'", __FUNCTION__, timer.strTitle.c_str(), timer.iClientIndex);
     PVR_TIMER tag;
     memset(&tag, 0, sizeof(PVR_TIMER));
+
+    /* TODO: Implement own timer types to get support for the timer features introduced with PVR API 1.9.7 */
+    tag.iTimerType = PVR_TIMER_TYPE_NONE;
+
     tag.iClientChannelUid = timer.iChannelId;
     tag.startTime         = timer.startTime;
     tag.endTime           = timer.endTime;
@@ -1040,7 +1043,6 @@ PVR_ERROR Vu::GetTimers(ADDON_HANDLE handle)
     tag.state             = timer.state;
     tag.iPriority         = 0;     // unused
     tag.iLifetime         = 0;     // unused
-    tag.bIsRepeating      = timer.bRepeating;
     tag.firstDay          = 0;     // unused
     tag.iWeekdays         = timer.iWeekdays;
     tag.iEpgUid           = timer.iEpgID;
@@ -1137,11 +1139,6 @@ std::vector<VuTimer> Vu::LoadTimers()
     else 
       timer.iWeekdays = 0;
 
-    if (timer.iWeekdays != 0)
-      timer.bRepeating      = true; 
-    else
-      timer.bRepeating = false;
-    
     if (XMLUtils::GetInt(pNode, "e2eit", iTmp))
       timer.iEpgID = iTmp;
     else 

--- a/src/VuData.h
+++ b/src/VuData.h
@@ -86,7 +86,6 @@ struct VuTimer
   int iChannelId;
   time_t startTime;
   time_t endTime;
-  bool bRepeating; 
   int iWeekdays;
   int iEpgID;
   PVR_TIMER_STATE state; 
@@ -104,7 +103,6 @@ struct VuTimer
     bChanged = bChanged && (startTime == right.startTime); 
     bChanged = bChanged && (endTime == right.endTime); 
     bChanged = bChanged && (iChannelId == right.iChannelId); 
-    bChanged = bChanged && (bRepeating == right.bRepeating); 
     bChanged = bChanged && (iWeekdays == right.iWeekdays); 
     bChanged = bChanged && (iEpgID == right.iEpgID); 
 
@@ -117,7 +115,6 @@ struct VuTimer
     bChanged = bChanged && (startTime == right.startTime); 
     bChanged = bChanged && (endTime == right.endTime); 
     bChanged = bChanged && (iChannelId == right.iChannelId); 
-    bChanged = bChanged && (bRepeating == right.bRepeating); 
     bChanged = bChanged && (iWeekdays == right.iWeekdays); 
     bChanged = bChanged && (iEpgID == right.iEpgID); 
     bChanged = bChanged && (state == right.state); 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -336,7 +336,6 @@ PVR_ERROR GetAddonCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities)
   pCapabilities->bSupportsRadio              = true;
   pCapabilities->bSupportsRecordings         = true;
   pCapabilities->bSupportsRecordingsUndelete = false;
-  pCapabilities->bSupportsRecordingFolders   = true;
   pCapabilities->bSupportsTimers             = true;
   pCapabilities->bSupportsChannelGroups      = true;
   pCapabilities->bSupportsChannelScan        = false;
@@ -433,6 +432,12 @@ PVR_ERROR RenameRecording(const PVR_RECORDING &recording)
   return PVR_ERROR_NOT_IMPLEMENTED;
 }
 
+PVR_ERROR GetTimerTypes(PVR_TIMER_TYPE types[], int *size)
+{
+  /* TODO: Implement this to get support for the timer features introduced with PVR API 1.9.7 */
+  return PVR_ERROR_NOT_IMPLEMENTED;
+}
+
 int GetTimersAmount(void)
 {
   if (!VuData || !VuData->IsConnected())
@@ -446,6 +451,7 @@ PVR_ERROR GetTimers(ADDON_HANDLE handle)
   if (!VuData || !VuData->IsConnected())
     return PVR_ERROR_SERVER_ERROR;
 
+  /* TODO: Change implementation to get support for the timer features introduced with PVR API 1.9.7 */
   return VuData->GetTimers(handle);
 }
 
@@ -457,11 +463,12 @@ PVR_ERROR AddTimer(const PVR_TIMER &timer)
   return VuData->AddTimer(timer);
 }
 
-PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete)
+PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete, bool /*bDeleteScheduled*/)
 {
   if (!VuData || !VuData->IsConnected())
     return PVR_ERROR_SERVER_ERROR;
 
+  /* TODO: Change implementation to support bDeleteScheduled (introduced with PVR API 1.9.7 */
   return VuData->DeleteTimer(timer);
 }
 


### PR DESCRIPTION
For, J**** PVR Addon API will be bumped to version 1.9.7 to introduce a couple of new features and enhancements for timers (esp. official series recording support). => https://github.com/xbmc/xbmc/pull/7079

This PR will ensure compatibility with and add minimalistic support for PVR addon API 1.9.7. Even if the maintainers of this addon will do nothing except merging this PR and bump the addon version in Kodi, the addon will still be usable in J**** and not loose any functionality compared to Isengard, but it will not profit from the new features. For the latter, every addon maintainer must do the respective changes on his own.