### PR TITLE
Updated en_GB summary and descriptions in addon.xml.in

### DIFF
--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -71,7 +71,7 @@
     <description lang="de_DE">VU+ -Oberfläche; Unterstützt Live TV &amp; Aufnahmen, EPG und Timer.</description>
     <description lang="el_GR">Frontend για το VU+. Υποστηρίζει ροές Live TV &amp; Εγγραφές, EPG, Χρονοδιακόπτες.</description>
     <description lang="en_AU">VU+ frontend; supporting streaming of Live TV &amp; Recordings, EPG, Timers.</description>
-    <description lang="en_GB">Enigma2 PVR client addon; frontend supporting streaming of Live TV & Recordings, EPG, Timers, Autotimers. Compatible with Enigma2-based TV-boxes from different manufacturers, such as Amiko, DBox2, Dreambox, Gigablue, SAB, VuPlus/Vu+, WeTek, Zgemma, Xtrend, and more.</description>
+    <description lang="en_GB">Enigma2 PVR client addon; frontend supporting streaming of Live TV &amp Recordings, EPG, Timers, Autotimers. Should be API compatible with Enigma2-based TV-boxes from different manufacturers if they do not deviate from the default Enigma2 configuration and standards. While not garanteed to work with this PVR client addon, a few examples of Enigma2-based TV-boxes are; Amiko, DBox2, Dreambox, Gigablue, SAB, VuPlus/Vu+, WeTek, Zgemma, Xtrend, and more.</description>
     <description lang="en_NZ">VU+ frontend; supporting streaming of Live TV &amp; Recordings, EPG, Timers.</description>
     <description lang="en_US">VU+ frontend; supporting streaming of Live TV &amp; Recordings, EPG, Timers.</description>
     <description lang="es_AR">VU+ frontend; soporta TV en vivo, grabaciones, guía de programación (GEP) y temporizadores.</description>

--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -19,7 +19,7 @@
     <summary lang="de_DE">Kodi Oberfläche für VU+ / Enigma2-basierte Settop-Boxen</summary>
     <summary lang="el_GR">Frontend του Kodi για αποκωδικοποιητές (settop box) τύπου VU+ / Enigma2</summary>
     <summary lang="en_AU">Kodi's frontend for VU+ / Enigma2 based settop boxes</summary>
-    <summary lang="en_GB">Kodi's frontend for Enigma2 based settop boxes</summary>
+    <summary lang="en_GB">Kodi's PVR frontend client for Enigma2-based set-top boxes</summary>
     <summary lang="en_NZ">Kodi's frontend for VU+ / Enigma2 based settop boxes</summary>
     <summary lang="en_US">Kodi's frontend for VU+ / Enigma2 based settop boxes</summary>
     <summary lang="es_AR">Kodi frontend para decodificadores equipados con VU+/Enigma2</summary>
@@ -71,7 +71,7 @@
     <description lang="de_DE">VU+ -Oberfläche; Unterstützt Live TV &amp; Aufnahmen, EPG und Timer.</description>
     <description lang="el_GR">Frontend για το VU+. Υποστηρίζει ροές Live TV &amp; Εγγραφές, EPG, Χρονοδιακόπτες.</description>
     <description lang="en_AU">VU+ frontend; supporting streaming of Live TV &amp; Recordings, EPG, Timers.</description>
-    <description lang="en_GB">Enigma2 frontend; supporting streaming of Live TV &amp; Recordings, EPG, Timers, Autotimers.</description>
+    <description lang="en_GB">Enigma2 PVR client addon; frontend supporting streaming of Live TV & Recordings, EPG, Timers, Autotimers. Compatible with Enigma2-based TV-boxes from different manufacturers, such as Amiko, DBox2, Dreambox, Gigablue, SAB, VuPlus/Vu+, WeTek, Zgemma, Xtrend, and more.</description>
     <description lang="en_NZ">VU+ frontend; supporting streaming of Live TV &amp; Recordings, EPG, Timers.</description>
     <description lang="en_US">VU+ frontend; supporting streaming of Live TV &amp; Recordings, EPG, Timers.</description>
     <description lang="es_AR">VU+ frontend; soporta TV en vivo, grabaciones, guía de programación (GEP) y temporizadores.</description>


### PR DESCRIPTION
Updated en_GB summary and descriptions in addon.xml.in to both reflect the new cosmetic name of "Enigma2" and clarify that the addon should be compatible with a multitude of set-top boxes from different manufacturers as long as their firmware is based on the Enigma2 framework.