### PR TITLE
[fix] wrong string replace syntax introduced at f445200

### DIFF
--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="3.5.5"
+  version="3.5.6"
   name="VU+ / Enigma2 Client"
   provider-name="Joerg Dembski">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,3 +1,6 @@
+v3.5.6
+- Fix string replace syntax
+
 v3.5.5
 - Remove StdString usage
 

--- a/src/VuData.cpp
+++ b/src/VuData.cpp
@@ -22,6 +22,8 @@
 
 #include "VuData.h"
 #include "client.h" 
+
+#include <algorithm>
 #include <iostream> 
 #include <fstream> 
 #include <string>
@@ -538,7 +540,7 @@ bool Vu::LoadChannels(std::string strServiceReference, std::string strGroupName)
 
     strTmp2 = StringUtils::Format("%s", strIcon.c_str());
 
-    strIcon.replace(strIcon.begin(), strIcon.end(), ':', '_');
+    std::replace(strIcon.begin(), strIcon.end(), ':', '_');
     strIcon = g_strIconPath.c_str() + strIcon + ".png";
 
     newChannel.strIconPath = strIcon;
@@ -551,7 +553,7 @@ bool Vu::LoadChannels(std::string strServiceReference, std::string strGroupName)
 
     if (g_bOnlinePicons == true)
     {
-      strTmp2.replace(strTmp2.begin(), strTmp2.end(), ':', '_');
+      std::replace(strTmp2.begin(), strTmp2.end(), ':', '_');
       strTmp = StringUtils::Format("%spicon/%s.png", m_strURL.c_str(), strTmp2.c_str());
       newChannel.strIconPath = strTmp;
     }


### PR DESCRIPTION
Accidentally changed it because of  errors caused by the missing `algorithm` include (which was included by `StdString.h` previously)

@ksooo ping
@MilhouseVH FYI