### PR TITLE
Streaming always use anonymous http connection

### DIFF
--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="3.0.1"
+  version="3.0.2"
   name="VU+ / Enigma2 Client"
   provider-name="Joerg Dembski">
   <requires>

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,3 +1,9 @@
+v3.0.2
+- streaming always use anonymous http connection, regardless of the "Use https" setting
+
+v3.0.1
+- updated language files from Transifex
+
 v3.0.0
 - Initial Kodi v18 version
 

--- a/src/VuData.cpp
+++ b/src/VuData.cpp
@@ -540,14 +540,8 @@ bool Vu::LoadChannels(CStdString strServiceReference, CStdString strGroupName)
 
     strTmp.Format("");
 
-    if ((g_strUsername.length() > 0) && (g_strPassword.length() > 0))
-      strTmp.Format("%s:%s@", g_strUsername.c_str(), g_strPassword.c_str());
-    
-    if (!g_bUseSecureHTTP)
-      strTmp.Format("http://%s%s:%d/%s", strTmp.c_str(), g_strHostname, g_iPortStream, strTmp2.c_str());
-    else
-      strTmp.Format("https://%s%s:%d/%s", strTmp.c_str(), g_strHostname, g_iPortStream, strTmp2.c_str());
-    
+    strTmp.Format("http://%s:%d/%s", g_strHostname, g_iPortStream, strTmp2.c_str());    
+
     newChannel.strStreamURL = strTmp;
 
     if (g_bOnlinePicons == true)


### PR DESCRIPTION
Streaming always use anonymous http connection, regardless of the "Use https" setting.

Same as #51 on Krypton