### PR TITLE
Genres episodes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,14 +21,21 @@ set(VUPLUS_SOURCES src/client.cpp
                    src/StreamReader.cpp
                    src/TimeshiftBuffer.cpp
                    src/Timers.cpp
+                   src/extract/EpgEntryExtractor.cpp
+                   src/extract/GenreExtractor.cpp
+                   src/extract/ShowInfoExtractor.cpp
                    src/RecordingReader.cpp)
 
 set(VUPLUS_HEADERS src/client.h
                    src/VuData.h
+                   src/VuBase.h
                    src/IStreamReader.h
                    src/StreamReader.h
                    src/TimeshiftBuffer.h
                    src/Timers.h
+                   src/extract/EpgEntryExtractor.h
+                   src/extract/GenreExtractor.h
+                   src/extract/ShowInfoExtractor.h
                    src/RecordingReader.h
                    src/LocalizedString.h)
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ VuPlus PVR client addon for [Kodi] (http://kodi.tv)
 Within this tab the mandatory addon options need to be configured before it can be successfully enabled.
 
 * **VU+ hostname or IP address**: The IP address or hostname of your enigma2 based settop box.
+* **Web interface port**: The port used to connect to the web interface
+* **Use Secure HTTP (https)**: Use https to connect to the web interface
 * **Fetch picons from web interface**: Fetch the picons straight from the Vuplus/Enigma 2 STB
 * **Use picons.eu file formate**: Assume all picons files fetched from the STB start with `1_1_1_` and end with `_0_0_0`
 * **Icon Path**: In order to have Kodi display channel logos you have to copy the picons from your settop box onto your OpenELEC machine. You then need to specify this path in this property.
@@ -36,7 +38,8 @@ Within this tab options that refer to channel and EPG data can be set.
 * **Fetch only one TV bouquet**: If this option is set than only the channels that are in one specified TV bouquet will be loaded, instead of fetching all available channels in all available bouquets.
 * **TV-Bouquet**: If the previous option has been enabled you need to specify the TV bouquet to be fetched from the settop box. Please not that this is the bouquet-name as shown on the settop box (i.e. "Favourites (TV)"). This setting is case-sensitive.
 * **Zap before channelswitch (i.e. for Single Tuner boxes)**: When using the addon with a single tuner box it may be necessary that the addon needs to be able to zap to another channel on the settop box. If this option is enabled each channel switch in Kodi will also result in a channel switch on the settop box. Please note that "allow channel switching" needs to be enabled in the webinterface on the settop box.
-* **Extract Genre, Season and Episode Info where possible**: Have kodi check the description fields in the EPG data and attempt to extract genre, season and episode info where possible.
+* **Extract Genre, Season and Episode Info where possible**: Have kodi check the description fields in the EPG data and attempt to extract genre, season and episode info where possible. Currently supports OTA, OpenTV and Rytec XMLTV EPG data for UK and Ireland channels. If you would like to support other formats please raise an issue at the github project https://github.com/kodi-pvr/pvr.vuplus. Genre support specificially requires the use of Rytec XMLTV Epg data.
+* **Log missing genre mappings**: If you would like missing genre mappings to be logged so you can report them enable this option. Note, any genres found that don't have a mapping will still be extracted and sent to Kodi as strings. Currently genres are extracted by looking for text between square brackets, e.g. [TV Drama]
 
 ### Recordings & Timers
 
@@ -47,7 +50,7 @@ Within this tab options that refer to channel and EPG data can be set.
 * **Number of repeat timers to generate**: The number of Kodi PVR timers to generate.
 * **Enable AutoTimers**: When this is enabled there are some settings required on the STB to enable linking of AutoTimers (Timer Rules) to Timers in the Kodi UI. On the STB enable the following options (note that this feature supports OpenWebIf 1.3.x and higher):
   1. Hit `Menu` on the remote and go to `Timers->AutoTimers`
-  2. Hit `Menu` again and then select `6 Setup`s
+  2. Hit `Menu` again and then select `6 Setup`
   3. Set the following to option to `yes`
     * `Include "AutoTimer" in tags`
     * `Include AutoTimer name in tags`

--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="3.11.3"
+  version="3.12.0"
   name="VU+ / Enigma2 Client"
   provider-name="Joerg Dembski">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,3 +1,8 @@
+v3.12.0
+- Added: Extracting Genre and Season/Episode numbers for EPG entries and recordings
+- Added: Updated Readme
+- Fixed: Minimum version now 1.3.0 to use autotimers
+
 v3.11.3
 - Added: New settings to allow feature switches for generating repeating timers and autotimers
 - Added: Config guide to Readme

--- a/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
@@ -164,7 +164,11 @@ msgctxt "#30036"
 msgid "Enable generate repeat timers"
 msgstr ""
 
-#empty strings from id 30037 to 30049
+msgctxt "#30037"
+msgid "Log missing genre mappings"
+msgstr ""
+
+#empty strings from id 30038 to 30049
 #notifications
 
 msgctxt "#30050"

--- a/pvr.vuplus/resources/settings.xml
+++ b/pvr.vuplus/resources/settings.xml
@@ -22,7 +22,8 @@
     <setting label="30026" type="text" id="onegroup" default="" enable="eq(-1,true)" subsetting="true"/>
     <setting label="30013" type="bool" id="zap" default="false"/>
     <setting label="30032" type="lsep"/>
-    <setting label="30033" type="bool" id="extracteventinfo" default="true"/>
+    <setting label="30033" type="bool" id="extracteventinfo" default="false"/>
+    <setting label="30037" type="bool" id="logmissinggenremapping" enable="eq(-1,true)" default="false"/>
   </category>
 
   <!-- Recordings and Timers-->

--- a/src/Timers.cpp
+++ b/src/Timers.cpp
@@ -141,6 +141,7 @@ std::vector<Timer> Timers::LoadTimers() const
     if (XMLUtils::GetString(pNode, "e2servicereference", strTmp))
       timer.iChannelId = vuData.GetChannelNumber(strTmp.c_str());
 
+    // Skip timers for channels we don't know about, such as when the addon only uses one bouquet or an old channel referene that doesn't exist
     if (timer.iChannelId < 0)
     {
       XBMC->Log(LOG_DEBUG, "%s could not find channel so skipping timer: '%s'", __FUNCTION__, timer.strTitle.c_str());
@@ -464,6 +465,7 @@ std::vector<AutoTimer> Timers::LoadAutoTimers() const
         {
           autoTimer.iChannelId = vuData.GetChannelNumber(strTmp.c_str());
 
+          // Skip autotimers for channels we don't know about, such as when the addon only uses one bouquet or an old channel referene that doesn't exist
           if (autoTimer.iChannelId < 0)
           {
             XBMC->Log(LOG_DEBUG, "%s could not find channel so skipping autotimer: '%s'", __FUNCTION__, autoTimer.strTitle.c_str());
@@ -563,10 +565,10 @@ void Timers::GetTimerTypes(std::vector<PVR_TIMER_TYPE> &types) const
   {
     TimerType(unsigned int id, unsigned int attributes,
       const std::string &description = std::string(),
-      const std::vector< std::pair<int, std::string> > &groupValues
-        = std::vector< std::pair<int, std::string> >(),
-      const std::vector< std::pair<int, std::string> > &deDupValues
-        = std::vector< std::pair<int, std::string> >())
+      const std::vector<std::pair<int, std::string>> &groupValues
+        = std::vector<std::pair<int, std::string>>(),
+      const std::vector<std::pair<int, std::string> > &deDupValues
+        = std::vector<std::pair<int, std::string>>())
     {
       int i;
       memset(this, 0, sizeof(PVR_TIMER_TYPE));
@@ -599,7 +601,7 @@ void Timers::GetTimerTypes(std::vector<PVR_TIMER_TYPE> &types) const
   };
 
   /* PVR_Timer.iRecordingGroup values and presentation.*/
-  std::vector< std::pair<int, std::string> > groupValues = {
+  std::vector<std::pair<int, std::string>> groupValues = {
     { 0, LocalizedString(30410) }, //automatic
   };
   for (auto &recf : vuData.GetLocations())
@@ -679,7 +681,7 @@ void Timers::GetTimerTypes(std::vector<PVR_TIMER_TYPE> &types) const
   if (CanAutoTimers() && vuData.GetAutoTimersEnabled())
   {
     /* PVR_Timer.iPreventDuplicateEpisodes values and presentation.*/
-    static std::vector< std::pair<int, std::string> > deDupValues =
+    static std::vector<std::pair<int, std::string>> deDupValues =
     {
       { AutoTimer::DeDup::DISABLED,                   LocalizedString(30430) },
       { AutoTimer::DeDup::CHECK_TITLE,                LocalizedString(30431) },

--- a/src/Timers.cpp
+++ b/src/Timers.cpp
@@ -550,7 +550,7 @@ std::vector<AutoTimer> Timers::LoadAutoTimers() const
 
 bool Timers::CanAutoTimers() const
 {
-  return vuData.GetWebIfVersion() >= vuData.GenerateWebIfVersionNum(1, 2, 4);
+  return vuData.GetWebIfVersion() >= vuData.GenerateWebIfVersionNum(1, 3, 0);
 }
 
 bool Timers::IsAutoTimer(const PVR_TIMER &timer) const

--- a/src/Timers.cpp
+++ b/src/Timers.cpp
@@ -892,7 +892,6 @@ PVR_ERROR Timers::AddAutoTimer(const PVR_TIMER &timer)
   if (deDup == AutoTimer::DeDup::DISABLED)
   {
     strTmp += StringUtils::Format("&avoidDuplicateDescription=0");
-    //strTmp += StringUtils::Format("&searchForDuplicateDescription=");
   }
   else
   {

--- a/src/VuBase.h
+++ b/src/VuBase.h
@@ -1,0 +1,38 @@
+#pragma once 
+/*
+ *      Copyright (C) 2005-2015 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include <string>
+
+struct VuBase 
+{
+  std::string strTitle;
+  std::string strPlotOutline;
+  std::string strPlot;
+  int genreType = 0;
+  int genreSubType = 0;
+  std::string genreDescription;
+  int episodeNumber = 0;
+  int episodePartNumber = 0;
+  int seasonNumber = 0;
+  int year = 0;
+};

--- a/src/VuData.h
+++ b/src/VuData.h
@@ -23,6 +23,8 @@
 
 #include "client.h"
 #include "Timers.h"
+#include "VuBase.h"
+#include "extract/EpgEntryExtractor.h"
 #include "RecordingReader.h"
 #include "p8-platform/threads/threads.h"
 #include "tinyxml.h"
@@ -36,7 +38,6 @@ public:
   bool Get(const std::string &strURL, std::string &strResult);
 };
 
-
 typedef enum VU_UPDATE_STATE
 {
     VU_UPDATE_STATE_NONE,
@@ -45,16 +46,13 @@ typedef enum VU_UPDATE_STATE
     VU_UPDATE_STATE_NEW
 } VU_UPDATE_STATE;
 
-struct VuEPGEntry 
+struct VuEPGEntry : public VuBase
 {
   int iEventId;
   std::string strServiceReference;
-  std::string strTitle;
   int iChannelId;
   time_t startTime;
   time_t endTime;
-  std::string strPlotOutline;
-  std::string strPlot;
 };
 
 struct VuChannelGroup 
@@ -79,21 +77,18 @@ struct VuChannel
   std::string strIconPath;
 };
 
-struct VuRecording
+struct VuRecording : public VuBase
 {
   std::string strRecordingId;
   time_t startTime;
   int iDuration;
   int iLastPlayedPosition;
-  std::string strTitle;
   std::string strStreamURL;
-  std::string strPlot;
-  std::string strPlotOutline;
   std::string strChannelName;
   std::string strDirectory;
   std::string strIconPath;
 };
- 
+
 class Vu  : public P8PLATFORM::CThread
 {
 private:
@@ -114,6 +109,7 @@ private:
   std::vector<VuRecording> m_recordings;
   std::vector<VuChannelGroup> m_groups;
   std::vector<std::string> m_locations;
+  vuplus::EpgEntryExtractor entryExtractor;
 
   vuplus::Timers my_timers = vuplus::Timers(*this);
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -76,6 +76,7 @@ bool        g_bUsePiconsEuFormat      = false;
 bool        g_bEnableAutoTimers       = true;
 bool        g_bEnableGenRepeatTimers  = true;
 bool        g_bExtractExtraEpgInfo    = true;
+bool        g_bLogMissingGenreMappings = true;
 
 CHelper_libXBMC_addon *XBMC           = NULL;
 CHelper_libXBMC_pvr   *PVR            = NULL;
@@ -190,7 +191,10 @@ void ADDON_ReadSettings(void)
     g_bEnableGenRepeatTimers = true;
 
   if (!XBMC->GetSetting("extracteventinfo", &g_bExtractExtraEpgInfo))
-    g_bExtractExtraEpgInfo = true;
+    g_bExtractExtraEpgInfo = false;
+
+  if (!XBMC->GetSetting("logmissinggenremapping", &g_bLogMissingGenreMappings))
+    g_bLogMissingGenreMappings = false;
 
   free (buffer);
 }
@@ -333,6 +337,8 @@ ADDON_STATUS ADDON_SetSetting(const char *settingName, const void *settingValue)
     return SetBoolSetting(str, *static_cast<const bool*>(settingValue), g_bZap, ADDON_STATUS_OK);
   else if (str == "extracteventinfo")
     return SetBoolSetting(str, *static_cast<const bool*>(settingValue), g_bExtractExtraEpgInfo, ADDON_STATUS_OK);
+  else if (str == "logmissinggenremapping")
+    return SetBoolSetting(str, *static_cast<const bool*>(settingValue), g_bLogMissingGenreMappings, ADDON_STATUS_OK);
   else if (str == "recordingpath")
     return SetStringSetting(str, static_cast<const char*>(settingValue), g_strRecordingPath, ADDON_STATUS_NEED_RESTART);
   else if (str == "onlycurrent")

--- a/src/client.h
+++ b/src/client.h
@@ -68,6 +68,7 @@ extern std::string               g_strChannelDataPath;
 extern bool                      g_bEnableAutoTimers;
 extern bool                      g_bEnableGenRepeatTimers;
 extern bool                      g_bExtractExtraEpgInfo;
+extern bool                      g_bLogMissingGenreMappings;
 extern ADDON::CHelper_libXBMC_addon *   XBMC;
 extern CHelper_libXBMC_pvr *     PVR;
 

--- a/src/extract/EpgEntryExtractor.cpp
+++ b/src/extract/EpgEntryExtractor.cpp
@@ -1,0 +1,24 @@
+#include "EpgEntryExtractor.h"
+#include "GenreExtractor.h"
+#include "ShowInfoExtractor.h"
+
+using namespace vuplus;
+using namespace ADDON;
+
+EpgEntryExtractor::EpgEntryExtractor()
+{
+   extractors.emplace_back(new GenreExtractor());
+   extractors.emplace_back(new ShowInfoExtractor());
+}
+
+EpgEntryExtractor::~EpgEntryExtractor(void)
+{
+}
+
+void EpgEntryExtractor::ExtractFromEntry(VuBase &entry)
+{
+  for (auto& extractor : extractors)
+  {
+    extractor->ExtractFromEntry(entry);
+  }  
+}

--- a/src/extract/EpgEntryExtractor.h
+++ b/src/extract/EpgEntryExtractor.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "../client.h"
+#include "IExtractor.h"
+#include "GenreExtractor.h"
+#include "ShowInfoExtractor.h"
+#include <string>
+#include "libXBMC_addon.h"
+
+namespace vuplus
+{
+
+class EpgEntryExtractor
+  : public IExtractor
+{
+private:
+  GenreExtractor genreExtractor;
+  ShowInfoExtractor showInfoExtractor;
+  std::vector<std::unique_ptr<IExtractor>> extractors;
+  
+public:
+  EpgEntryExtractor();
+  ~EpgEntryExtractor(void);
+  void ExtractFromEntry(VuBase &entry);
+};
+
+} // end vuplus

--- a/src/extract/GenreExtractor.cpp
+++ b/src/extract/GenreExtractor.cpp
@@ -1,0 +1,98 @@
+#include "GenreExtractor.h"
+#include <regex>
+
+using namespace vuplus;
+using namespace ADDON;
+
+GenreExtractor::GenreExtractor()
+{
+  for (std::map<int, std::string>::const_iterator it = kodiKeyToGenreMap.begin(); it != kodiKeyToGenreMap.end(); it++)
+  {
+    kodiGenreToKeyMap.insert({it->second, it->first});
+  }
+
+  genrePattern = std::regex(GENRE_PATTERN);
+  genreMajorPattern = std::regex(GENRE_MAJOR_PATTERN);
+}
+
+GenreExtractor::~GenreExtractor(void)
+{
+}
+
+void GenreExtractor::ExtractFromEntry(VuBase &entry)
+{
+  std::string genreText = GetMatchedText(entry.strPlotOutline, entry.strPlot, genrePattern);
+
+  if (!genreText.empty() && genreText != GENRE_RESERVED_IGNORE)
+  {
+    int combinedGenreType = GetGenreTypeFromText(genreText, entry.strTitle);
+
+    if (combinedGenreType == EPG_EVENT_CONTENTMASK_UNDEFINED)
+    {
+      if (g_bLogMissingGenreMappings)
+        XBMC->Log(LOG_NOTICE, "%s: Could not lookup genre using genre description string instead:'%s'", __FUNCTION__, genreText.c_str());
+
+      entry.genreType = EPG_GENRE_USE_STRING;
+      entry.genreDescription = genreText;
+    }
+    else
+    {
+      entry.genreType = GetGenreTypeFromCombined(combinedGenreType);
+      entry.genreSubType = GetGenreSubTypeFromCombined(combinedGenreType);
+    }
+  }
+}
+
+int GenreExtractor::GetGenreTypeFromCombined(int combinedGenreType)
+{
+  return combinedGenreType & 0xF0;
+}
+
+int GenreExtractor::GetGenreSubTypeFromCombined(int combinedGenreType)
+{
+  return combinedGenreType & 0x0F;
+}
+
+int GenreExtractor::GetGenreTypeFromText(const std::string &genreText, const std::string &showName)
+{
+  int genreType = LookupGenreValueInMaps(genreText);
+
+  if (genreType == EPG_EVENT_CONTENTMASK_UNDEFINED) 
+  {
+    if (g_bLogMissingGenreMappings)
+      XBMC->Log(LOG_NOTICE, "%s: Tried to find genre text but no value: '%s', show - '%s'", __FUNCTION__, genreText.c_str(), showName.c_str());
+
+    std::string genreMajorText = GetMatchTextFromString(genreText, genreMajorPattern);
+    
+    if (!genreMajorText.empty())
+    {
+      genreType = LookupGenreValueInMaps(genreMajorText);
+
+      if (genreType == EPG_EVENT_CONTENTMASK_UNDEFINED && g_bLogMissingGenreMappings)
+        XBMC->Log(LOG_NOTICE, "%s: Tried to find major genre text but no value: '%s', show - '%s'", __FUNCTION__, genreMajorText.c_str(), showName.c_str());  
+    }
+  } 
+
+  return genreType;
+}
+
+int GenreExtractor::LookupGenreValueInMaps(const std::string &genreText)
+{
+  int genreType = EPG_EVENT_CONTENTMASK_UNDEFINED;
+
+  auto genreMapSearch = genreMap.find(genreText);
+  if (genreMapSearch != genreMap.end()) 
+  {
+    genreType = genreMapSearch->second;
+  } 
+  else
+  {
+    auto kodiGenreMapSearch = kodiGenreToKeyMap.find(genreText);
+    if (kodiGenreMapSearch != kodiGenreToKeyMap.end()) 
+    {
+      genreType = kodiGenreMapSearch->second;
+    }     
+  }
+
+  return genreType;
+}

--- a/src/extract/GenreExtractor.h
+++ b/src/extract/GenreExtractor.h
@@ -1,0 +1,270 @@
+#pragma once
+
+#include "../client.h"
+#include "IExtractor.h"
+#include <map>
+#include <string>
+#include <regex>
+#include "libXBMC_addon.h"
+
+namespace vuplus
+{
+  static const std::string GENRE_PATTERN = "^\\[([a-zA-Z /]{3}[a-zA-Z ./]+)\\].*";
+  static const std::string GENRE_MAJOR_PATTERN = "^([a-zA-Z /]{3,})\\.?.*";
+  static const std::string GENRE_RESERVED_IGNORE = "reserved";
+
+class GenreExtractor
+  : public IExtractor
+{
+private:
+
+  std::regex genrePattern;
+  std::regex genreMajorPattern;
+  std::map<std::string, int> kodiGenreToKeyMap;
+  const std::map<int, std::string> kodiKeyToGenreMap
+  {
+    {0x00, "Undefined"},
+    //MOVIE/DRAMA
+    {0x10, "Movie/Drama"},
+    {0x11, "Detective/Thriller"},
+    {0x12, "Adventure/Western/War"},
+    {0x13, "Science Fiction/Fantasy/Horror"},
+    {0x14, "Comedy"},
+    {0x15, "Soap/Melodrama/Folkloric"},
+    {0x16, "Romance"},
+    {0x17, "Serious/Classical/Religious/Historical Movie/Drama"},
+    {0x18, "Adult Movie/Drama"},
+    //NEWS/CURRENT AFFAIRS
+    {0x20, "News/Current Affairs"},
+    {0x21, "News/Weather Report"},
+    {0x22, "News Magazine"},
+    {0x23, "Documentary"},
+    {0x24, "Discussion/Interview/Debate"},
+    //SHOW
+    {0x30, "Show/Game Show"},
+    {0x31, "Game Show/Quiz/Contest"},
+    {0x32, "Variety Show"},
+    {0x33, "Talk Show"},
+    //SPORTS
+    {0x40, "Sports"},
+    {0x41, "Special Event"},
+    {0x42, "Sport Magazine"},
+    {0x43, "Football"},
+    {0x44, "Tennis/Squash"},
+    {0x45, "Team Sports"},
+    {0x46, "Athletics"},
+    {0x47, "Motor Sport"},
+    {0x48, "Water Sport"},
+    {0x49, "Winter Sports"},
+    {0x4A, "Equestrian"},
+    {0x4B, "Martial Sports"},
+    //CHILDREN/YOUTH
+    {0x50, "Children's/Youth Programmes"},
+    {0x51, "Pre-school Children's Programmes"},
+    {0x52, "Entertainment Programmes for 6 to 14"},
+    {0x53, "Entertainment Programmes for 10 to 16"},
+    {0x54, "Informational/Educational/School Programme"},
+    {0x55, "Cartoons/Puppets"},
+    //MUSIC/BALLET/DANCE
+    {0x60, "Music/Ballet/Dance"},
+    {0x61, "Rock/Pop"},
+    {0x62, "Serious/Classical Music"},
+    {0x63, "Folk/Traditional Music"},
+    {0x64, "Musical/Opera"},
+    {0x65, "Ballet"},
+    //ARTS/CULTURE
+    {0x70, "Arts/Culture"},
+    {0x71, "Performing Arts"},
+    {0x72, "Fine Arts"},
+    {0x73, "Religion"},
+    {0x74, "Popular Culture/Traditional Arts"},
+    {0x75, "Literature"},
+    {0x76, "Film/Cinema"},
+    {0x77, "Experimental Film/Video"},
+    {0x78, "Broadcasting/Press"},
+    {0x79, "New Media"},
+    {0x7A, "Arts/Culture Magazines"},
+    {0x7B, "Fashion"},
+    //SOCIAL/POLITICAL/ECONOMICS
+    {0x80, "Social/Political/Economics"},
+    {0x81, "Magazines/Reports/Documentary"},
+    {0x82, "Economics/Social Advisory"},
+    {0x83, "Remarkable People"},
+    //EDUCATIONAL/SCIENCE
+    {0x90, "Education/Science/Factual"},
+    {0x91, "Nature/Animals/Environment"},
+    {0x92, "Technology/Natural Sciences"},
+    {0x93, "Medicine/Physiology/Psychology"},
+    {0x94, "Foreign Countries/Expeditions"},
+    {0x95, "Social/Spiritual Sciences"},
+    {0x96, "Further Education"},
+    {0x97, "Languages"},
+    //LEISURE/HOBBIES
+    {0xA0, "Leisure/Hobbies"},
+    {0xA1, "Tourism/Travel"},
+    {0xA2, "Handicraft"},
+    {0xA3, "Motoring"},
+    {0xA4, "Fitness & Health"},
+    {0xA5, "Cooking"},
+    {0xA6, "Advertisement/Shopping"},
+    {0xA7, "Gardening"},
+    //SPECIAL
+    {0xB0, "Special Characteristics"},
+    {0xB1, "Original Language"},
+    {0xB2, "Black & White"},
+    {0xB3, "Unpublished"},
+    {0xB4, "Live Broadcast"},
+    //USERDEFINED
+    {0xF0, "Drama"},
+    {0xF1, "Detective/Thriller"},
+    {0xF2, "Adventure/Western/War"},
+    {0xF3, "Science Fiction/Fantasy/Horror"},
+    //---- below currently ignored by XBMC see http://trac.xbmc.org/ticket/13627
+    {0xF4, "Comedy"},
+    {0xF5, "Soap/Melodrama/Folkloric"},
+    {0xF6, "Romance"},
+    {0xF7, "Serious/ClassicalReligion/Historical"},
+    {0xF8, "Adult"}
+  };  
+  
+  const std::map<std::string, int> genreMap
+  {
+    //MOVIE/DRAMA
+    {"General Movie/Drama", 0x10},
+    {"Movie", 0x10},
+    {"Film", 0x10},
+    {"Animated Movie/Drama", 0x10},
+    {"Thriller", 0x11},
+    {"Detective/Thriller", 0x11},
+    {"Action", 0x12},
+    {"Adventure", 0x12},
+    {"Adventure/War", 0x12},
+    {"Western", 0x12},
+    {"Gangster", 0x12},
+    {"Fantasy", 0x13},
+    {"Science Fiction", 0x13},
+    {"Family", 0x14},
+    {"Sitcom", 0x14},
+    {"Comedy", 0x14},
+    {"TV Drama. Comedy", 0x14},
+    {"Drama", 0x15},
+    {"Soap/Melodrama/Folkloric", 0x15},
+    {"TV Drama. Melodrama", 0x15},
+    {"TV Drama. Factual", 0x15},
+    {"TV Drama", 0x15},
+    {"TV Drama. Crime", 0x15},
+    {"TV Drama. Period", 0x15},
+    {"Romance", 0x16},
+    {"Medical Drama", 0x15},
+    {"Crime drama", 0x17},
+    {"Historical/Period Drama", 0x17},
+    {"Police/Crime Drama", 0x17},
+    //NEWS/CURRENT AFFAIRS
+    {"News", 0x20},
+    {"General News/Current Affairs", 0x20},
+    {"Documentary", 0x23},
+    {"Documentary. News", 0x23},
+    {"Discussion. News", 0x24},
+    //SHOW
+    {"Series", 0x30},
+    {"Show", 0x30},
+    {"Vets/Pets", 0x30},
+    {"Wildlife", 0x30},
+    {"Property", 0x30},
+    {"General Show/Game Show", 0x31},
+    {"Game Show", 0x31},
+    {"Challenge/Reality Show", 0x31},
+    {"Show. Variety Show", 0x32},
+    {"Variety Show", 0x32},
+    {"Entertainment", 0x32},
+    {"Miscellaneous", 0x32},
+    {"Talk Show", 0x33},
+    {"Show. Talk Show", 0x33},
+    //SPORTS
+    {"Sport", 0x40},
+    {"Live/Sport", 0x40},
+    {"General Sports", 0x40},
+    {"Football. Sports", 0x43},
+    {"Martial Sports", 0x4B},
+    {"Martial Sports. Sports", 0x4B},
+    {"Wrestling", 0x4B},
+    //CHILDREN/YOUTH
+    {"Children", 0x50},
+    {"Educational/Schools Programmes", 0x50},
+    {"Animation", 0x55},
+    {"Cartoons/Puppets", 0x55},
+    //MUSIC/BALLET/DANCE
+    {"Music", 0x60},
+    {"General Music/Ballet/Dance", 0x60},
+    {"Music. Folk", 0x63},
+    {"Musical", 0x64},
+    //ARTS/CULTURE
+    {"General Arts/Culture", 0x70},
+    {"Arts/Culture", 0x70},
+    {"Arts/Culture. Fine Arts", 0x72},
+    {"Religion", 0x73},
+    //SOCIAL/POLITICAL/ECONOMICS
+    {"Social/Political", 0x80},
+    {"Social/Political. Famous People", 0x83},
+    //EDUCATIONAL/SCIENCE
+    {"Education", 0x90},
+    {"Educational", 0x90},
+    {"History", 0x90},
+    {"Factual", 0x90},
+    {"General Education/Science/Factual Topics", 0x90},
+    {"Science", 0x90},
+    {"Educational. Nature", 0x91},
+    {"Environment", 0x91},
+    {"Technology", 0x92},
+    {"Computers/Internet/Gaming", 0x92},
+    //LEISURE/HOBBIES
+    {"Leisure", 0xA0},
+    {"Leisure. Lifestyle", 0xA0},
+    {"Travel", 0xA1},
+    {"Health", 0xA4},
+    {"Leisure. Health", 0xA4},
+    {"Medicine/Health", 0xA4},
+    {"Cookery", 0xA5},
+    {"Leisure. Cooking", 0xA5},
+    {"Leisure. Shopping", 0xA6},
+    {"Advertisement/Shopping", 0xA6},
+    {"Consumer", 0xA6},
+    //SPECIAL
+    //USERDEFINED
+    {"Factual Crime", 0xF1},
+  };
+
+  static int GetGenreTypeFromCombined(int combinedGenreType);
+  static int GetGenreSubTypeFromCombined(int combinedGenreType);
+
+  int GetGenreTypeFromText(const std::string &genreText, const std::string &showName);
+  int LookupGenreValueInMaps(const std::string &genreText);
+
+/*
+Useful reference to Genres uses by Kodi PVR
+
+EPG_EVENT_CONTENTMASK_UNDEFINED                0x00
+EPG_EVENT_CONTENTMASK_MOVIEDRAMA               0x10
+EPG_EVENT_CONTENTMASK_NEWSCURRENTAFFAIRS       0x20
+EPG_EVENT_CONTENTMASK_SHOW                     0x30
+EPG_EVENT_CONTENTMASK_SPORTS                   0x40
+EPG_EVENT_CONTENTMASK_CHILDRENYOUTH            0x50
+EPG_EVENT_CONTENTMASK_MUSICBALLETDANCE         0x60
+EPG_EVENT_CONTENTMASK_ARTSCULTURE              0x70
+EPG_EVENT_CONTENTMASK_SOCIALPOLITICALECONOMICS 0x80
+EPG_EVENT_CONTENTMASK_EDUCATIONALSCIENCE       0x90
+EPG_EVENT_CONTENTMASK_LEISUREHOBBIES           0xA0
+EPG_EVENT_CONTENTMASK_SPECIAL                  0xB0
+EPG_EVENT_CONTENTMASK_USERDEFINED              0xF0
+
+EPG_GENRE_USE_STRING                           0x100
+EPG_STRING_TOKEN_SEPARATOR ","
+*/
+
+public:
+  GenreExtractor();
+  ~GenreExtractor(void);
+  void ExtractFromEntry(VuBase &base);
+};
+
+} // end vuplus

--- a/src/extract/IExtractor.h
+++ b/src/extract/IExtractor.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#ifndef PVR_VUPLUS_IEXTRACTOR_H
+#define PVR_VUPLUS_IEXTRACTOR_H
+
+#include "../VuBase.h"
+#include <regex>
+
+class IExtractor
+{
+protected:
+  static std::string GetMatchTextFromString(const std::string &text, const std::regex &pattern)
+  {
+    std::string matchText = "";
+    std::smatch match;
+
+    if (regex_match(text, match, pattern))
+    {
+      if (match.size() == 2)
+      {
+        std::ssub_match base_sub_match = match[1];
+        matchText = base_sub_match.str();  
+      }
+    }
+
+    return matchText;
+  };
+
+  static std::string GetMatchedText(const std::string &firstText, const std::string &secondText, const std::regex &pattern)
+  {
+    std::string matchedText = GetMatchTextFromString(firstText, pattern);
+
+    if (matchedText.empty())
+      matchedText = GetMatchTextFromString(secondText, pattern);
+
+    return matchedText;
+  }
+
+public:
+  virtual ~IExtractor(void) = default;
+  virtual void ExtractFromEntry(VuBase &base) = 0;
+};
+
+#endif

--- a/src/extract/ShowInfoExtractor.cpp
+++ b/src/extract/ShowInfoExtractor.cpp
@@ -1,0 +1,74 @@
+#include "ShowInfoExtractor.h"
+#include <regex>
+
+using namespace vuplus;
+using namespace ADDON;
+
+ShowInfoExtractor::ShowInfoExtractor()
+{
+  episodeSeasonPatterns.emplace_back(
+      EpisodeSeasonPattern(MASTER_SEASON_EPISODE_PATTERN, 
+        GET_SEASON_PATTERN, GET_EPISODE_PATTERN));
+  episodeSeasonPatterns.emplace_back(
+      EpisodeSeasonPattern(MASTER_EPISODE_PATTERN, 
+        GET_EPISODE_PATTERN));
+  episodeSeasonPatterns.emplace_back(
+      EpisodeSeasonPattern(MASTER_YEAR_EPISODE_PATTERN, 
+        GET_EPISODE_PATTERN));
+  episodeSeasonPatterns.emplace_back(
+      EpisodeSeasonPattern(MASTER_EPISODE_NO_PREFIX_PATTERN, 
+        GET_EPISODE_NO_PREFIX_PATTERN));
+
+  yearPatterns.emplace_back(std::regex(GET_YEAR_PATTERN));
+  yearPatterns.emplace_back(std::regex(GET_YEAR_EPISODE_PATTERN));
+}
+
+ShowInfoExtractor::~ShowInfoExtractor(void)
+{
+}
+
+void ShowInfoExtractor::ExtractFromEntry(VuBase &entry)
+{
+  for (const auto& patternSet : episodeSeasonPatterns)
+  {
+    std::string masterText = GetMatchedText(entry.strPlotOutline, entry.strPlot, patternSet.masterRegex);
+
+    if (!masterText.empty())
+    {
+      if (patternSet.hasSeasonRegex && entry.seasonNumber == 0)
+      {
+        std::string seasonText = GetMatchTextFromString(masterText, patternSet.seasonRegex);
+        if (!seasonText.empty())
+        {
+          entry.seasonNumber = atoi(seasonText.c_str());
+        }
+      }
+
+      if (entry.episodeNumber == 0)
+      {
+        std::string episodeText = GetMatchTextFromString(masterText, patternSet.episodeRegex);      
+        if (!episodeText.empty())
+        {
+          entry.episodeNumber = atoi(episodeText.c_str());
+        }
+      }
+    }
+
+    //Once we have at least an episode number we are done
+    if (entry.episodeNumber != 0)
+      break;
+  }
+
+  for (const auto& pattern : yearPatterns)
+  {
+    std::string yearText = GetMatchedText(entry.strPlotOutline, entry.strPlot, pattern);
+
+    if (!yearText.empty() && entry.year == 0)
+    {
+      entry.year = atoi(yearText.c_str());
+    }
+
+    if (entry.year != 0)
+      break;
+  }
+}

--- a/src/extract/ShowInfoExtractor.h
+++ b/src/extract/ShowInfoExtractor.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "../client.h"
+#include "IExtractor.h"
+#include <map>
+#include <string>
+#include <vector>
+#include <regex>
+#include "libXBMC_addon.h"
+
+namespace vuplus
+{
+
+// (S4E37) (S04E37) (S2 Ep3/6) (S2 Ep7)
+static const std::string MASTER_SEASON_EPISODE_PATTERN = "^.*\\(?([sS]\\.?[0-9]+ ?[eE][pP]?\\.?[0-9]+/?[0-9]*)\\)?.*$";
+// (E130) (Ep10) (E7/9) (Ep7/10) (Ep.25)
+static const std::string MASTER_EPISODE_PATTERN = "^.*\\(?([eE][pP]?\\.?[0-9]+/?[0-9]*)\\)?.*$";
+// (2015E22) (2007E3) (2007E3/6)
+static const std::string MASTER_YEAR_EPISODE_PATTERN = "^.*\\(?([12][0-9][0-9][0-9][eE][pP]?\\.?[0-9]+\\.?/?[0-9]*)\\)?.*$";
+// Starts with 4/4 6/6, no prefix
+static const std::string MASTER_EPISODE_NO_PREFIX_PATTERN = "^.*([0-9]+/[0-9]+)\\.? +.*$";
+
+// Get from matster match, prefixed by S,s,E,e,Ep
+static const std::string GET_SEASON_PATTERN = "^.*[sS]\\.?([0-9][0-9]*).*$";
+static const std::string GET_EPISODE_PATTERN = "^.*[eE][pP]?\\.?([0-9][0-9]*).*$";
+// Get from master match, no prefix
+static const std::string GET_EPISODE_NO_PREFIX_PATTERN = "^([0-9]+)/[0-9]+";
+
+// (2018)
+static const std::string GET_YEAR_PATTERN = "^.*\\(([12][0-9][0-9][0-9])\\).*$";
+// (2018E25)
+static const std::string GET_YEAR_EPISODE_PATTERN = "^.*\\(([12][0-9][0-9][0-9])[eE][pP]?\\.?[0-9]+/?[0-9]*\\).*$";
+
+struct EpisodeSeasonPattern
+{
+  std::regex masterRegex;
+  std::regex seasonRegex;
+  std::regex episodeRegex;
+  bool hasSeasonRegex;
+
+  EpisodeSeasonPattern(const std::string &masterPattern, const std::string &seasonPattern, const std::string &episodePattern)
+  {
+    masterRegex = std::regex(masterPattern);
+    seasonRegex = std::regex(seasonPattern);
+    episodeRegex = std::regex(episodePattern);
+    hasSeasonRegex = true;
+  }
+
+  EpisodeSeasonPattern(const std::string &masterPattern, const std::string &episodePattern)
+  {
+    masterRegex = std::regex(masterPattern);
+    episodeRegex = std::regex(episodePattern);
+    hasSeasonRegex = false;
+  }
+};
+
+class ShowInfoExtractor
+  : public IExtractor
+{
+private:
+  std::vector<EpisodeSeasonPattern> episodeSeasonPatterns;
+  std::vector<std::regex> yearPatterns;
+
+public:
+  ShowInfoExtractor();
+  ~ShowInfoExtractor(void);
+  void ExtractFromEntry(VuBase &base);
+};
+
+} // end vuplus


### PR DESCRIPTION
v3.12.0
- Added: Extracting Genre and Season/Episode numbers for EPG entries and recordings
- Added: Updated Readme
- Fixed: Minimum version now openwebif 1.3.0 to use autotimers