### PR TITLE
Potential fix for possible race condition on startup, fixes #114

### DIFF
--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -175,6 +175,9 @@
     <disclaimer lang="zh_TW">這是測試版軟體！其原創作者並無法對於以下情況負責，包含：錄影失敗，不正確的定時設定，多餘時數，或任何產生的其它不良影響...</disclaimer>
     <platform>@PLATFORM@</platform>
     <news>
+v3.12.7
+- Fixed: Possible race condition on startup #114
+
 v3.12.6
 - Fixed: Windows build fix
 - Fixed: tsbuffer.ts never got deleted, fixes #115

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,3 +1,6 @@
+v3.12.7
+- Fixed: Possible race condition on startup #114
+
 v3.12.6
 - Fixed: Windows build fix
 - Fixed: tsbuffer.ts never got deleted, fixes #115

--- a/src/Enigma2.cpp
+++ b/src/Enigma2.cpp
@@ -53,6 +53,7 @@ Enigma2::Enigma2()
 Enigma2::~Enigma2() 
 {
   CLockObject lock(m_mutex);
+
   Logger::Log(LEVEL_DEBUG, "%s Stopping update thread...", __FUNCTION__);
   StopThread();
   
@@ -218,6 +219,8 @@ PVR_ERROR Enigma2::GetChannelGroups(ADDON_HANDLE handle)
 
 PVR_ERROR Enigma2::GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &group)
 {
+  CLockObject lock(m_mutex);
+
   Logger::Log(LEVEL_DEBUG, "%s - group '%s'", __FUNCTION__, group.strGroupName);
   std::string strTmp = group.strGroupName;
   for (const auto& channel : m_channels.GetChannelsList())
@@ -244,11 +247,12 @@ PVR_ERROR Enigma2::GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL
  * Channels
  **************************************************************************/
 
-int Enigma2::GetChannelsAmount() const
+int Enigma2::GetChannelsAmount()
 {
+  CLockObject lock(m_mutex);
+
   return m_channels.GetNumChannels();
 }
-
 
 PVR_ERROR Enigma2::GetChannels(ADDON_HANDLE handle, bool bRadio)
 {
@@ -272,6 +276,8 @@ PVR_ERROR Enigma2::GetChannels(ADDON_HANDLE handle, bool bRadio)
 
 PVR_ERROR Enigma2::GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL &channel, time_t iStart, time_t iEnd)
 {
+  CLockObject lock(m_mutex);
+
   return m_epg.GetEPGForChannel(handle, channel, iStart, iEnd);
 }
 
@@ -280,8 +286,9 @@ PVR_ERROR Enigma2::GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL &chan
  **************************************************************************/
 bool Enigma2::OpenLiveStream(const PVR_CHANNEL &channelinfo)
 {
-  Logger::Log(LEVEL_DEBUG, "%s: channel=%u", __FUNCTION__, channelinfo.iUniqueId);
   CLockObject lock(m_mutex);
+
+  Logger::Log(LEVEL_DEBUG, "%s: channel=%u", __FUNCTION__, channelinfo.iUniqueId);
 
   if (channelinfo.iUniqueId != m_iCurrentChannel)
   {
@@ -306,11 +313,14 @@ bool Enigma2::OpenLiveStream(const PVR_CHANNEL &channelinfo)
 void Enigma2::CloseLiveStream(void)
 {
   CLockObject lock(m_mutex);
+
   m_iCurrentChannel = -1;
 }
 
 const std::string Enigma2::GetLiveStreamURL(const PVR_CHANNEL &channelinfo)
 {
+  CLockObject lock(m_mutex);
+
   if (m_settings.GetAutoConfigLiveStreamsEnabled())
   {
     // we need to download the M3U file that contains the URL for the stream...
@@ -351,18 +361,19 @@ std::string Enigma2::GetStreamURL(const std::string& strM3uURL)
  * Recordings
  **************************************************************************/
 
-unsigned int Enigma2::GetRecordingsAmount() 
+unsigned int Enigma2::GetRecordingsAmount()
 {
+  CLockObject lock(m_mutex);
+
   return m_recordings.GetNumRecordings();
 }
 
 PVR_ERROR Enigma2::GetRecordings(ADDON_HANDLE handle)
 {
-  m_recordings.LoadRecordings();
-
   std::vector<PVR_RECORDING> recordings;
   {
     CLockObject lock(m_mutex);
+    m_recordings.LoadRecordings();
     m_recordings.GetRecordings(recordings);
   }
 
@@ -376,12 +387,15 @@ PVR_ERROR Enigma2::GetRecordings(ADDON_HANDLE handle)
 
 PVR_ERROR Enigma2::DeleteRecording(const PVR_RECORDING &recinfo) 
 {
+  CLockObject lock(m_mutex);
+
   return m_recordings.DeleteRecording(recinfo);
 }
 
 RecordingReader *Enigma2::OpenRecordedStream(const PVR_RECORDING &recinfo)
 {
   CLockObject lock(m_mutex);
+
   std::time_t now = std::time(nullptr), end = 0;
   std::string channelName = recinfo.strChannelName;
   auto timer = m_timers.GetTimer([&](const Timer &timer)
@@ -399,7 +413,7 @@ RecordingReader *Enigma2::OpenRecordedStream(const PVR_RECORDING &recinfo)
  **************************************************************************/
 
 void Enigma2::GetTimerTypes(PVR_TIMER_TYPE types[], int *size)
-{
+{  
   std::vector<PVR_TIMER_TYPE> timerTypes;
   {
     CLockObject lock(m_mutex);
@@ -438,16 +452,22 @@ PVR_ERROR Enigma2::GetTimers(ADDON_HANDLE handle)
 
 PVR_ERROR Enigma2::AddTimer(const PVR_TIMER &timer)
 {
+  CLockObject lock(m_mutex);
+
   return m_timers.AddTimer(timer);
 }
 
 PVR_ERROR Enigma2::UpdateTimer(const PVR_TIMER &timer)
 {
+  CLockObject lock(m_mutex);
+
   return m_timers.UpdateTimer(timer);
 }
 
 PVR_ERROR Enigma2::DeleteTimer(const PVR_TIMER &timer)
 {
+  CLockObject lock(m_mutex);
+
   return m_timers.DeleteTimer(timer);
 }
 
@@ -457,5 +477,7 @@ PVR_ERROR Enigma2::DeleteTimer(const PVR_TIMER &timer)
 
 PVR_ERROR Enigma2::GetDriveSpace(long long *iTotal, long long *iUsed)
 {
+  CLockObject lock(m_mutex);
+
   return m_admin.GetDriveSpace(iTotal, iUsed, m_locations);
 }

--- a/src/Enigma2.h
+++ b/src/Enigma2.h
@@ -56,7 +56,7 @@ public:
   unsigned int GetNumChannelGroups(void) const;
   PVR_ERROR    GetChannelGroups(ADDON_HANDLE handle);
   PVR_ERROR    GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &group);
-  int GetChannelsAmount(void) const;
+  int GetChannelsAmount(void);
   PVR_ERROR GetChannels(ADDON_HANDLE handle, bool bRadio);
   PVR_ERROR GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL &channel, time_t iStart, time_t iEnd);
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -37,10 +37,12 @@
 #include "xbmc_pvr_dll.h"
 
 using namespace ADDON;
+using namespace P8PLATFORM;
 using namespace enigma2;
 using namespace enigma2::data;
 using namespace enigma2::utilities;
 
+CMutex g_mutex;
 bool            m_bCreated  = false;
 ADDON_STATUS    m_CurStatus = ADDON_STATUS_UNKNOWN;
 IStreamReader   *strReader  = nullptr;
@@ -135,6 +137,8 @@ ADDON_STATUS ADDON_Create(void* hdl, void* props)
 
 ADDON_STATUS ADDON_GetStatus()
 {
+  CLockObject lock(g_mutex);
+
   /* check whether we're still connected */
   if (m_CurStatus == ADDON_STATUS_OK && !enigma->IsConnected())
     m_CurStatus = ADDON_STATUS_LOST_CONNECTION;
@@ -144,6 +148,8 @@ ADDON_STATUS ADDON_GetStatus()
 
 void ADDON_Destroy()
 {
+  CLockObject lock(g_mutex);
+
   if (m_bCreated)
   {
     m_bCreated = false;
@@ -163,6 +169,8 @@ void ADDON_Destroy()
 
 ADDON_STATUS ADDON_SetSetting(const char *settingName, const void *settingValue)
 {
+  CLockObject lock(g_mutex);
+  
   if (!XBMC || !enigma)
     return ADDON_STATUS_OK;
 


### PR DESCRIPTION
@ksooo 
Ok, let me preface this by me saying I understand this is a risky change but there is probably also some learning with it. I'm more than happy to close it if needs be.

Currently it takes somewhere between 20 and 50 restart attempts to make this happen so testing it is problematic. I would much rather fix the root of the problem but figuring out what that is is difficult.

Some questions:

1) What generally should be covered by a lock object? Surely you want them to be as minimal as possible so only for when reading and changing backend data to ensure these reads and writes are atomic, correct?

2) You also mentioned that making the mutexes mutable is preferable to removing const from a function. Would the mutex not need to be a member variable to make it mutable? 

3) Are there any techniques I can use locally to make the race condition happen more often. Faced with a similar issue how would you go about tackling it? 

Another approach would be to wait until a users has this occur more often and get a debug log from them to point me in the right direction. At least with this approach we do not risk deadlock which is better.

As I said at the start happy to bin this. I've mostly talked myself into the wait and see approach already but would like to hear your thoughts.

Thanks in advance ;)