### PR TITLE
 Update to PVR addon API v4.1.0

### DIFF
--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="1.11.5"
+  version="1.11.6"
   name="VU+ / Enigma2 Client"
   provider-name="Joerg Dembski">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="4.0.0"/>
+    <import addon="xbmc.pvr" version="4.1.0"/>
   </requires>
   <extension
     point="xbmc.pvrclient"

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,3 +1,6 @@
+1.11.6
+- Updated to PVR API v4.1.0
+
 1.11.5
 - Updated to PVR API v4.0.0
 

--- a/src/VuData.cpp
+++ b/src/VuData.cpp
@@ -820,6 +820,7 @@ PVR_ERROR Vu::GetInitialEPGForChannel(ADDON_HANDLE handle, const VuChannel &chan
       broadcast.iEpisodeNumber      = 0;  // unused
       broadcast.iEpisodePartNumber  = 0;  // unused
       broadcast.strEpisodeName      = ""; // unused
+      broadcast.iFlags              = EPG_TAG_FLAG_UNDEFINED;
 
       PVR->TransferEpgEntry(handle, &broadcast);
     }
@@ -981,6 +982,7 @@ PVR_ERROR Vu::GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL &channel, 
     broadcast.iEpisodeNumber      = 0;  // unused
     broadcast.iEpisodePartNumber  = 0;  // unused
     broadcast.strEpisodeName      = ""; // unused
+    broadcast.iFlags              = EPG_TAG_FLAG_UNDEFINED;
 
     PVR->TransferEpgEntry(handle, &broadcast);
 


### PR DESCRIPTION
This PR implements all changes needed to properly support PVR Addon API v4.1.0, including a PVR addon micro version bump.

Details can be found here: xbmc/xbmc#8075
