### PR TITLE
request live-stream-URL from OpenWebif instead of generating it (Isengard)

### DIFF
--- a/src/VuData.cpp
+++ b/src/VuData.cpp
@@ -539,17 +539,8 @@ bool Vu::LoadChannels(CStdString strServiceReference, CStdString strGroupName)
 
     newChannel.strIconPath = strIcon;
 
-    strTmp.Format("");
-
-    if ((g_strUsername.length() > 0) && (g_strPassword.length() > 0))
-      strTmp.Format("%s:%s@", g_strUsername.c_str(), g_strPassword.c_str());
-    
-    if (!g_bUseSecureHTTP)
-      strTmp.Format("http://%s%s:%d/%s", strTmp.c_str(), g_strHostname, g_iPortStream, strTmp2.c_str());
-    else
-      strTmp.Format("https://%s%s:%d/%s", strTmp.c_str(), g_strHostname, g_iPortStream, strTmp2.c_str());
-    
-    newChannel.strStreamURL = strTmp;
+    strTmp.Format("%s/web/stream.m3u?ref=%s", m_strURL.c_str(), URLEncodeInline(newChannel.strServiceReference.c_str()));
+    newChannel.strM3uURL = strTmp;
 
     if (g_bOnlinePicons == true)
     {
@@ -564,6 +555,22 @@ bool Vu::LoadChannels(CStdString strServiceReference, CStdString strGroupName)
 
   XBMC->Log(LOG_INFO, "%s Loaded %d Channels", __FUNCTION__, m_channels.size());
   return true;
+}
+
+std::string Vu::getStreamURL(std::string& strM3uURL)
+{
+    CStdString strTmp;
+    strTmp = strM3uURL;
+    std::string strM3U;
+    strM3U = GetHttpXML(strTmp);
+    std::istringstream streamM3U(strM3U);
+    std::string strURL = "";
+    while (std::getline(streamM3U, strURL))
+    {
+      if (strURL.compare(0, 4, "http", 4) == 0)
+        break;
+    };
+    return strURL;
 }
 
 bool Vu::IsConnected() 
@@ -1673,7 +1680,13 @@ const char* Vu::GetLiveStreamURL(const PVR_CHANNEL &channelinfo)
 {
   SwitchChannel(channelinfo);
 
-  return m_channels.at(channelinfo.iUniqueId-1).strStreamURL.c_str();
+  // we need to download the M3U file that contains the URL for the stream...
+  // we do it here for 2 reasons:
+  //  1. This is faster than doing it during initialization
+  //  2. The URL can change, so this is more up-to-date.
+  std::string strStreamURL;
+  strStreamURL = getStreamURL(m_channels.at(channelinfo.iUniqueId-1).strM3uURL);
+  return strStreamURL.c_str();
 }
 
 bool Vu::OpenLiveStream(const PVR_CHANNEL &channelinfo)

--- a/src/VuData.h
+++ b/src/VuData.h
@@ -75,7 +75,8 @@ struct VuChannel
   std::string strGroupName;
   std::string strChannelName;
   std::string strServiceReference;
-  std::string strStreamURL;
+//  std::string strStreamURL;
+  std::string strM3uURL;
   std::string strIconPath;
 };
 
@@ -186,6 +187,7 @@ private:
   void TimerUpdates();
   bool GetDeviceInfo();
   int GetRecordingIndex(CStdString);
+  std::string getStreamURL(std::string& strM3uURL);
 
   // helper functions
   static long TimeStringToSeconds(const CStdString &timeString);


### PR DESCRIPTION
Hello,

this fixes the alternative channels problem that is described in issue #20.

If have added some code to read out the streamURL from the M3u file that can be downloaded by a web/stream.m3u?ref=ref request.
I should mention that I have tested it without https and/or password, hoping that these are automatically inserted into the M3U-file by openWebIf.

Best regards,
Steffen.