### PR TITLE
GetDriveSpace for Enigma2 based pvr clients

### DIFF
--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="3.6.4"
+  version="3.6.5"
   name="VU+ / Enigma2 Client"
   provider-name="Joerg Dembski">
   <requires>@ADDON_DEPENDS@</requires>
@@ -79,7 +79,7 @@
     <description lang="es_MX">VU+ frontend; Soportando transmisión de TV en directo y grabaciones, EPG, Temporizadores.</description>
     <description lang="et_EE">VU+ liides. Toetab telekanalite striimimist ja salvestamist ning elektroonilist saatekava.</description>
     <description lang="fi_FI">VU+-asiakasohjelma. Tukee suorien tv-lähetysten ja tallennusten katsomista, ohjelmaopasta ja ohjelmien ajastamista.</description>
-    <description lang="fr_CA">Frontal VU+, prenant en charge la diffusion en continu des télés en direct et les enregistrements, le GÉP et les minuteries.</description>
+    <description lang="fr_CA">Frontal VU+, prenant en charge la diffusion en continu des télés en direct et les enregistrements, le GÉP et les minuteries</description>
     <description lang="fr_FR">Interface logicielle pour enregistreur VU+. Gère la diffusion et les enregistrements de la TV en direct, le guide électronique des programmes TV et les programmations.</description>
     <description lang="gl_ES">Interface VU+; soporta TV en directo, gravacións, Guía de programación e temporizadores.</description>
     <description lang="he_IL">לקוח טלוויזיה חיה של VU+. תומך בהזרמת שידורים חיים והקלטות, הצגת לוח שידורים ותזמון הקלטות.</description>
@@ -132,7 +132,7 @@
     <disclaimer lang="et_EE">See on ebastabiilne tarkvara! Autorid ei ole kuidagi moodi vastutavad nurjunud salvestiste, ebaõige aegrelee, raisatud tundide ega muude soovimatute asjade eest.</disclaimer>
     <disclaimer lang="eu_ES">Software hau beta bertsioan dago! Egilea ez da arduratzen grabaketa erroretaz, kronometro erroreak, hordu galduak edo beste edozein ondorio ezerosotaz</disclaimer>
     <disclaimer lang="fi_FI">Tämä on epävakaa ohjelma! Sen tekijät eivät ole millään muotoa vastuussa epäonnistuneista tallennuksista, virheellisistä ajastuksista, haaskatusta ajasta, verenpaineen noususta tai mistään muusta epäsuotuisasta vaikutuksesta.</disclaimer>
-    <disclaimer lang="fr_CA">Ce logiciel est instable! Les auteurs ne sont aucunement responsables des enregistrements défaillants, des minuteries erronées, des heures perdues ou tout autre effet indésirable.</disclaimer>
+    <disclaimer lang="fr_CA">Ce logiciel est instable ! Les auteurs ne sont aucunement responsables des enregistrements défaillants, des minuteries erronées, des heures perdues ou tout autre effet indésirable.</disclaimer>
     <disclaimer lang="fr_FR">Logiciel en cours d'élaboration ! Les auteurs ne sont en aucun cas responsables de l'échec des enregistrements, programmations défectueuses, temps perdu ou autres effets indésirables.</disclaimer>
     <disclaimer lang="gl_ES">Software non estable, os autores non se fan responsábeis dos erros na gravacións, temporizadores incorrectos, e outros efectos non desexados.</disclaimer>
     <disclaimer lang="he_IL">זוהי איננה הרחבה יציבה! המפתחים אינם אחראים על כשלון בניגון, זמנים שגויים במדריך השידורים, שעות מבוזבזות או כל תופעה לא רצויה אחרת.</disclaimer>

--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="3.6.2"
+  version="3.6.3"
   name="VU+ / Enigma2 Client"
   provider-name="Joerg Dembski">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="3.6.5"
+  version="3.7.0"
   name="VU+ / Enigma2 Client"
   provider-name="Joerg Dembski">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="3.6.3"
+  version="3.6.4"
   name="VU+ / Enigma2 Client"
   provider-name="Joerg Dembski">
   <requires>@ADDON_DEPENDS@</requires>
@@ -11,7 +11,7 @@
   <extension point="xbmc.addon.metadata">
     <summary lang="af_ZA">Kodi se voorprogram vir VU+ / Enigma2 gebasseerde 'set-top' bokse</summary>
     <summary lang="be_BY">Kodi's frontend for VU+ / Enigma2 based settop boxes</summary>
-    <summary lang="bg_BG">Kodi клиент за тунери базирани на VU+ / Enigma2</summary>
+    <summary lang="bg_BG">Клиент за устройства, базирани на VU+ / Enigma2</summary>
     <summary lang="ca_ES">Frontal de Kodi per als descodificadors basats en VU+/Enigma2</summary>
     <summary lang="cs_CZ">Rozhraní Kodi pro přijímače založené na VU+ nebo Enigma2</summary>
     <summary lang="cy_GB">Blaen Kodi ar gyfer blychau teledu VU+ / Enigma2</summary>
@@ -63,7 +63,7 @@
     <summary lang="zh_TW">給以VU+ / Enigma2開發的機上盒所使用的Kodi前端</summary>
     <description lang="af_ZA">VU+ voorprogram; ondersteun stroom van Lewendige TV &amp; Opnames, EPG, Tydhouers.</description>
     <description lang="be_BY">VU+ frontend; supporting streaming of Live TV &amp; Recordings, EPG, Timers.</description>
-    <description lang="bg_BG">VU+ клиент. Поддържа поточна телевизия и записване, електронен програмен справочник и броячи.</description>
+    <description lang="bg_BG">Клиент за „VU+“. Поддържа телевизия на живо и записване, електронен програмен справочник и броячи.</description>
     <description lang="ca_ES">Frontal de VU+; és compatible amb les transmissions en línia de TV en directe i enregistraments, guia electrònica de programació (EPG) i temporitzadors.</description>
     <description lang="cs_CZ">Rozhraní VU+; podporuje streamování živého vysílání a nahrávání, televizní program, časovače.</description>
     <description lang="cy_GB">Blaen VU+; cynnal ffrydio Teledu Byw, Recordio, Amserlenni, Amseryddion</description>

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,3 +1,6 @@
+v3.6.3
+- Updated to PVR addon API v5.9.0
+
 v3.6.0
 - Updated to PVR addon API v5.8.0
 

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,3 +1,6 @@
+v3.7.0
+- Updated to PVR addon API v5.10.0
+
 v3.6.3
 - Updated to PVR addon API v5.9.0
 

--- a/pvr.vuplus/resources/language/resource.language.bg_bg/strings.po
+++ b/pvr.vuplus/resources/language/resource.language.bg_bg/strings.po
@@ -18,7 +18,7 @@ msgstr ""
 
 msgctxt "#30000"
 msgid "VU+ hostname or IP address"
-msgstr "VU+ хост или IP адрес"
+msgstr "Име на хост или IP адрес на VU+"
 
 msgctxt "#30002"
 msgid "Streaming Port"
@@ -34,15 +34,15 @@ msgstr "Парола"
 
 msgctxt "#30007"
 msgid "Response timeout in seconds"
-msgstr "Време на изчакване на отговор (секунди)"
+msgstr "Време на изчакване за отговор (секунди)"
 
 msgctxt "#30008"
 msgid "Icon Path"
-msgstr "Път до иконите"
+msgstr "Път до иконките"
 
 msgctxt "#30010"
 msgid "Update Interval in minutes"
-msgstr "Интервал за обновяване в минути"
+msgstr "Интервал на обновяване (минути)"
 
 msgctxt "#30011"
 msgid "Automatic Timerlist Cleanup"
@@ -54,23 +54,23 @@ msgstr "Порт на уеб интерфейса"
 
 msgctxt "#30013"
 msgid "Zap before channelswitch (i.e. for Single Tuner boxes)"
-msgstr "Нулиране преди превключване на канал (за едно-тунерни устройства)"
+msgstr "Нулиране преди превключване на канал (за устройства с един тунер)"
 
 msgctxt "#30014"
 msgid "Folder for channeldata"
-msgstr "Папка за данните на канала"
+msgstr "Папка за данните на каналите"
 
 msgctxt "#30015"
 msgid "Check for bouquett updates"
-msgstr "Провери за обновявания на букетите"
+msgstr "Проверка за промени на букетите"
 
 msgctxt "#30016"
 msgid "Check for channel updates"
-msgstr "Проверявай за обновяване на каналите"
+msgstr "Проверка за промени по каналите"
 
 msgctxt "#30017"
 msgid "Use only the DVB boxes' current recording path"
-msgstr "Ползвай само за запис на зададения в DVB път"
+msgstr "Използване само на текущия път за запис на устройствата"
 
 msgctxt "#30018"
 msgid "General"
@@ -82,7 +82,7 @@ msgstr "Канали"
 
 msgctxt "#30020"
 msgid "Advanced"
-msgstr "Допълнителни"
+msgstr "Разширени"
 
 msgctxt "#30021"
 msgid "HTTP"
@@ -98,11 +98,11 @@ msgstr "Папка за записите на приемника"
 
 msgctxt "#30024"
 msgid "Send DeepStandby-Command"
-msgstr "Изпращай DeepStandby команда"
+msgstr "Изпращане на команда за дълбоко заспиване"
 
 msgctxt "#30025"
 msgid "Fetch only one TV bouquet"
-msgstr "Избери само един ТВ букет"
+msgstr "Извличане само на един ТВ букет"
 
 msgctxt "#30026"
 msgid "TV-Bouquet"
@@ -110,16 +110,24 @@ msgstr "ТВ букет"
 
 msgctxt "#30027"
 msgid "Fetch picons from webinterface"
-msgstr "Взимай логото на канала от уеб интерфейса"
+msgstr "Получаване на логото на канала от уеб интерфейса"
 
 msgctxt "#30028"
 msgid "Use Secure HTTP (https)"
-msgstr "Ползвай защитена HTTP (https)"
+msgstr "Ползване на HTTPS"
+
+msgctxt "#30029"
+msgid "Enable automatic configuration for live streams"
+msgstr "Автоматична настройка на потоците на живо"
+
+msgctxt "#30030"
+msgid "Keep folder structure for records"
+msgstr "Запазване на структурата на папките за записите"
 
 msgctxt "#30500"
 msgid "Disconnected from '%s'"
-msgstr "Изключен от '%s'"
+msgstr "Връзката с „%s“ се разпадна"
 
 msgctxt "#30501"
 msgid "Reconnected to '%s'"
-msgstr "Повторно свързан с '%s'"
+msgstr "Отново има връзка с „%s“"

--- a/src/VuData.cpp
+++ b/src/VuData.cpp
@@ -1840,7 +1840,97 @@ bool Vu::GetDeviceInfo()
   m_strServerName = strTmp.c_str();
   XBMC->Log(LOG_NOTICE, "%s - E2DeviceName: %s", __FUNCTION__, m_strServerName.c_str());
 
+  m_driveSpace.total = m_driveSpace.used = m_driveSpace.lastrefresh = -1;
+  ParseDriveSpace(pElem->FirstChildElement("e2hdds"));
+  if (m_driveSpace.total > 0)
+  {
+    XBMC->Log(LOG_NOTICE, "%s - Hdd capacity: %d", __FUNCTION__, m_driveSpace.total);
+  }
+  else
+  {
+    XBMC->Log(LOG_NOTICE, "%s - No hdd found", __FUNCTION__);
+  }
+
   return true;
+}
+
+bool Vu::GetDriveSpace(long long *iTotal, long long *iUsed)
+{
+  //initial check has not found a hdd => break
+  if (m_driveSpace.total <= 0)
+    return false;
+
+  //kodi calls GetDriveSpace() every 3sec => 30sec are enough for a PVR
+  if (difftime(time(NULL), m_driveSpace.lastrefresh) >= m_driveSpace.INTERVAL)
+  {
+    std::string url = StringUtils::Format("%sweb/deviceinfo", m_strURL.c_str());
+    std::string strXML = GetHttpXML(url);
+
+    TiXmlDocument xmlDoc;
+    if (!xmlDoc.Parse(strXML.c_str()))
+    {
+      XBMC->Log(LOG_ERROR, "Unable to parse XML: %s at line %d", xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
+      return false;
+    }
+
+    TiXmlHandle hDoc(&xmlDoc);
+    TiXmlElement* pElem = hDoc.FirstChildElement("e2deviceinfo").FirstChildElement("e2hdds").Element();
+    if (!pElem)
+    {
+      XBMC->Log(LOG_ERROR, "%s Could not find <e2hdds> element", __FUNCTION__);
+      return false;
+    }
+    ParseDriveSpace(pElem);
+  }
+
+  if (m_driveSpace.used < 0)
+  {
+    return false;
+  }
+  else
+  {
+    *iTotal = m_driveSpace.total;
+    *iUsed = m_driveSpace.used;
+  }
+  return true;
+}
+
+void Vu::ParseDriveSpace(TiXmlElement* pElem)
+{
+  if (pElem)
+  {
+    //some boxes use usb sticks for caching => multiple entries possible
+    for (TiXmlElement* hddElement = pElem->FirstChildElement("e2hdd");
+    hddElement != NULL; hddElement = hddElement->NextSiblingElement("e2hdd"))
+    {
+      std::string strTmp;
+      try
+      {
+        if (!XMLUtils::GetString(hddElement, "e2capacity", strTmp))
+          continue;
+
+        long e2capacity = std::stod(strTmp.c_str()) * 1024 * 1024;
+        
+        if (!XMLUtils::GetString(hddElement, "e2free", strTmp))
+          continue;
+        
+        long e2free = std::stod(strTmp.c_str()) * 1024 * 1024;
+        
+        //biggest capacity must be hdd
+        if (e2capacity > 0 && e2free >= 0 && e2capacity >= m_driveSpace.total)
+        {
+          m_driveSpace.total = e2capacity;
+          m_driveSpace.used = e2capacity - e2free;
+          m_driveSpace.lastrefresh = time(NULL);
+          XBMC->Log(LOG_DEBUG, "%s - Drivespace refreshed capacity: %d free: %d", __FUNCTION__, m_driveSpace.total, m_driveSpace.used);
+        }
+      }
+      catch (...)
+      {
+        XBMC->Log(LOG_ERROR, "%s - Conversion error: %s", __FUNCTION__, strTmp.c_str());
+      }
+    }
+  }
 }
 
 const char SAFE[256] =

--- a/src/VuData.h
+++ b/src/VuData.h
@@ -182,6 +182,14 @@ private:
   std::vector<VuTimer> LoadTimers();
   void TimerUpdates();
   bool GetDeviceInfo();
+  struct
+  {
+    long long total, used;
+    //30 secs btw. refreshes is enough for PVR
+    const int INTERVAL = 30;
+    long lastrefresh;
+  } m_driveSpace;
+  void ParseDriveSpace(TiXmlElement* pNode);
   std::string GetStreamURL(std::string& strM3uURL);
 
   // helper functions
@@ -226,6 +234,7 @@ public:
   bool SwitchChannel(const PVR_CHANNEL &channel);
   bool Open();
   void Action();
+  bool GetDriveSpace(long long *iTotal, long long *iUsed);
   bool m_bInitialEPG;
 };
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -361,7 +361,10 @@ const char *GetBackendHostname(void)
 
 PVR_ERROR GetDriveSpace(long long *iTotal, long long *iUsed)
 {
-  return PVR_ERROR_SERVER_ERROR;
+  if (!VuData || !VuData->IsConnected())
+    return PVR_ERROR_SERVER_ERROR;
+  
+  return (VuData->GetDriveSpace(iTotal, iUsed) ? PVR_ERROR_NO_ERROR : PVR_ERROR_SERVER_ERROR);
 }
 
 PVR_ERROR GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL &channel, time_t iStart, time_t iEnd)

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -576,5 +576,6 @@ PVR_ERROR IsEPGTagRecordable(const EPG_TAG*, bool*) { return PVR_ERROR_NOT_IMPLE
 PVR_ERROR IsEPGTagPlayable(const EPG_TAG*, bool*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR GetEPGTagStreamProperties(const EPG_TAG*, PVR_NAMED_VALUE*, unsigned int*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR GetEPGTagEdl(const EPG_TAG* epgTag, PVR_EDL_ENTRY edl[], int *size) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR GetStreamReadChunkSize(int* chunksize) { return PVR_ERROR_NOT_IMPLEMENTED; }
 
 }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -575,5 +575,6 @@ PVR_ERROR GetStreamTimes(PVR_STREAM_TIMES*) { return PVR_ERROR_NOT_IMPLEMENTED; 
 PVR_ERROR IsEPGTagRecordable(const EPG_TAG*, bool*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR IsEPGTagPlayable(const EPG_TAG*, bool*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR GetEPGTagStreamProperties(const EPG_TAG*, PVR_NAMED_VALUE*, unsigned int*) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR GetEPGTagEdl(const EPG_TAG* epgTag, PVR_EDL_ENTRY edl[], int *size) { return PVR_ERROR_NOT_IMPLEMENTED; }
 
 }


### PR DESCRIPTION
Missing api feature implemented.
Enigma devices are receivers on a linux base with low specs (single core processors with less than 100MB are not uncommon) so I decided to limit the update interval to one update every 30 secs. The kodi default (3 secs) seems a bit high for a device thats used as pure receiver and not as NAS. For the case KODI changes the update interval, I've implemented the limit as timestamp.

Attention: 
This is my second C++ code (after a "Hello World"-Tutorial), so someone with more C++ knowledge should have a look at my changes. 
I prefer to learn a language in practice and the vuplus client misses contributors, that's why I've chosen the client as playing field