### PR TITLE
Update to libp8-platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,11 +8,11 @@ enable_language(CXX)
 
 find_package(kodi REQUIRED)
 find_package(kodiplatform REQUIRED)
-find_package(platform REQUIRED)
+find_package(p8-platform REQUIRED)
 find_package(TinyXML REQUIRED)
 
 include_directories(${kodiplatform_INCLUDE_DIRS}
-                    ${platform_INCLUDE_DIRS}
+                    ${p8-platform_INCLUDE_DIRS}
                     ${TINYXML_INCLUDE_DIR}
                     ${KODI_INCLUDE_DIR})
 
@@ -20,7 +20,7 @@ set(VUPLUS_SOURCES src/client.cpp
                    src/VuData.cpp)
 
 set(DEPLIBS ${kodiplatform_LIBRARIES}
-            ${platform_LIBRARIES}
+            ${p8-platform_LIBRARIES}
             ${TINYXML_LIBRARIES})
 
 build_addon(pvr.vuplus VUPLUS DEPLIBS)

--- a/src/VuData.cpp
+++ b/src/VuData.cpp
@@ -29,7 +29,7 @@
 
 
 using namespace ADDON;
-using namespace PLATFORM;
+using namespace P8PLATFORM;
 
 bool CCurlFile::Get(const std::string &strURL, std::string &strResult)
 {

--- a/src/VuData.h
+++ b/src/VuData.h
@@ -21,9 +21,9 @@
  *
  */
 
-#include "platform/util/StdString.h"
+#include "p8-platform/util/StdString.h"
 #include "client.h"
-#include "platform/threads/threads.h"
+#include "p8-platform/threads/threads.h"
 #include "tinyxml.h"
     
 #define CHANNELDATAVERSION  2
@@ -140,7 +140,7 @@ struct VuRecording
   std::string strIconPath;
 };
  
-class Vu  : public PLATFORM::CThread
+class Vu  : public P8PLATFORM::CThread
 {
 private:
 
@@ -164,8 +164,8 @@ private:
   std::vector<std::string> m_locations;
   unsigned int m_iClientIndexCounter;
 
-  PLATFORM::CMutex m_mutex;
-  PLATFORM::CCondition<bool> m_started;
+  P8PLATFORM::CMutex m_mutex;
+  P8PLATFORM::CCondition<bool> m_started;
 
   bool m_bUpdating;
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -25,7 +25,7 @@
 #include "kodi/libKODI_guilib.h"
 #include <stdlib.h>
 #include "VuData.h"
-#include "platform/util/util.h"
+#include "p8-platform/util/util.h"
 
 using namespace std;
 using namespace ADDON;


### PR DESCRIPTION
Do not merge this! Needs libp8-platform-dev packaging first and it's missing add-on bump.
Also, currently untested.