### PR TITLE
Rename addon title to "Vu+ / Enigma2 PVR Client Addon"

### DIFF
--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -2,7 +2,7 @@
 <addon
   id="pvr.vuplus"
   version="2.2.1"
-  name="VU+ / Enigma2 Client"
+  name="Vu+ / Enigma2 PVR Client Addon"
   provider-name="Joerg Dembski">
   <requires>
     <c-pluff version="0.1"/>


### PR DESCRIPTION
Suggest renaming of the addon title to "Vu+ / Enigma2 PVR Client Addon" just to try to make it a little more clear and more consistant with the naming-standard of the other PVR client addons for Kodi.