### PR TITLE
Windows fixes and Timeshift buffer deletion

### DIFF
--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="3.12.5"
+  version="3.12.6"
   name="Enigma2 Client"
   provider-name="Joerg Dembski and Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>
@@ -175,6 +175,10 @@
     <disclaimer lang="zh_TW">這是測試版軟體！其原創作者並無法對於以下情況負責，包含：錄影失敗，不正確的定時設定，多餘時數，或任何產生的其它不良影響...</disclaimer>
     <platform>@PLATFORM@</platform>
     <news>
+v3.12.6
+- Fixed: Windows build fix
+- Fixed: tsbuffer.ts never got deleted, fixes #115
+
 v3.12.5
 - Fixed: Large refactor for code organisation
 - Added: Disk space, only for mounts configured for recordings - Requires OpenWebIf 1.3.5, fixes #112

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,3 +1,7 @@
+v3.12.6
+- Fixed: Windows build fix
+- Fixed: tsbuffer.ts never got deleted, fixes #115
+
 v3.12.5
 - Fixed: Large refactor for code organisation
 - Fixed: Disk space, only for mounts configured for recordings - Requires OpenWebIf 1.3.5, fixes #112

--- a/src/Enigma2.cpp
+++ b/src/Enigma2.cpp
@@ -39,10 +39,6 @@
 #include "util/XMLUtils.h"
 #include <p8-platform/util/StringUtils.h>
 
-#if defined(_WIN32)
-#include <Bits.h>
-#endif
-
 using namespace ADDON;
 using namespace P8PLATFORM;
 using namespace enigma2;

--- a/src/enigma2/Epg.cpp
+++ b/src/enigma2/Epg.cpp
@@ -31,7 +31,7 @@ void Epg::InitialiseEpgReadyFile()
 bool Epg::IsInitialEpgCompleted()
 {
   m_readHandle = XBMC->OpenFile(INITIAL_EPG_READY_FILE.c_str(), 0);
-  byte buf[1];
+  char buf[1];
   XBMC->ReadFile(m_readHandle, buf, 1);
   XBMC->CloseFile(m_readHandle);
   char buf2[] = { "N" };

--- a/src/enigma2/TimeshiftBuffer.cpp
+++ b/src/enigma2/TimeshiftBuffer.cpp
@@ -39,6 +39,10 @@ TimeshiftBuffer::~TimeshiftBuffer(void)
   }
   if (m_filebufferReadHandle)
     XBMC->CloseFile(m_filebufferReadHandle);
+  
+  if (!XBMC->DeleteFile(m_bufferPath.c_str()))
+    Logger::Log(LEVEL_ERROR, "%s Unable to delete file when timeshift buffer is deleted: %s", __FUNCTION__, m_bufferPath.c_str());
+  
   SAFE_DELETE(m_strReader);
   Logger::Log(LEVEL_DEBUG, "Timeshift: Stopped");
 }

--- a/src/enigma2/data/AutoTimer.cpp
+++ b/src/enigma2/data/AutoTimer.cpp
@@ -4,6 +4,7 @@
 #include "util/XMLUtils.h"
 #include "p8-platform/util/StringUtils.h"
 
+using namespace enigma2;
 using namespace enigma2::data;
 using namespace enigma2::utilities;
 

--- a/src/enigma2/data/BaseEntry.cpp
+++ b/src/enigma2/data/BaseEntry.cpp
@@ -3,6 +3,7 @@
 #include "inttypes.h"
 #include "p8-platform/util/StringUtils.h"
 
+using namespace enigma2;
 using namespace enigma2::data;
 
 void BaseEntry::ProcessPrependMode(PrependOutline prependOutlineMode)

--- a/src/enigma2/data/Channel.cpp
+++ b/src/enigma2/data/Channel.cpp
@@ -9,6 +9,7 @@
 #include "util/XMLUtils.h"
 #include "p8-platform/util/StringUtils.h"
 
+using namespace enigma2;
 using namespace enigma2::data;
 using namespace enigma2::utilities;
 

--- a/src/enigma2/data/ChannelGroup.cpp
+++ b/src/enigma2/data/ChannelGroup.cpp
@@ -3,6 +3,7 @@
 #include "inttypes.h"
 #include "util/XMLUtils.h"
 
+using namespace enigma2;
 using namespace enigma2::data;
 using namespace enigma2::utilities;
 

--- a/src/enigma2/data/RecordingEntry.cpp
+++ b/src/enigma2/data/RecordingEntry.cpp
@@ -6,6 +6,7 @@
 #include "util/XMLUtils.h"
 #include "p8-platform/util/StringUtils.h"
 
+using namespace enigma2;
 using namespace enigma2::data;
 using namespace enigma2::utilities;
 

--- a/src/enigma2/data/Timer.cpp
+++ b/src/enigma2/data/Timer.cpp
@@ -6,6 +6,7 @@
 #include "util/XMLUtils.h"
 #include "p8-platform/util/StringUtils.h"
 
+using namespace enigma2;
 using namespace enigma2::data;
 using namespace enigma2::utilities;
 


### PR DESCRIPTION
v3.12.6
- Fixed: Possible race condition on startup, fixes #114
- Fixed: Windows build in Epg.cpp
- Fixed: tsbuffer.ts never got deleted, fixes #115

First appears to be a race condition on addon startup, I have to start the addon about 50 times to get it to happen. Welcome any feedback how I added the lock objects. I referenced several other addons to see how it was done there so I think  have everything covered. On the third the Epg.cpp fixed worked bu now's it's stuck on AutoTimer.cpp