### PR TITLE
Genre id and fix

### DIFF
--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="3.12.3"
+  version="3.12.4"
   name="Enigma2 Client"
   provider-name="Joerg Dembski and Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>
@@ -175,9 +175,24 @@
     <disclaimer lang="zh_TW">這是測試版軟體！其原創作者並無法對於以下情況負責，包含：錄影失敗，不正確的定時設定，多餘時數，或任何產生的其它不良影響...</disclaimer>
     <platform>@PLATFORM@</platform>
     <news>
+v3.12.4
+- Fixed: Used space instead of free space in GetDriveSpace - fixes #109
+- Added: Genre id support from OTA feeds - Requires OpenWebIf 1.3.5
+
+v3.12.3
+- Fixed: Refactoring - Changed Directory structure, split out classes and added getters/setters #102
+- Fixed: Updated readme without VU+ entries - Courtesy of Hedda
+- Fixed: New temporary icon
+
 v3.12.2
 - Fixed: Refactoring - Conventions: includes, namesapce naming, public private order in class definition
 - Fixed: GetInitialEPGForGroup called for each CHANNEL while initial EPG Update - #86
+
+v3.12.1
+- Added: New setting for Prepending outline to plot
+- Added: New setting for stream read chunk size
+- Fixed: cosmetic error when recordings folder is empty #10
+- Fixed: Rename "VuPlus" PVR client addon to Enigma2 or something else for Kodi? #28
     </news>
   </extension>
 </addon>

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,3 +1,7 @@
+v3.12.4
+- Fixed: Used space instead of free space in GetDriveSpace - fixes #109
+- Added: Genre id support from OTA feeds - Requires OpenWebIf 1.3.5
+
 v3.12.3
 - Fixed: Refactoring - Changed Directory structure, split out classes and added getters/setters #102
 - Fixed: Updated readme without VU+ entries - Courtesy of Hedda

--- a/src/Enigma2.cpp
+++ b/src/Enigma2.cpp
@@ -795,7 +795,7 @@ bool Enigma2::LoadLocations()
     Logger::Log(LEVEL_DEBUG, "%s Added '%s' as a recording location", __FUNCTION__, strTmp.c_str());
   }
 
-  Logger::Log(LEVEL_INFO, "%s Loded '%d' recording locations", __FUNCTION__, m_locations.size());
+  Logger::Log(LEVEL_INFO, "%s Loaded '%d' recording locations", __FUNCTION__, m_locations.size());
 
   return true;
 }
@@ -1151,7 +1151,7 @@ bool Enigma2::GetInitialEPGForGroup(ChannelGroup &group)
       entry.SetPlot(strTmp);
 
     if (XMLUtils::GetString(pNode, "e2eventdescription", strTmp))
-       entry.SetPlotOutline(strTmp);
+      entry.SetPlotOutline(strTmp);
 
     // Some providers only use PlotOutline (e.g. freesat) and Kodi does not display it, if this is the case swap them
     if (entry.GetPlot().empty())
@@ -1722,8 +1722,8 @@ PVR_ERROR Enigma2::DeleteTimer(const PVR_TIMER &timer)
 
 PVR_ERROR Enigma2::GetDriveSpace(long long *iTotal, long long *iUsed)
 {
-  long long total = 0;
-  long long used = 0;
+  long long totalKb = 0;
+  long long freeKb = 0;
 
   const std::string url = StringUtils::Format("%s%s", m_strURL.c_str(), "web/deviceinfo"); 
 
@@ -1774,51 +1774,41 @@ PVR_ERROR Enigma2::GetDriveSpace(long long *iTotal, long long *iUsed)
     XMLUtils::GetString(hddNode, "e2capacity", capacity);
     XMLUtils::GetString(hddNode, "e2free", freeSpace);
 
-    std::regex regexGB ("^.* GB");
-    std::regex regexMB ("^.* MB");
-    std::regex regexReplaceGB (" GB");
-    std::regex regexReplaceMB (" MB");
-    std::string replaceWith = "";
-
-    if (regex_match(capacity, regexGB))
-    {
-      //It's GB
-      double gigabytesSize = atof(regex_replace(capacity, regexReplaceGB, replaceWith).c_str());
-
-      total += (long long)(gigabytesSize * 1024 * 1024);
-    }
-    else
-    {
-      //It's MB
-      if (regex_match(capacity, regexMB))
-      {
-        double megabytesSize = atof(regex_replace(capacity, regexReplaceMB, replaceWith).c_str());
-
-        total += (long long)(megabytesSize * 1024);
-      }
-    }
-
-    if (regex_match(freeSpace, regexGB))
-    {
-      double gigabytesSize = atof(regex_replace(freeSpace, regexReplaceGB, replaceWith).c_str());
-
-      used += (long long)(gigabytesSize * 1024 * 1024);
-    }
-    else
-    {
-      if (regex_match(freeSpace, regexMB))
-      {
-        double megabytesSize = atof(regex_replace(freeSpace, regexReplaceMB, replaceWith).c_str());
-
-        used += (long long)(megabytesSize * 1024);
-      }
-    }
+    totalKb += GetKbFromString(capacity);
+    freeKb += GetKbFromString(freeSpace);
   }
 
-  *iTotal = total;
-  *iUsed = used;
+  *iTotal = totalKb;
+  *iUsed = totalKb - freeKb;
 
-  Logger::Log(LEVEL_INFO, "GetDriveSpace Total: %u, Free %u", *iTotal, *iUsed);
+  Logger::Log(LEVEL_INFO, "GetDriveSpace Total: %lld, Used %lld", *iTotal, *iUsed);
 
   return PVR_ERROR_NO_ERROR;
+}
+
+long long Enigma2::GetKbFromString(const std::string &stringInMbGbTb) const
+{
+  long long sizeInKb = 0;
+
+  static const std::vector<std::string> sizes = {"MB", "GB", "TB"};
+  long multiplier = 1024 * 1024;
+  std::string replaceWith = "";
+  for (const std::string& size : sizes)
+  {
+    std::regex regexSize ("^.* " + size);
+    std::regex regexReplaceSize (" " + size);
+
+    if (regex_match(stringInMbGbTb, regexSize))
+    {
+      double sizeValue = atof(regex_replace(stringInMbGbTb, regexReplaceSize, replaceWith).c_str());
+
+      sizeInKb += static_cast<long long>(sizeValue * multiplier);
+
+      break;
+    }
+
+    multiplier = multiplier * 1024;
+  }
+
+  return sizeInKb;
 }

--- a/src/Enigma2.cpp
+++ b/src/Enigma2.cpp
@@ -1166,6 +1166,19 @@ bool Enigma2::GetInitialEPGForGroup(ChannelGroup &group)
       entry.SetPlotOutline("");
     }    
 
+    if (XMLUtils::GetString(pNode, "e2eventgenre", strTmp))
+    {
+      entry.SetGenreDescription(strTmp);
+
+      TiXmlElement* genreNode = pNode->FirstChildElement("e2eventgenre");
+      int genreId = 0;
+      if (genreNode->QueryIntAttribute("id", &genreId) == TIXML_SUCCESS)
+      {
+        entry.SetGenreType(genreId & 0xF0);
+        entry.SetGenreSubType(genreId & 0x0F);
+      }
+    }
+
     if (m_settings.GetExtractExtraEpgInfo())
       m_entryExtractor->ExtractFromEntry(entry);
 
@@ -1386,6 +1399,19 @@ PVR_ERROR Enigma2::GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL &chan
       entry.SetPlot(entry.GetPlotOutline() + "\n" + entry.GetPlot());
       entry.SetPlotOutline("");
     }    
+
+    if (XMLUtils::GetString(pNode, "e2eventgenre", strTmp))
+    {
+      entry.SetGenreDescription(strTmp);
+
+      TiXmlElement* genreNode = pNode->FirstChildElement("e2eventgenre");
+      int genreId = 0;
+      if (genreNode->QueryIntAttribute("id", &genreId) == TIXML_SUCCESS)
+      {
+        entry.SetGenreType(genreId & 0xF0);
+        entry.SetGenreSubType(genreId & 0x0F);
+      }
+    }
 
     if (m_settings.GetExtractExtraEpgInfo())
       m_entryExtractor->ExtractFromEntry(entry);

--- a/src/Enigma2.h
+++ b/src/Enigma2.h
@@ -122,6 +122,7 @@ private:
   std::string& Escape(std::string &s, std::string from, std::string to);
   bool IsInRecordingFolder(std::string);
   void TransferRecordings(ADDON_HANDLE handle);
+  long long GetKbFromString(const std::string &stringInMbGbTb) const;
 
   // members
   void *m_writeHandle;

--- a/src/enigma2/extract/GenreExtractor.cpp
+++ b/src/enigma2/extract/GenreExtractor.cpp
@@ -25,24 +25,27 @@ GenreExtractor::~GenreExtractor(void)
 
 void GenreExtractor::ExtractFromEntry(BaseEntry &entry)
 {
-  std::string genreText = GetMatchedText(entry.GetPlotOutline(), entry.GetPlot(), genrePattern);
-
-  if (!genreText.empty() && genreText != GENRE_RESERVED_IGNORE)
+  if (entry.GetGenreType() == 0)
   {
-    int combinedGenreType = GetGenreTypeFromText(genreText, entry.GetTitle());
+    const std::string genreText = GetMatchedText(entry.GetPlotOutline(), entry.GetPlot(), genrePattern);
 
-    if (combinedGenreType == EPG_EVENT_CONTENTMASK_UNDEFINED)
+    if (!genreText.empty() && genreText != GENRE_RESERVED_IGNORE)
     {
-      if (m_settings.GetLogMissingGenreMappings())
-        Logger::Log(LEVEL_NOTICE, "%s: Could not lookup genre using genre description string instead:'%s'", __FUNCTION__, genreText.c_str());
+      int combinedGenreType = GetGenreTypeFromText(genreText, entry.GetTitle());
 
-      entry.SetGenreType(EPG_GENRE_USE_STRING);
-      entry.SetGenreDescription(genreText);
-    }
-    else
-    {
-      entry.SetGenreType(GetGenreTypeFromCombined(combinedGenreType));
-      entry.SetGenreSubType(GetGenreSubTypeFromCombined(combinedGenreType));
+      if (combinedGenreType == EPG_EVENT_CONTENTMASK_UNDEFINED)
+      {
+        if (m_settings.GetLogMissingGenreMappings())
+          Logger::Log(LEVEL_NOTICE, "%s: Could not lookup genre using genre description string instead:'%s'", __FUNCTION__, genreText.c_str());
+
+        entry.SetGenreType(EPG_GENRE_USE_STRING);
+        entry.SetGenreDescription(genreText);
+      }
+      else
+      {
+        entry.SetGenreType(GetGenreTypeFromCombined(combinedGenreType));
+        entry.SetGenreSubType(GetGenreSubTypeFromCombined(combinedGenreType));
+      }
     }
   }
 }


### PR DESCRIPTION
v3.12.4
- Fixed: Used space instead of free space in GetDriveSpace - fixes #109
- Added: Genre id support from OTA feeds - Requires OpenWebIf 1.3.5