### PR TITLE
added option to keep the folder structure from STB

### DIFF
--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="3.3.1"
+  version="3.3.2"
   name="VU+ / Enigma2 Client"
   provider-name="Joerg Dembski">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,3 +1,6 @@
+v3.3.2
+- added option to keep the folder structure from STB
+
 v3.3.1
 - added option to request the streaming-URL from openWebif and thus eliminating the need to configure the streaming port
 

--- a/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
@@ -128,7 +128,11 @@ msgctxt "#30029"
 msgid "Enable automatic configuration for live streams"
 msgstr ""
 
-#empty strings from id 30029 to 30499
+msgctxt "#30030"
+msgid "Keep folder structure for records"
+msgstr ""
+
+#empty strings from id 30031 to 30499
 #notifications
 
 msgctxt "#30500"

--- a/pvr.vuplus/resources/settings.xml
+++ b/pvr.vuplus/resources/settings.xml
@@ -27,5 +27,6 @@
     <setting label="30017" type="bool" id="onlycurrent" default="false"/>
     <setting label="30011" type="bool" id="timerlistcleanup" default="false"/>
     <setting label="30024" type="bool" id="setpowerstate" default="false" />
+    <setting label="30030" type="bool" id="keepfolders" default="false" />
   </category>
 </settings>

--- a/src/VuData.cpp
+++ b/src/VuData.cpp
@@ -1369,12 +1369,16 @@ void Vu::TransferRecordings(ADDON_HANDLE handle)
     strncpy(tag.strChannelName, recording.strChannelName.c_str(), sizeof(tag.strChannelName));
     strncpy(tag.strIconPath, recording.strIconPath.c_str(), sizeof(tag.strIconPath));
 
-    if(IsInRecordingFolder(recording.strTitle))
-      strTmp.Format("/%s/", recording.strTitle.c_str());
-    else
-      strTmp.Format("/");
+    if (!g_bKeepFolders)
+    {
+      if(IsInRecordingFolder(recording.strTitle))
+        strTmp.Format("/%s/", recording.strTitle.c_str());
+      else
+        strTmp.Format("/");
 
-    recording.strDirectory = strTmp;
+      recording.strDirectory = strTmp;
+    }
+
     strncpy(tag.strDirectory, recording.strDirectory.c_str(), sizeof(tag.strDirectory));
     tag.recordingTime     = recording.startTime;
     tag.iDuration         = recording.iDuration;
@@ -1392,11 +1396,18 @@ void Vu::TransferRecordings(ADDON_HANDLE handle)
 bool Vu::GetRecordingFromLocation(CStdString strRecordingFolder)
 {
   CStdString url;
+  CStdString directory;
 
   if (!strRecordingFolder.compare("default"))
+  {
     url.Format("%s%s", m_strURL.c_str(), "web/movielist"); 
+    directory.Format("/");
+  }
   else 
+  {
     url.Format("%s%s?dirname=%s", m_strURL.c_str(), "web/movielist", URLEncodeInline(strRecordingFolder.c_str())); 
+    directory = strRecordingFolder;
+  }
  
   CStdString strXML;
   strXML = GetHttpXML(url);
@@ -1438,6 +1449,8 @@ bool Vu::GetRecordingFromLocation(CStdString strRecordingFolder)
     int iTmp;
 
     VuRecording recording;
+
+    recording.strDirectory = directory;
 
     recording.iLastPlayedPosition = 0;
     if (XMLUtils::GetString(pNode, "e2servicereference", strTmp))

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -102,7 +102,7 @@ void ADDON_ReadSettings(void)
   if (!XBMC->GetSetting("use_secure", &g_bUseSecureHTTP))
     g_bUseSecureHTTP = false;
   
-  /* read setting "use_secure" from settings.xml */
+  /* read setting "autoconfig" from settings.xml */
   if (!XBMC->GetSetting("autoconfig", &g_bAutoConfig))
     g_bAutoConfig = false;
   

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -55,6 +55,7 @@ bool        g_bOnlyOneGroup           = false;
 bool        g_bOnlinePicons           = true;
 bool        g_bUseSecureHTTP          = false;
 bool        g_bAutoConfig             = false;
+bool        g_bKeepFolders            = false;
 std::string g_strOneGroup             = "";
 std::string g_szClientPath            = "";
 
@@ -124,6 +125,10 @@ void ADDON_ReadSettings(void)
   /* read setting "setpowerstate" from settings.xml */
   if (!XBMC->GetSetting("setpowerstate", &g_bSetPowerstate))
     g_bSetPowerstate = false;
+  
+  /* read setting "keepfolders" from settings.xml */
+  if (!XBMC->GetSetting("keepfolders", &g_bKeepFolders))
+    g_bKeepFolders = false;
   
   /* read setting "zap" from settings.xml */
   if (!XBMC->GetSetting("zap", &g_bZap))

--- a/src/client.h
+++ b/src/client.h
@@ -46,6 +46,7 @@ extern bool			 g_bZap;
 extern bool                      g_bAutomaticTimerlistCleanup;
 extern bool                      g_bUseSecureHTTP;
 extern bool                      g_bAutoConfig;
+extern bool                      g_bKeepFolders;
 extern bool                      g_bOnlyCurrentLocation;
 extern bool			 g_bSetPowerstate;
 extern bool			 g_bOnlyOneGroup;


### PR DESCRIPTION
On Enigma2 based devices it is possible to store records into separate folders. There are even plug-ins that automatically put series into separate folders, like "Serien Recorder".
But there are also some scenarios where it could make sense to combine all records into one folder.

Thus I added an option to the settings dialog that allows users to use the folder structure from the STB with this pvr-plug-in.
The new option needs to be explicitly enabled, default is the old behavior.