### PR TITLE
Unique channels and radio groups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ set(VUPLUS_HEADERS src/client.h
                    src/enigma2/extract/ShowInfoExtractor.h
                    src/enigma2/utilities/CurlFile.h
                    src/enigma2/utilities/DeviceInfo.h
+                   src/enigma2/utilities/DeviceSettings.h
                    src/enigma2/utilities/LocalizedString.h
                    src/enigma2/utilities/UpdateState.h
                    src/enigma2/utilities/FileUtils.h

--- a/README.md
+++ b/README.md
@@ -28,29 +28,32 @@ VuPlus PVR client addon for [Kodi] (https://kodi.tv)
 ### Connection
 Within this tab the connection options need to be configured before it can be successfully enabled.
 
-* **Enigma2 hostname or IP address**: The IP address or hostname of your enigma2 based settop box.
+* **Enigma2 hostname or IP address**: The IP address or hostname of your enigma2 based set-top box.
 * **Web interface port**: The port used to connect to the web interface
 * **Use secure HTTP (https)**: Use https to connect to the web interface
-* **Username**: If the webinterface of the settop box is protected with a username / password combination this needs to be set in this option.
-* **Password**: If the webinterface of the settop box is protected with a username / password combination this needs to be set in this option.
+* **Username**: If the webinterface of the set-top box is protected with a username / password combination this needs to be set in this option.
+* **Password**: If the webinterface of the set-top box is protected with a username / password combination this needs to be set in this option.
 * **Enable automatic configuration for live streams**: When enabled the stream URL will be read from an M3U file. When disabled it is constructed based on the filename.
-* **Streaming port**: This option defines the streaming port the settop box uses to stream live tv. The default is 8001 which should be fine if the user did not define a custom port within the webinterface.
-Webinterface Port: This option defines the port that should be used to access the webinterface of the settop box.
+* **Streaming port**: This option defines the streaming port the set-top box uses to stream live tv. The default is 8001 which should be fine if the user did not define a custom port within the webinterface.
+Webinterface Port: This option defines the port that should be used to access the webinterface of the set-top box.
 * **Use secure HTTP (https) for streams**: Use https to connect to streams
 * **Use login for streams**: Use the login username and password for streams
 
 ### General
 Within this tab general options are configured.
 
-* **Fetch picons from web interface**: Fetch the picons straight from the Enigma 2 STB
-* **Use picons.eu file formate**: Assume all picons files fetched from the STB start with `1_1_1_` and end with `_0_0_0`
-* **Icon path**: In order to have Kodi display channel logos you have to copy the picons from your settop box onto your OpenELEC machine. You then need to specify this path in this property.
-* **Update interval**: As the settop box can also be used to modify timers, delete recordings etc. and the settop box does not notify the Kodi installation, the addon needs to regularly check for updates (new channels, new/changed/deletes timers, deleted recordings, etc.) This property defines how often the addon checks for updates.
+* **Fetch picons from web interface**: Fetch the picons straight from the Enigma 2 set-top box.
+* **Use picons.eu file formate**: Assume all picons files fetched from the set-top box start with `1_1_1_` and end with `_0_0_0`
+* **Icon path**: In order to have Kodi display channel logos you have to copy the picons from your set-top box onto your OpenELEC machine. You then need to specify this path in this property.
+* **Update interval**: As the set-top box can also be used to modify timers, delete recordings etc. and the set-top box does not notify the Kodi installation, the addon needs to regularly check for updates (new channels, new/changed/deletes timers, deleted recordings, etc.) This property defines how often the addon checks for updates.
+* **Update mode**: The mode used when the update interval is reached. Note that if there is any timer change detected a recordings update will always occur regardless of the update mode. Choose from one of the following two modes:
+    - `Timers and Recordings` - Update all timers and recordings.
+    - `Timers only` - Only update the timers.
 
 ### Channels
 Within this tab options that refer to channel data can be set. When changing bouquets you may need to clear the channel cache to the settings to take effect. You can do this by going to the following in Kodi settings: `Settings->PVR & Live TV->General->Clear cache`.
 
-* **Zap before channelswitch (i.e. for Single Tuner boxes)**: When using the addon with a single tuner box it may be necessary that the addon needs to be able to zap to another channel on the settop box. If this option is enabled each channel switch in Kodi will also result in a channel switch on the settop box. Please note that "allow channel switching" needs to be enabled in the webinterface on the settop box.
+* **Zap before channelswitch (i.e. for Single Tuner boxes)**: When using the addon with a single tuner box it may be necessary that the addon needs to be able to zap to another channel on the set-top box. If this option is enabled each channel switch in Kodi will also result in a channel switch on the set-top box. Please note that "allow channel switching" needs to be enabled in the webinterface on the set-top box.
 * **TV bouquet fetch mode**: Choose from one of the following three modes:
     - `All bouquets` - Fetch all TV bouquets from the set-top box.
     - `Only one bouquet` - Only fetch the bouquet specified in the next option
@@ -77,26 +80,26 @@ Information on customising the extraction and mapper configs can be found in the
 
 * **Extract season, episode and year info where possible**: Check the description fields in the EPG data and attempt to extract season, episode and year info where possible. 
 * **Extract show info file**: The config used to extract season, episode and year information. The default file is `English-ShowInfo.xml`. 
-* **Enable genre ID mappings**: If the genre IDs sent with EPG data from your STB are not using the DVB standard, map from these to the DVB standard IDs. Sky UK for instance uses OpenTV, in that case without this option set the genre colouring and text would be incorrect in Kodi. 
-* **Genre ID mappings file**: The config used to map STB EPG genre IDs to DVB standard IDs. The default file is `Sky-UK.xml`. 
+* **Enable genre ID mappings**: If the genre IDs sent with EPG data from your set-top box are not using the DVB standard, map from these to the DVB standard IDs. Sky UK for instance uses OpenTV, in that case without this option set the genre colouring and text would be incorrect in Kodi. 
+* **Genre ID mappings file**: The config used to map set-top box EPG genre IDs to DVB standard IDs. The default file is `Sky-UK.xml`. 
 * **Enable Rytec genre text mappings**: If you use Rytec XMLTV EPG data this option can be used to map the text genres to DVB standard IDs. 
 * **Rytec genre text mappings file**: The config used to map Rytec Genre Text to DVB IDs. The default file is `Rytec-UK-Ireland.xml`. 
 * **Log missing genre text mappings**: If you would like missing genre mappings to be logged so you can report them enable this option. Note: any genres found that don't have a mapping will still be extracted and sent to Kodi as strings. Currently genres are extracted by looking for text between square brackets, e.g. [TV Drama], or for major, minor genres using a dot (.) to separate [TV Drama. Soap Opera]
 
 ### Recordings & Timers
 
-* **Recording folder on receiver**: Per default the addon does not specify the recording folder in newly created timers, so the default set in the settop box will be used. If you want to specify a different folder (i.e. because you want all recordings scheduled via Kodi to be stored in a separate folder), then you need to set this option.
-* **Use only the DVB boxes' current recording path**: If this option is not set the addon will fetch all available recordings from all configured paths from the STB. If this option is set then it will only list recordings that are stored within the "current recording path" on the settop box.
+* **Recording folder on receiver**: Per default the addon does not specify the recording folder in newly created timers, so the default set in the set-top box will be used. If you want to specify a different folder (i.e. because you want all recordings scheduled via Kodi to be stored in a separate folder), then you need to set this option.
+* **Use only the DVB boxes' current recording path**: If this option is not set the addon will fetch all available recordings from all configured paths from the set-top box. If this option is set then it will only list recordings that are stored within the "current recording path" on the set-top box.
 * **Keep folder structure for records**: If enabled do not specify a recording folder, when disabled (defaut), check if the recording is in it's own folder or in the root of the recording path
 * **Enable generate repeat timers**: Repeat timers will display as timer rules. Enabling this will make Kodi generate regular timers to match the repeat timer rules so the UI can show what's scheduled and currently recording for each repeat timer.
 * **Number of repeat timers to generate**: The number of Kodi PVR timers to generate.
-* **Enable autotimers**: When this is enabled there are some settings required on the STB to enable linking of AutoTimers (Timer Rules) to Timers in the Kodi UI. The addon attempts to set these automatically on boot. To set manually on the STB enable the following options (note that this feature supports OpenWebIf 1.3.x and higher):
+* **Enable autotimers**: When this is enabled there are some settings required on the set-top box to enable linking of AutoTimers (Timer Rules) to Timers in the Kodi UI. The addon attempts to set these automatically on boot. To set manually on the set-top box enable the following options (note that this feature supports OpenWebIf 1.3.x and higher):
   1. Hit `Menu` on the remote and go to `Timers->AutoTimers`
   2. Hit `Menu` again and then select `6 Setup`
   3. Set the following to option to `yes`
     * `Include "AutoTimer" in tags`
     * `Include AutoTimer name in tags`
-* **Automatic timerlist cleanup**: If this option is set then the addon will send the command to delete completed timers from the STB after each update interval.
+* **Automatic timerlist cleanup**: If this option is set then the addon will send the command to delete completed timers from the set-top box after each update interval.
 
 ### Timeshift
 * **Enable timeshift**: What timeshift option do you want:
@@ -110,10 +113,10 @@ Within this tab more uncommon and advanced options can be configured.
 
 * **Put outline (e.g. sub-title) before plot**: By default plot outline (short description on Enigma2) is not displayed in the UI. Can be
  displayed in EPG, Recordings or both. After changing this option you will need to clear the EPG cache `Settings->PVR & Live TV->Guide->Clear cache` for it to take effect.
-* **Send powerstate mode on addon exit**: If this option is set to a value other than `DISABLED` then the addon will send a Powerstate command to the STB when Kodi will be closed (or the addon will be deactivated).
+* **Send powerstate mode on addon exit**: If this option is set to a value other than `DISABLED` then the addon will send a Powerstate command to the set-top box when Kodi will be closed (or the addon will be deactivated).
     - `Disabled` - No command sent when the addon exits
     - `Standby` - Send the standby command on exit
-    - `Deep standby` - Send the deep standby command on exit. Note, the STB will not respond to Kodi after this command is sent.
+    - `Deep standby` - Send the deep standby command on exit. Note, the set-top box will not respond to Kodi after this command is sent.
     - `Wakeup, then standby` - Similar to standby but first sends a wakeup command. Can be useful if you want to ensure all streams have stopped. Note: if you use CEC this could cause your TV to wake.
 * **Custom live TV timeout (0 to use default)**: The timemout to use when trying to read live streams
 * **Stream read chunk size**: The chunk size used by Kodi for streams. Default 0 to leave it to Kodi to decide.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Information on customising the extraction and mapper configs can be found in the
 * **Keep folder structure for records**: If enabled do not specify a recording folder, when disabled (defaut), check if the recording is in it's own folder or in the root of the recording path
 * **Enable generate repeat timers**: Repeat timers will display as timer rules. Enabling this will make Kodi generate regular timers to match the repeat timer rules so the UI can show what's scheduled and currently recording for each repeat timer.
 * **Number of repeat timers to generate**: The number of Kodi PVR timers to generate.
-* **Enable autotimers**: When this is enabled there are some settings required on the STB to enable linking of AutoTimers (Timer Rules) to Timers in the Kodi UI. On the STB enable the following options (note that this feature supports OpenWebIf 1.3.x and higher):
+* **Enable autotimers**: When this is enabled there are some settings required on the STB to enable linking of AutoTimers (Timer Rules) to Timers in the Kodi UI. The addon attempts to set these automatically on boot. To set manually on the STB enable the following options (note that this feature supports OpenWebIf 1.3.x and higher):
   1. Hit `Menu` on the remote and go to `Timers->AutoTimers`
   2. Hit `Menu` again and then select `6 Setup`
   3. Set the following to option to `yes`

--- a/README.md
+++ b/README.md
@@ -48,11 +48,27 @@ Within this tab general options are configured.
 * **Update interval**: As the settop box can also be used to modify timers, delete recordings etc. and the settop box does not notify the Kodi installation, the addon needs to regularly check for updates (new channels, new/changed/deletes timers, deleted recordings, etc.) This property defines how often the addon checks for updates.
 
 ### Channels
-Within this tab options that refer to channel data can be set.
+Within this tab options that refer to channel data can be set. When changing bouquets you may need to clear the channel cache to the settings to take effect. You can do this by going to the following in Kodi settings: `Settings->PVR & Live TV->General->Clear cache`.
 
-* **Fetch only one TV bouquet**: If this option is set than only the channels that are in one specified TV bouquet will be loaded, instead of fetching all available channels in all available bouquets.
-* **TV bouquet**: If the previous option has been enabled you need to specify the TV bouquet to be fetched from the settop box. Please not that this is the bouquet-name as shown on the settop box (i.e. "Favourites (TV)"). This setting is case-sensitive.
 * **Zap before channelswitch (i.e. for Single Tuner boxes)**: When using the addon with a single tuner box it may be necessary that the addon needs to be able to zap to another channel on the settop box. If this option is enabled each channel switch in Kodi will also result in a channel switch on the settop box. Please note that "allow channel switching" needs to be enabled in the webinterface on the settop box.
+* **TV bouquet fetch mode**: Choose from one of the following three modes:
+    - `All bouquets` - Fetch all TV bouquets from the set-top box.
+    - `Only one bouquet` - Only fetch the bouquet specified in the next option
+    - `Favourites group` - Only fetch the system bouquet for TV favourites.
+* **TV bouquet**: If the previous option has been has been set to `Only one bouquet` you need to specify the TV bouquet to be fetched from the set-top box. Please not that this is the bouquet-name as shown on the set-top box (i.e. "Favourites (TV)"). This setting is case-sensitive.
+* **Fetch TV favourites bouquet**: If the fetch mode is `All bouquets` or `Only one bouquet` depending on your Enigma2 image you may need to explicitly fetch favourites if you require them. The options are:
+    - `Disabled` - Don't explicitly fetch TV favourites.
+    - `As first bouquet` - Explicitly fetch them as the first bouquet.
+    - `As last bouquet` - Explicitly fetch them as the last bouquet.
+* **Radio bouquet fetch mode**: Choose from one of the following three modes:
+    - `All bouquets` - Fetch all Radio bouquets from the set-top box.
+    - `Only one bouquet` - Only fetch the bouquet specified in the next option
+    - `Favourites group` - Only fetch the system bouquet for Radio favourites.
+* **Radio bouquet**: If the previous option has been has been set to `Only one bouquet` you need to specify the Radio bouquet to be fetched from the set-top box. Please not that this is the bouquet-name as shown on the set-top box (i.e. "Favourites (Radio)"). This setting is case-sensitive.
+* **Fetch Radio favourites bouquet**: If the fetch mode is `All bouquets` or `Only one bouquet` depending on your Enigma2 image you may need to explicitly fetch favourites if you require them. The options are:
+    - `Disabled` - Don't explicitly fetch Radio favourites.
+    - `As first bouquet` - Explicitly fetch them as the first bouquet.
+    - `As last bouquet` - Explicitly fetch them as the last bouquet.
 
 ### EPG
 Within this tab options that refer to EPG data can be set. Excluding logging missing genre text mappings all other options will require clearing the EPG cache to take effect. This can be done by going to `Settings->PVR & Live TV->Guide->Clear cache` in Kodi after the addon restarts.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,11 @@ Within this tab more uncommon and advanced options can be configured.
 
 * **Put outline (e.g. sub-title) before plot**: By default plot outline (short description on Enigma2) is not displayed in the UI. Can be
  displayed in EPG, Recordings or both. After changing this option you will need to clear the EPG cache `Settings->PVR & Live TV->Guide->Clear cache` for it to take effect.
-* **Send deep standby command**: If this option is set then the addon will send the DeepStandby-Command to the settop box when Kodi will be closed (or the addon will be deactivated), causing the settop box to shutdown into DeepStandby.
+* **Send powerstate mode on addon exit**: If this option is set to a value other than `DISABLED` then the addon will send a Powerstate command to the STB when Kodi will be closed (or the addon will be deactivated).
+    - `Disabled` - No command sent when the addon exits
+    - `Standby` - Send the standby command on exit
+    - `Deep standby` - Send the deep standby command on exit. Note, the STB will not respond to Kodi after this command is sent.
+    - `Wakeup, then standby` - Similar to standby but first sends a wakeup command. Can be useful if you want to ensure all streams have stopped. Note: if you use CEC this could cause your TV to wake.
 * **Custom live TV timeout (0 to use default)**: The timemout to use when trying to read live streams
 * **Stream read chunk size**: The chunk size used by Kodi for streams. Default 0 to leave it to Kodi to decide.
 

--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -179,6 +179,11 @@ v3.15.0
 - Added: Support for Radio Groups
 - Added: Create unique list of channels instead of a copy of each channel per group, fixes #101
 - Fixed: hdd free space is wrong, fixes #122
+- Added: Device Settings - AutoTimer and Padding
+- Added: PowerstateMode on exit, fixes #128
+- Fixed: Store timer state on update, fixes #131
+- Fixed: Updates not occuring at specified time and immediate update on timer event, fixes #130
+- Added: Support different update modes for timers and recordings, fixes #125
 
 v3.14.0
 - Added: Externalised season/episode and genre config to allow users support other formats/languages, closes #118

--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="3.14.1"
+  version="3.15.0"
   name="Enigma2 Client"
   provider-name="Joerg Dembski and Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>
@@ -175,6 +175,11 @@
     <disclaimer lang="zh_TW">這是測試版軟體！其原創作者並無法對於以下情況負責，包含：錄影失敗，不正確的定時設定，多餘時數，或任何產生的其它不良影響...</disclaimer>
     <platform>@PLATFORM@</platform>
     <news>
+v3.15.0
+- Added: Support for Radio Groups
+- Added: Create unique list of channels instead of a copy of each channel per group, fixes #101
+- Fixed: hdd free space is wrong, fixes #122
+
 v3.14.0
 - Added: Externalised season/episode and genre config to allow users support other formats/languages, closes #118
 - Added: Server OpenWebIf version now reported by addon
@@ -186,29 +191,6 @@ v3.13.0
 v3.12.6
 - Fixed: Windows build fix
 - Fixed: tsbuffer.ts never got deleted, fixes #115
-
-v3.12.5
-- Fixed: Large refactor for code organisation
-- Added: Disk space, only for mounts configured for recordings - Requires OpenWebIf 1.3.5, fixes #112
-
-v3.12.4
-- Fixed: Used space instead of free space in GetDriveSpace - fixes #109
-- Added: Genre id support from OTA feeds - Requires OpenWebIf 1.3.5
-
-v3.12.3
-- Fixed: Refactoring - Changed Directory structure, split out classes and added getters/setters #102
-- Fixed: Updated readme without VU+ entries - Courtesy of Hedda
-- Fixed: New temporary icon
-
-v3.12.2
-- Fixed: Refactoring - Conventions: includes, namesapce naming, public private order in class definition
-- Fixed: GetInitialEPGForGroup called for each CHANNEL while initial EPG Update - #86
-
-v3.12.1
-- Added: New setting for Prepending outline to plot
-- Added: New setting for stream read chunk size
-- Fixed: cosmetic error when recordings folder is empty #10
-- Fixed: Rename "VuPlus" PVR client addon to Enigma2 or something else for Kodi? #28
     </news>
   </extension>
 </addon>

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -2,6 +2,14 @@ v3.15.0
 - Added: Support for Radio Groups
 - Added: Create unique list of channels instead of a copy of each channel per group, fixes #101
 - Fixed: hdd free space is wrong,  fixes #122
+- Added: Device Settings - AutoTimer and Padding
+- Added: PowerstateMode on exit, fixes #128
+- Fixed: Store timer state on update, fixes #131
+- Fixed: Updates not occuring at specified time and immediate update on timer event, fixes #130
+- Added: Support different update modes for timers and recordings, fixes #125
+
+v3.14.1
+- Added: updated language files from Transifex
 
 v3.14.0
 - Added: Externalised season/episode and genre config to allow users support other formats/languages, closes #118

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,3 +1,8 @@
+v3.15.0
+- Added: Support for Radio Groups
+- Added: Create unique list of channels instead of a copy of each channel per group, fixes #101
+- Fixed: hdd free space is wrong,  fixes #122
+
 v3.14.0
 - Added: Externalised season/episode and genre config to allow users support other formats/languages, closes #118
 - Added: Server OpenWebIf version now reported by addon

--- a/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
@@ -113,7 +113,7 @@ msgid "Recording folder on the receiver"
 msgstr ""
 
 msgctxt "#30024"
-msgid "Send deep standby command"
+msgid "Send powerstate mode on addon exit"
 msgstr ""
 
 msgctxt "#30025"
@@ -402,6 +402,18 @@ msgstr ""
 
 msgctxt "#30096"
 msgid "False"
+msgstr ""
+
+msgctxt "#30097"
+msgid "Standby"
+msgstr ""
+
+msgctxt "#30098"
+msgid "Deep standby"
+msgstr ""
+
+msgctxt "#30099"
+msgid "Wakeup, then standby"
 msgstr ""
 
 #empty strings from id 30097 to 30409

--- a/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
@@ -340,7 +340,27 @@ msgctxt "#30080"
 msgid "Favourites (Radio)"
 msgstr ""
 
-#empty strings from id 30081 to 30409
+msgctxt "#30081"
+msgid "unknown"
+msgstr ""
+
+msgctxt "#30082"
+msgid " (Not connected!)"
+msgstr ""
+
+msgctxt "#30083"
+msgid "addon error"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Enigma2 Media Server"
+msgstr ""
+
+msgctxt "#30085"
+msgid "OK"
+msgstr ""
+
+#empty strings from id 30086 to 30409
 
 msgctxt "#30410"
 msgid "Automatic"

--- a/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
@@ -117,7 +117,7 @@ msgid "Send deep standby command"
 msgstr ""
 
 msgctxt "#30025"
-msgid "Fetch only one TV bouquet"
+msgid "TV bouquet fetch mode"
 msgstr ""
 
 msgctxt "#30026"
@@ -240,7 +240,21 @@ msgctxt "#30055"
 msgid "Genre ID mappings file"
 msgstr ""
 
-#empty strings from id 30056 to 30059
+msgctxt "#30056"
+msgid "TV"
+msgstr ""
+
+msgctxt "#30057"
+msgid "Radio"
+msgstr ""
+
+msgctxt "#30058"
+msgid "Radio bouquet fetch mode"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Radio bouquet"
+msgstr ""
 
 msgctxt "#30060"
 msgid "Timeshift"
@@ -274,7 +288,13 @@ msgctxt "#30067"
 msgid "Use login for streams"
 msgstr ""
 
-#empty strings from id 30068 to 30069
+msgctxt "#30068"
+msgid "Fetch TV favourites bouquet"
+msgstr ""
+
+msgctxt "#30069"
+msgid "Fetch radio favourites bouquet"
+msgstr ""
 
 msgctxt "#30070"
 msgid "Recordings & Timers"
@@ -292,7 +312,35 @@ msgctxt "#30073"
 msgid "Number of repeat timers to generate"
 msgstr ""
 
-#empty strings from id 30074 to 30409
+msgctxt "#30074"
+msgid "All bouquets"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Only one bouquet"
+msgstr ""
+
+msgctxt "#30076"
+msgid "As first bouquet"
+msgstr ""
+
+msgctxt "#30077"
+msgid "As last bouquet"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Favourites group"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Favourites (TV)"
+msgstr ""
+
+msgctxt "#30080"
+msgid "Favourites (Radio)"
+msgstr ""
+
+#empty strings from id 30081 to 30409
 
 msgctxt "#30410"
 msgid "Automatic"

--- a/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
@@ -360,7 +360,51 @@ msgctxt "#30085"
 msgid "OK"
 msgstr ""
 
-#empty strings from id 30086 to 30409
+msgctxt "#30086"
+msgid "Backend"
+msgstr ""
+
+msgctxt "#30087"
+msgid "Recording Padding"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Global start padding"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Global end padding"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Device Info"
+msgstr ""
+
+msgctxt "#30091"
+msgid "WebIf version"
+msgstr ""
+
+msgctxt "#30092"
+msgid "AutoTimer tag in timer tags"
+msgstr ""
+
+msgctxt "#30093"
+msgid "AutoTimer name in timer tags"
+msgstr ""
+
+msgctxt "#30094"
+msgid "N/A"
+msgstr ""
+
+msgctxt "#30095"
+msgid "True"
+msgstr ""
+
+msgctxt "#30096"
+msgid "False"
+msgstr ""
+
+#empty strings from id 30097 to 30409
 
 msgctxt "#30410"
 msgid "Automatic"

--- a/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
@@ -416,7 +416,19 @@ msgctxt "#30099"
 msgid "Wakeup, then standby"
 msgstr ""
 
-#empty strings from id 30097 to 30409
+msgctxt "#30100"
+msgid "Update mode"
+msgstr ""
+
+msgctxt "#30101"
+msgid "Timers and recordings"
+msgstr ""
+
+msgctxt "#30102"
+msgid "Timers only"
+msgstr ""
+
+#empty strings from id 30103 to 30409
 
 msgctxt "#30410"
 msgid "Automatic"

--- a/pvr.vuplus/resources/settings.xml
+++ b/pvr.vuplus/resources/settings.xml
@@ -135,30 +135,103 @@
 
     <!-- Channels -->
     <category id="channels" label="30019">
-      <group id="1" label="30019">
-        <setting id="onlyonegroup" type="boolean" label="30025">
-          <level>0</level>
-          <default>false</default>
-          <control type="toggle" />
-        </setting>
-        <setting id="onegroup" type="string" parent="onlyonegroup" label="30026">
-          <level>0</level>
-          <default></default>
-          <constraints>
-            <allowempty>true</allowempty>
-          </constraints>
-          <dependencies>
-            <dependency type="enable" setting="onlyonegroup">true</dependency>
-          </dependencies>
-          <control type="edit" format="string" />
-        </setting>
+      <group id="1" label="30018">
         <setting id="zap" type="boolean" label="30013">
           <level>0</level>
           <default>false</default>
           <control type="toggle" />
         </setting>
       </group>
-
+      <group id="2" label="30056">
+        <setting id="tvgroupmode" type="integer" label="30025">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="30074">0</option> <!-- ALL_GROUPS -->
+              <option label="30075">1</option> <!-- ONLY_ONE_GROUP -->
+              <option label="30078">2</option> <!-- FAVOURITES_GROUP -->
+            </options>
+          </constraints>
+          <control type="spinner" format="integer" />
+        </setting>        
+        <setting id="onetvgroup" type="string" parent="tvgroupmode" label="30026">
+          <level>0</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <dependencies>
+            <dependency type="visible" setting="tvgroupmode" operator="is">1</dependency>
+          </dependencies>
+          <control type="edit" format="string" />
+        </setting>
+        <setting id="tvfavouritesmode" type="integer" label="30068">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="30430">0</option> <!-- DISABLED -->
+              <option label="30076">1</option> <!-- AS_FIRST_GROUP -->
+              <option label="30077">2</option> <!-- AS_LAST_GROUP -->
+            </options>
+          </constraints>
+          <dependencies>
+            <dependency type="visible">
+              <or>
+                <condition setting="tvgroupmode" operator="is">0</condition>
+                <condition setting="tvgroupmode" operator="is">1</condition>
+              </or>
+            </dependency>
+          </dependencies>
+          <control type="spinner" format="integer" />
+        </setting>        
+      </group>
+      <group id="3" label="30057">
+        <setting id="radiogroupmode" type="integer" label="30058">
+          <level>0</level>
+          <default>2</default>
+          <constraints>
+            <options>
+              <option label="30074">0</option> <!-- ALL_GROUPS -->
+              <option label="30075">1</option> <!-- ONLY_ONE_GROUP -->
+              <option label="30078">2</option> <!-- FAVOURITES_GROUP -->
+            </options>
+          </constraints>
+          <control type="spinner" format="integer" />
+        </setting>        
+        <setting id="oneradiogroup" type="string" parent="radiogroupmode" label="30059">
+          <level>0</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <dependencies>
+            <dependency type="visible" setting="radiogroupmode" operator="is">1</dependency>
+          </dependencies>
+          <control type="edit" format="string" />
+        </setting>
+        <setting id="radiofavouritesmode" type="integer" label="30069">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="30430">0</option> <!-- DISABLED -->
+              <option label="30076">1</option> <!-- AS_FIRST_GROUP -->
+              <option label="30077">2</option> <!-- AS_LAST_GROUP -->
+            </options>
+          </constraints>
+          <dependencies>
+            <dependency type="visible">
+              <or>
+                <condition setting="radiogroupmode" operator="is">0</condition>
+                <condition setting="radiogroupmode" operator="is">1</condition>
+              </or>
+            </dependency>
+          </dependencies>
+          <control type="spinner" format="integer" />
+        </setting>        
+      </group>      
     </category>
 
     <!-- EPG -->

--- a/pvr.vuplus/resources/settings.xml
+++ b/pvr.vuplus/resources/settings.xml
@@ -445,5 +445,67 @@
         </setting>
       </group>
     </category>
+
+    <!-- Backend -->
+    <!-- Add again one new addon API is supported -->
+    <!--
+    <category id="backend" label="30086">      
+      <group id="1" label="30090"> 
+        <setting id="webifversion" type="string" label="30091">
+          <level>0</level>
+          <default>N/A</default>
+          <dependencies>
+            <dependency type="enable" setting="timeshiftbufferpath" operator="is">AnyTextThatDoesNotMatch</dependency>
+          </dependencies>
+          <control type="edit" format="string" />
+        </setting>
+        <setting id="autotimertagintags" type="string" label="30092">
+          <level>0</level>
+          <default>N/A</default>
+          <dependencies>
+            <dependency type="enable" setting="timeshiftbufferpath" operator="is">AnyTextThatDoesNotMatch</dependency>
+          </dependencies>
+          <control type="edit" format="string" />
+        </setting>
+        <setting id="autotimernameintags" type="string" label="30093">
+          <level>0</level>
+          <default>N/A</default>
+          <dependencies>
+            <dependency type="enable" setting="timeshiftbufferpath" operator="is">AnyTextThatDoesNotMatch</dependency>
+          </dependencies>
+          <control type="edit" format="string" />
+        </setting>
+      </group>
+
+      <group id="2" label="30087">   
+        <setting id="globalstartpaddingstb" type="integer" label="30088">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>120</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>true</popup>
+            <formatlabel>14044</formatlabel>
+          </control>
+        </setting>
+        <setting id="globalendpaddingstb" type="integer" label="30089">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>120</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>true</popup>
+            <formatlabel>14044</formatlabel>
+          </control>
+        </setting>
+      </group>   
+    </category>            
+    -->
   </section>
 </settings>

--- a/pvr.vuplus/resources/settings.xml
+++ b/pvr.vuplus/resources/settings.xml
@@ -412,10 +412,18 @@
           </constraints>
           <control type="list" format="integer" />
         </setting>
-        <setting id="setpowerstate" type="boolean" label="30024">
+        <setting id="powerstatemode" type="integer" label="30024">
           <level>0</level>
-          <default>false</default>
-          <control type="toggle" />
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="30430">0</option> <!-- DISABLED -->
+              <option label="30097">1</option> <!-- STANDBY -->
+              <option label="30098">2</option> <!-- DEEP_STANDBY -->
+              <option label="30099">3</option> <!-- WAKEUP_THEN_STANDBY -->
+            </options>
+          </constraints>
+          <control type="list" format="integer" />
         </setting>
         <setting id="readtimeout" type="integer" label="30050">
           <level>0</level>

--- a/pvr.vuplus/resources/settings.xml
+++ b/pvr.vuplus/resources/settings.xml
@@ -123,13 +123,24 @@
           <constraints>
             <minimum>1</minimum>
             <step>1</step>
-            <maximum>60</maximum>
+            <maximum>1440</maximum>
           </constraints>
           <control type="slider" format="integer">
             <popup>true</popup>
             <formatlabel>14044</formatlabel>
           </control>
         </setting>      
+        <setting id="updatemode" type="integer" label="30100">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="30101">0</option> <!-- TIMERS_AND_RECORDINGS -->
+              <option label="30102">1</option> <!-- TIMERS_ONLY -->
+            </options>
+          </constraints>
+          <control type="list" format="integer" />
+        </setting>
       </group>
     </category>
 

--- a/src/Enigma2.cpp
+++ b/src/Enigma2.cpp
@@ -95,13 +95,15 @@ bool Enigma2::Open()
       return false;
     }
   } 
-  m_isConnected = m_admin.LoadDeviceInfo();
+  m_isConnected = m_admin.Initialise();
 
   if (!m_isConnected)
   {
     Logger::Log(LEVEL_ERROR, "%s It seem's that the webinterface cannot be reached. Make sure that you set the correct configuration options in the addon settings!", __FUNCTION__);
     return false;
   }
+
+  m_settings.ReadFromAddon();
 
   m_recordings.ClearLocations();
   m_recordings.LoadLocations();

--- a/src/Enigma2.cpp
+++ b/src/Enigma2.cpp
@@ -205,12 +205,12 @@ unsigned int Enigma2::GetNumChannelGroups() const
   return m_channelGroups.GetNumChannelGroups();
 }
 
-PVR_ERROR Enigma2::GetChannelGroups(ADDON_HANDLE handle)
+PVR_ERROR Enigma2::GetChannelGroups(ADDON_HANDLE handle, bool radio)
 {
   std::vector<PVR_CHANNEL_GROUP> channelGroups;
   {
     CLockObject lock(m_mutex);
-    m_channelGroups.GetChannelGroups(channelGroups);
+    m_channelGroups.GetChannelGroups(channelGroups, radio);
   }
 
   Logger::Log(LEVEL_DEBUG, "%s - channel groups available '%d'", __FUNCTION__, channelGroups.size());

--- a/src/Enigma2.cpp
+++ b/src/Enigma2.cpp
@@ -223,25 +223,17 @@ PVR_ERROR Enigma2::GetChannelGroups(ADDON_HANDLE handle)
 
 PVR_ERROR Enigma2::GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &group)
 {
-  Logger::Log(LEVEL_DEBUG, "%s - group '%s'", __FUNCTION__, group.strGroupName);
-  std::string strTmp = group.strGroupName;
-  for (const auto& channel : m_channels.GetChannelsList())
+  std::vector<PVR_CHANNEL_GROUP_MEMBER> channelGroupMembers;
   {
-    if (strTmp == channel.GetGroupName()) 
-    {
-      PVR_CHANNEL_GROUP_MEMBER tag;
-      memset(&tag,0 , sizeof(PVR_CHANNEL_GROUP_MEMBER));
-
-      strncpy(tag.strGroupName, group.strGroupName, sizeof(tag.strGroupName));
-      tag.iChannelUniqueId = channel.GetUniqueId();
-      tag.iChannelNumber   = channel.GetChannelNumber();
-
-      Logger::Log(LEVEL_DEBUG, "%s - add channel %s (%d) to group '%s' channel number %d",
-          __FUNCTION__, channel.GetChannelName().c_str(), tag.iChannelUniqueId, group.strGroupName, channel.GetChannelNumber());
-
-      PVR->TransferChannelGroupMember(handle, &tag);
-    }
+    CLockObject lock(m_mutex);
+    m_channelGroups.GetChannelGroupMembers(channelGroupMembers, group.strGroupName);
   }
+
+  Logger::Log(LEVEL_DEBUG, "%s - group '%s' members available '%d'", __FUNCTION__, group.strGroupName, channelGroupMembers.size());
+
+  for (const auto& channelGroupMember : channelGroupMembers)
+      PVR->TransferChannelGroupMember(handle, &channelGroupMember);
+
   return PVR_ERROR_NO_ERROR;
 }
 
@@ -295,7 +287,7 @@ bool Enigma2::OpenLiveStream(const PVR_CHANNEL &channelinfo)
     if (m_settings.GetZapBeforeChannelSwitch())
     {
       // Zapping is set to true, so send the zapping command to the PVR box
-      std::string strServiceReference = m_channels.GetChannel(channelinfo.iUniqueId).GetServiceReference().c_str();
+      std::string strServiceReference = m_channels.GetChannel(channelinfo.iUniqueId)->GetServiceReference().c_str();
 
       std::string strTmp;
       strTmp = StringUtils::Format("web/zap?sRef=%s", WebUtils::URLEncodeInline(strServiceReference).c_str());
@@ -322,10 +314,10 @@ const std::string Enigma2::GetLiveStreamURL(const PVR_CHANNEL &channelinfo)
     // we do it here for 2 reasons:
     //  1. This is faster than doing it during initialization
     //  2. The URL can change, so this is more up-to-date.
-    return GetStreamURL(m_channels.GetChannel(channelinfo.iUniqueId).GetM3uURL());
+    return GetStreamURL(m_channels.GetChannel(channelinfo.iUniqueId)->GetM3uURL());
   }
 
-  return m_channels.GetChannel(channelinfo.iUniqueId).GetStreamURL();
+  return m_channels.GetChannel(channelinfo.iUniqueId)->GetStreamURL();
 }
 
 

--- a/src/Enigma2.h
+++ b/src/Enigma2.h
@@ -58,8 +58,8 @@ public:
   
   //groups, channels and EPG
   unsigned int GetNumChannelGroups(void) const;
-  PVR_ERROR    GetChannelGroups(ADDON_HANDLE handle, bool radio);
-  PVR_ERROR    GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &group);
+  PVR_ERROR GetChannelGroups(ADDON_HANDLE handle, bool radio);
+  PVR_ERROR GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &group);
   int GetChannelsAmount(void) const;
   PVR_ERROR GetChannels(ADDON_HANDLE handle, bool bRadio);
   PVR_ERROR GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL &channel, time_t iStart, time_t iEnd);
@@ -69,8 +69,8 @@ public:
   void CloseLiveStream();
   const std::string GetLiveStreamURL(const PVR_CHANNEL &channelinfo);
   unsigned int GetRecordingsAmount();
-  PVR_ERROR    GetRecordings(ADDON_HANDLE handle);
-  PVR_ERROR    DeleteRecording(const PVR_RECORDING &recinfo);
+  PVR_ERROR GetRecordings(ADDON_HANDLE handle);
+  PVR_ERROR DeleteRecording(const PVR_RECORDING &recinfo);
   bool GetRecordingsFromLocation(std::string strRecordingFolder);
   enigma2::RecordingReader *OpenRecordedStream(const PVR_RECORDING &recinfo);
   void GetTimerTypes(PVR_TIMER_TYPE types[], int *size);

--- a/src/Enigma2.h
+++ b/src/Enigma2.h
@@ -21,6 +21,9 @@
  *
  */
 
+#include <atomic>
+#include <time.h>
+
 #include "client.h"
 #include "enigma2/Admin.h"
 #include "enigma2/Channels.h"
@@ -88,7 +91,9 @@ private:
   // members
   bool m_isConnected = false;
   unsigned int m_updateTimer = 0;
+  time_t m_lastUpdateTimeSeconds;
   int m_currentChannel = -1;
+  std::atomic_bool m_dueRecordingUpdate{true};
 
   enigma2::Channels m_channels;
   enigma2::ChannelGroups m_channelGroups;

--- a/src/Enigma2.h
+++ b/src/Enigma2.h
@@ -55,7 +55,7 @@ public:
   
   //groups, channels and EPG
   unsigned int GetNumChannelGroups(void) const;
-  PVR_ERROR    GetChannelGroups(ADDON_HANDLE handle);
+  PVR_ERROR    GetChannelGroups(ADDON_HANDLE handle, bool radio);
   PVR_ERROR    GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &group);
   int GetChannelsAmount(void) const;
   PVR_ERROR GetChannels(ADDON_HANDLE handle, bool bRadio);

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -211,13 +211,13 @@ PVR_ERROR GetAddonCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities)
 
 const char *GetBackendName(void)
 {
-  static const char *backendName = enigma ? enigma->GetServerName() : "unknown";
+  static const char *backendName = enigma ? enigma->GetServerName() : LocalizedString(60081).c_str(); //unknown
   return backendName;
 }
 
 const char *GetBackendVersion(void)
 {
-  static const char *backendVersion = enigma ? enigma->GetServerVersion() : "unknown";
+  static const char *backendVersion = enigma ? enigma->GetServerVersion() : LocalizedString(60081).c_str(); //unknown
   return backendVersion;
 }
 
@@ -226,9 +226,9 @@ static std::string connectionString;
 const char *GetConnectionString(void)
 {
   if (enigma)
-    connectionString = StringUtils::Format("%s%s", settings.GetHostname().c_str(), enigma->IsConnected() ? "" : " (Not connected!)");
+    connectionString = StringUtils::Format("%s%s", settings.GetHostname().c_str(), enigma->IsConnected() ? "" : LocalizedString(60082).c_str()); // (Not connected!)
   else
-    connectionString = StringUtils::Format("%s (addon error!)", settings.GetHostname().c_str());
+    connectionString = StringUtils::Format("%s (%s!)", settings.GetHostname().c_str(), LocalizedString(60083).c_str()); //addon error
   return connectionString.c_str();
 }
 
@@ -247,8 +247,8 @@ PVR_ERROR SignalStatus(PVR_SIGNAL_STATUS &signalStatus)
 {
   // the RS api doesn't provide information about signal quality (yet)
 
-  PVR_STRCPY(signalStatus.strAdapterName, "Enigma2 Media Server");
-  PVR_STRCPY(signalStatus.strAdapterStatus, "OK");
+  PVR_STRCPY(signalStatus.strAdapterName, LocalizedString(60084).c_str()); //Enigma2 Media Server
+  PVR_STRCPY(signalStatus.strAdapterStatus, LocalizedString(60085).c_str()); //OK
   return PVR_ERROR_NO_ERROR;
 }
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -114,7 +114,7 @@ ADDON_STATUS ADDON_Create(void* hdl, void* props)
 
   Logger::GetInstance().SetPrefix("pvr.vuplus");
 
-  Logger::Log(LogLevel::LEVEL_INFO, "starting PVR client XXX");  
+  Logger::Log(LogLevel::LEVEL_INFO, "%s starting PVR client...", __FUNCTION__);  
 
   settings.ReadFromAddon();
 
@@ -267,20 +267,14 @@ int GetChannelGroupsAmount(void)
 
 PVR_ERROR GetChannelGroups(ADDON_HANDLE handle, bool bRadio)
 {
-  if (bRadio)
-    return PVR_ERROR_NO_ERROR;
-
   if (!enigma || !enigma->IsConnected())
     return PVR_ERROR_SERVER_ERROR;
 
-  return enigma->GetChannelGroups(handle);
+  return enigma->GetChannelGroups(handle, bRadio);
 }
 
 PVR_ERROR GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &group)
 {
-  if (group.bIsRadio)
-    return PVR_ERROR_NO_ERROR;
-
   if (!enigma || !enigma->IsConnected())
     return PVR_ERROR_SERVER_ERROR;
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -41,16 +41,16 @@ using namespace enigma2;
 using namespace enigma2::data;
 using namespace enigma2::utilities;
 
-bool            m_created  = false;
-ADDON_STATUS    m_currentStatus = ADDON_STATUS_UNKNOWN;
-IStreamReader   *streamReader  = nullptr;
-int             m_streamReadChunkSize = 64;
-RecordingReader *recordingReader  = nullptr;
-Settings        &settings = Settings::GetInstance();
+bool m_created = false;
+ADDON_STATUS m_currentStatus = ADDON_STATUS_UNKNOWN;
+IStreamReader *streamReader = nullptr;
+int m_streamReadChunkSize = 64;
+RecordingReader *recordingReader = nullptr;
+Settings &settings = Settings::GetInstance();
 
-CHelper_libXBMC_addon *XBMC           = nullptr;
-CHelper_libXBMC_pvr   *PVR            = nullptr;
-Enigma2               *enigma         = nullptr;
+CHelper_libXBMC_addon *XBMC = nullptr;
+CHelper_libXBMC_pvr *PVR = nullptr;
+Enigma2 *enigma = nullptr;
 
 extern "C" {
 

--- a/src/enigma2/Admin.cpp
+++ b/src/enigma2/Admin.cpp
@@ -19,13 +19,32 @@ using namespace enigma2::utilities;
 
 void Admin::SendPowerstate()
 {
-  if (Settings::GetInstance().GetDeepStandbyOnAddonExit())
+  if (Settings::GetInstance().GetPowerstateModeOnAddonExit() != PowerstateMode::DISABLED)
   {  
-    std::string strTmp;
-    strTmp = StringUtils::Format("web/powerstate?newstate=1");
+    if (Settings::GetInstance().GetPowerstateModeOnAddonExit() == PowerstateMode::WAKEUP_THEN_STANDBY)
+    {
+      std::string strTmp = StringUtils::Format("web/powerstate?newstate=4"); //Wakeup
 
-    std::string strResult;
-    WebUtils::SendSimpleCommand(strTmp, strResult, true); 
+      std::string strResult;
+      WebUtils::SendSimpleCommand(strTmp, strResult, true);
+    }
+
+    if (Settings::GetInstance().GetPowerstateModeOnAddonExit() == PowerstateMode::STANDBY ||
+      Settings::GetInstance().GetPowerstateModeOnAddonExit() == PowerstateMode::WAKEUP_THEN_STANDBY)
+    {
+      std::string strTmp = StringUtils::Format("web/powerstate?newstate=5"); //Standby
+
+      std::string strResult;
+      WebUtils::SendSimpleCommand(strTmp, strResult, true);
+    }    
+
+    if (Settings::GetInstance().GetPowerstateModeOnAddonExit() == PowerstateMode::DEEP_STANDBY)
+    {
+      std::string strTmp = StringUtils::Format("web/powerstate?newstate=1"); //Deep Standby
+
+      std::string strResult;
+      WebUtils::SendSimpleCommand(strTmp, strResult, true); 
+    }
   }
 }
 

--- a/src/enigma2/Admin.cpp
+++ b/src/enigma2/Admin.cpp
@@ -223,7 +223,7 @@ long long Admin::GetKbFromString(const std::string &stringInMbGbTb) const
   long long sizeInKb = 0;
 
   static const std::vector<std::string> sizes = {"MB", "GB", "TB"};
-  long multiplier = 1024 * 1024;
+  long multiplier = 1024;
   std::string replaceWith = "";
   for (const std::string& size : sizes)
   {

--- a/src/enigma2/Admin.h
+++ b/src/enigma2/Admin.h
@@ -25,16 +25,22 @@
 #include <vector>
 
 #include "utilities/DeviceInfo.h"
+#include "utilities/DeviceSettings.h"
 
 #include "libXBMC_pvr.h"
 
 namespace enigma2
 {
+
   class Admin
   {
   public:
     void SendPowerstate();
-    bool LoadDeviceInfo();
+    bool Initialise();
+    bool LoadDeviceSettings();
+    bool SendAutoTimerSettings();
+    bool SendGlobalRecordingStartMarginSetting(int newValue);
+    bool SendGlobalRecordingEndMarginSetting(int newValue);
     const utilities::DeviceInfo& GetDeviceInfo() const { return m_deviceInfo; }
     PVR_ERROR GetDriveSpace(long long *iTotal, long long *iUsed, std::vector<std::string> &locations);
     const std::string& GetServerName() const { return m_deviceInfo.GetServerName(); }
@@ -44,9 +50,13 @@ namespace enigma2
     unsigned int GetWebIfVersionAsNum() const { return m_deviceInfo.GetWebIfVersionAsNum(); }
 
   private:   
+    bool LoadDeviceInfo();
+    bool LoadAutoTimerSettings();
+    bool LoadRecordingMarginSettings();
     unsigned int ParseWebIfVersion(const std::string &webIfVersion);
     long long GetKbFromString(const std::string &stringInMbGbTb) const;
 
     enigma2::utilities::DeviceInfo m_deviceInfo;
+    enigma2::utilities::DeviceSettings m_deviceSettings;
   };
 } //namespace enigma2

--- a/src/enigma2/ChannelGroups.cpp
+++ b/src/enigma2/ChannelGroups.cpp
@@ -4,6 +4,7 @@
 
 #include "../client.h"
 #include "../Enigma2.h"
+#include "utilities/LocalizedString.h"
 #include "utilities/Logger.h"
 #include "utilities/WebUtils.h"
 
@@ -14,18 +15,21 @@ using namespace enigma2;
 using namespace enigma2::data;
 using namespace enigma2::utilities;
 
-void ChannelGroups::GetChannelGroups(std::vector<PVR_CHANNEL_GROUP> &kodiChannelGroups) const
+void ChannelGroups::GetChannelGroups(std::vector<PVR_CHANNEL_GROUP> &kodiChannelGroups, bool radio) const
 {
   for (const auto& channelGroup : m_channelGroups)
   {
     Logger::Log(LEVEL_DEBUG, "%s - Transfer channelGroup '%s', ChannelGroupIndex '%d'", __FUNCTION__, channelGroup->GetGroupName().c_str(), channelGroup->GetUniqueId());
 
-    PVR_CHANNEL_GROUP kodiChannelGroup;
-    memset(&kodiChannelGroup, 0 , sizeof(PVR_CHANNEL_GROUP));
+    if (channelGroup->IsRadio() == radio)
+    {
+      PVR_CHANNEL_GROUP kodiChannelGroup;
+      memset(&kodiChannelGroup, 0 , sizeof(PVR_CHANNEL_GROUP));
 
-    channelGroup->UpdateTo(kodiChannelGroup);
+      channelGroup->UpdateTo(kodiChannelGroup);
 
-    kodiChannelGroups.emplace_back(kodiChannelGroup);
+      kodiChannelGroups.emplace_back(kodiChannelGroup);
+    }
   }
 }
 
@@ -134,63 +138,168 @@ std::vector<std::shared_ptr<ChannelGroup>>& ChannelGroups::GetChannelGroupsList(
 
 bool ChannelGroups::LoadChannelGroups()
 {
-  std::string strTmp; 
-
-  strTmp = StringUtils::Format("%sweb/getservices", Settings::GetInstance().GetConnectionURL().c_str());
-
-  std::string strXML = WebUtils::GetHttpXML(strTmp);  
-
-  TiXmlDocument xmlDoc;
-  if (!xmlDoc.Parse(strXML.c_str()))
-  {
-    Logger::Log(LEVEL_DEBUG, "Unable to parse XML: %s at line %d", xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
-    return false;
-  }
-
-  TiXmlHandle hDoc(&xmlDoc);
-  TiXmlElement* pElem;
-  TiXmlHandle hRoot(0);
-
-  pElem = hDoc.FirstChildElement("e2servicelist").Element();
-
-  if (!pElem)
-  {
-    Logger::Log(LEVEL_DEBUG, "%s Could not find <e2servicelist> element!", __FUNCTION__);
-    return false;
-  }
-
-  hRoot=TiXmlHandle(pElem);
-
-  TiXmlElement* pNode = hRoot.FirstChildElement("e2service").Element();
-
-  if (!pNode)
-  {
-    Logger::Log(LEVEL_DEBUG, "%s Could not find <e2service> element", __FUNCTION__);
-    return false;
-  }
-
   m_channelGroups.clear();
 
-  for (; pNode != nullptr; pNode = pNode->NextSiblingElement("e2service"))
+  bool successful = LoadTVChannelGroups();
+
+  if (successful)
+    LoadRadioChannelGroups();
+
+  return successful;
+}
+
+bool ChannelGroups::LoadTVChannelGroups()
+{
+  if ((Settings::GetInstance().GetTVFavouritesMode() == FavouritesGroupMode::AS_FIRST_GROUP &&
+      Settings::GetInstance().GetTVChannelGroupMode() != ChannelGroupMode::FAVOURITES_GROUP) ||
+      Settings::GetInstance().GetTVChannelGroupMode() == ChannelGroupMode::FAVOURITES_GROUP)
   {
-    ChannelGroup newChannelGroup;
-
-    if (!newChannelGroup.UpdateFrom(pNode, false))
-      continue;
- 
-    AddChannelGroup(newChannelGroup);
-
-    Logger::Log(LEVEL_INFO, "%s Loaded channelgroup: %s", __FUNCTION__, newChannelGroup.GetGroupName().c_str());
+    AddTVFavouritesChannelGroup();
   }
 
-  //Now add a radio channel group
+  if (Settings::GetInstance().GetTVChannelGroupMode() != ChannelGroupMode::FAVOURITES_GROUP)
+  {  
+    std::string strTmp; 
+
+    strTmp = StringUtils::Format("%sweb/getservices", Settings::GetInstance().GetConnectionURL().c_str());
+
+    std::string strXML = WebUtils::GetHttpXML(strTmp);  
+
+    TiXmlDocument xmlDoc;
+    if (!xmlDoc.Parse(strXML.c_str()))
+    {
+      Logger::Log(LEVEL_DEBUG, "Unable to parse XML: %s at line %d", xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
+      return false;
+    }
+
+    TiXmlHandle hDoc(&xmlDoc);
+    TiXmlElement* pElem;
+    TiXmlHandle hRoot(0);
+
+    pElem = hDoc.FirstChildElement("e2servicelist").Element();
+
+    if (!pElem)
+    {
+      Logger::Log(LEVEL_DEBUG, "%s Could not find <e2servicelist> element!", __FUNCTION__);
+      return false;
+    }
+
+    hRoot=TiXmlHandle(pElem);
+
+    TiXmlElement* pNode = hRoot.FirstChildElement("e2service").Element();
+
+    if (!pNode)
+    {
+      Logger::Log(LEVEL_DEBUG, "%s Could not find <e2service> element", __FUNCTION__);
+      return false;
+    }
+
+    for (; pNode != nullptr; pNode = pNode->NextSiblingElement("e2service"))
+    {
+      ChannelGroup newChannelGroup;
+
+      if (!newChannelGroup.UpdateFrom(pNode, false))
+        continue;
+  
+      AddChannelGroup(newChannelGroup);
+
+      Logger::Log(LEVEL_INFO, "%s Loaded channelgroup: %s", __FUNCTION__, newChannelGroup.GetGroupName().c_str());
+    }
+  }
+
+  if (Settings::GetInstance().GetTVFavouritesMode() == FavouritesGroupMode::AS_LAST_GROUP &&
+      Settings::GetInstance().GetTVChannelGroupMode() != ChannelGroupMode::FAVOURITES_GROUP)
+  {
+    AddTVFavouritesChannelGroup();
+  }
+
+  Logger::Log(LEVEL_INFO, "%s Loaded %d TV Channelgroups", __FUNCTION__, m_channelGroups.size());
+  return true;
+}
+
+bool ChannelGroups::LoadRadioChannelGroups()
+{
+  if ((Settings::GetInstance().GetRadioFavouritesMode() == FavouritesGroupMode::AS_FIRST_GROUP &&
+      Settings::GetInstance().GetRadioChannelGroupMode() != ChannelGroupMode::FAVOURITES_GROUP) ||
+      Settings::GetInstance().GetRadioChannelGroupMode() == ChannelGroupMode::FAVOURITES_GROUP)
+  {
+    AddRadioFavouritesChannelGroup();
+  }
+
+  if (Settings::GetInstance().GetRadioChannelGroupMode() != ChannelGroupMode::FAVOURITES_GROUP)
+  {  
+    std::string strTmp = StringUtils::Format("%sweb/getallservices?type=radio&renameserviceforxbmc=yes", Settings::GetInstance().GetConnectionURL().c_str());
+
+    std::string strXML = WebUtils::GetHttpXML(strTmp);  
+
+    TiXmlDocument xmlDoc;
+    if (!xmlDoc.Parse(strXML.c_str()))
+    {
+      Logger::Log(LEVEL_DEBUG, "Unable to parse XML: %s at line %d", xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
+      return false;
+    }
+
+    TiXmlHandle hDoc(&xmlDoc);
+    TiXmlElement* pElem;
+    TiXmlHandle hRoot(0);
+
+    pElem = hDoc.FirstChildElement("e2servicelistrecursive").Element();
+
+    if (!pElem)
+    {
+      Logger::Log(LEVEL_DEBUG, "%s Could not find <e2servicelistrecursive> element!", __FUNCTION__);
+      return false;
+    }
+
+    hRoot=TiXmlHandle(pElem);
+
+    TiXmlElement* pNode = hRoot.FirstChildElement("e2bouquet").Element();
+
+    if (!pNode)
+    {
+      Logger::Log(LEVEL_DEBUG, "%s Could not find <e2bouquet> element", __FUNCTION__);
+      return false;
+    }
+
+    for (; pNode != nullptr; pNode = pNode->NextSiblingElement("e2bouquet"))
+    {
+      ChannelGroup newChannelGroup;
+
+      if (!newChannelGroup.UpdateFrom(pNode, true))
+        continue;
+  
+      AddChannelGroup(newChannelGroup);
+
+      Logger::Log(LEVEL_INFO, "%s Loaded channelgroup: %s", __FUNCTION__, newChannelGroup.GetGroupName().c_str());
+    }
+  }
+
+  if (Settings::GetInstance().GetRadioFavouritesMode() == FavouritesGroupMode::AS_LAST_GROUP &&
+      Settings::GetInstance().GetRadioChannelGroupMode() != ChannelGroupMode::FAVOURITES_GROUP)
+  {
+    AddRadioFavouritesChannelGroup();
+  }
+
+  Logger::Log(LEVEL_INFO, "%s Loaded %d Radio Channelgroups", __FUNCTION__, m_channelGroups.size());
+  return true;
+}
+
+void ChannelGroups::AddTVFavouritesChannelGroup()
+{
+  ChannelGroup newChannelGroup;
+  newChannelGroup.SetRadio(false);
+  newChannelGroup.SetGroupName(LocalizedString(30079)); //Favourites (TV)
+  newChannelGroup.SetServiceReference("1:7:1:0:0:0:0:0:0:0:FROM BOUQUET \"userbouquet.favourites.tv\" ORDER BY bouquet");
+  AddChannelGroup(newChannelGroup);
+  Logger::Log(LEVEL_INFO, "%s Loaded channelgroup: %s", __FUNCTION__, newChannelGroup.GetGroupName().c_str());  
+}
+
+void ChannelGroups::AddRadioFavouritesChannelGroup()
+{
   ChannelGroup newChannelGroup;
   newChannelGroup.SetRadio(true);
-  newChannelGroup.SetGroupName("Radio");
+  newChannelGroup.SetGroupName(LocalizedString(30080)); //Favourites (Radio)
   newChannelGroup.SetServiceReference("1:7:1:0:0:0:0:0:0:0:FROM BOUQUET \"userbouquet.favourites.radio\" ORDER BY bouquet");
   AddChannelGroup(newChannelGroup);
   Logger::Log(LEVEL_INFO, "%s Loaded channelgroup: %s", __FUNCTION__, newChannelGroup.GetGroupName().c_str());  
-
-  Logger::Log(LEVEL_INFO, "%s Loaded %d Channelgroups", __FUNCTION__, m_channelGroups.size());
-  return true;
 }

--- a/src/enigma2/ChannelGroups.cpp
+++ b/src/enigma2/ChannelGroups.cpp
@@ -18,22 +18,48 @@ void ChannelGroups::GetChannelGroups(std::vector<PVR_CHANNEL_GROUP> &kodiChannel
 {
   for (const auto& channelGroup : m_channelGroups)
   {
-    Logger::Log(LEVEL_DEBUG, "%s - Transfer channelGroup '%s', ChannelGroupIndex '%d'", __FUNCTION__, channelGroup.GetGroupName().c_str(), channelGroup.GetUniqueId());
+    Logger::Log(LEVEL_DEBUG, "%s - Transfer channelGroup '%s', ChannelGroupIndex '%d'", __FUNCTION__, channelGroup->GetGroupName().c_str(), channelGroup->GetUniqueId());
+
     PVR_CHANNEL_GROUP kodiChannelGroup;
     memset(&kodiChannelGroup, 0 , sizeof(PVR_CHANNEL_GROUP));
 
-    channelGroup.UpdateTo(kodiChannelGroup);
+    channelGroup->UpdateTo(kodiChannelGroup);
 
     kodiChannelGroups.emplace_back(kodiChannelGroup);
   }
+}
+
+PVR_ERROR ChannelGroups::GetChannelGroupMembers(std::vector<PVR_CHANNEL_GROUP_MEMBER> &channelGroupMembers, const std::string &groupName)
+{
+  std::shared_ptr<ChannelGroup> channelGroup = GetChannelGroup(groupName);
+
+  if (!channelGroup)
+    return PVR_ERROR_NO_ERROR;
+
+  for (const auto& channel : channelGroup->GetChannelList())
+  {
+    PVR_CHANNEL_GROUP_MEMBER tag;
+    memset(&tag,0 , sizeof(PVR_CHANNEL_GROUP_MEMBER));
+
+    strncpy(tag.strGroupName, groupName.c_str(), sizeof(tag.strGroupName));
+    tag.iChannelUniqueId = channel->GetUniqueId();
+    tag.iChannelNumber   = channel->GetChannelNumber();
+
+    Logger::Log(LEVEL_DEBUG, "%s - add channel %s (%d) to group '%s' channel number %d",
+        __FUNCTION__, channel->GetChannelName().c_str(), tag.iChannelUniqueId, groupName.c_str(), channel->GetChannelNumber());
+
+    channelGroupMembers.emplace_back(tag);
+  }
+
+  return PVR_ERROR_NO_ERROR;
 }
 
 int ChannelGroups::GetChannelGroupUniqueId(const std::string &groupName) const
 {
   for (const auto& channelGroup : m_channelGroups)
   {
-    if (groupName == channelGroup.GetGroupName())
-      return channelGroup.GetUniqueId();
+    if (groupName == channelGroup->GetGroupName())
+      return channelGroup->GetUniqueId();
   }
   return -1;
 }
@@ -42,20 +68,38 @@ std::string ChannelGroups::GetChannelGroupServiceReference(const std::string &gr
 {
   for (const auto& channelGroup : m_channelGroups)
   {
-    if (groupName == channelGroup.GetGroupName())
-      return channelGroup.GetServiceReference();
+    if (groupName == channelGroup->GetGroupName())
+      return channelGroup->GetServiceReference();
   }
   return "error";
 }
 
-enigma2::data::ChannelGroup& ChannelGroups::GetChannelGroup(int uniqueId)
+std::shared_ptr<ChannelGroup> ChannelGroups::GetChannelGroup(int uniqueId)
 {
   return m_channelGroups.at(uniqueId - 1);
+}
+
+std::shared_ptr<ChannelGroup> ChannelGroups::GetChannelGroup(std::string groupName)
+{
+  std::shared_ptr<ChannelGroup> channelGroup = nullptr;
+
+  auto channelGroupPair = m_channelGroupsNameMap.find(groupName);
+  if (channelGroupPair != m_channelGroupsNameMap.end()) 
+  {
+    channelGroup = channelGroupPair->second;
+  } 
+
+  return channelGroup;
 }
 
 bool ChannelGroups::IsValid(int uniqueId) const
 {
   return (uniqueId - 1) < m_channelGroups.size();
+}
+
+bool ChannelGroups::IsValid(std::string groupName)
+{
+  return GetChannelGroup(groupName) != nullptr;
 }
 
 int ChannelGroups::GetNumChannelGroups() const
@@ -70,12 +114,20 @@ void ChannelGroups::ClearChannelGroups()
 
 void ChannelGroups::AddChannelGroup(ChannelGroup& newChannelGroup)
 {
-  newChannelGroup.SetUniqueId(m_channelGroups.size() + 1);
+  std::shared_ptr<ChannelGroup> foundChannelGroup = GetChannelGroup(newChannelGroup.GetGroupName());
 
-  m_channelGroups.emplace_back(newChannelGroup);
+  if (!foundChannelGroup)
+  {  
+    newChannelGroup.SetUniqueId(m_channelGroups.size() + 1);
+
+    m_channelGroups.emplace_back(new ChannelGroup(newChannelGroup));
+
+    std::shared_ptr<ChannelGroup> channelGroup = m_channelGroups.back();
+    m_channelGroupsNameMap.insert({channelGroup->GetGroupName(), channelGroup});
+  }
 }
 
-std::vector<enigma2::data::ChannelGroup>& ChannelGroups::GetChannelGroupsList()
+std::vector<std::shared_ptr<ChannelGroup>>& ChannelGroups::GetChannelGroupsList()
 {
   return m_channelGroups;
 }
@@ -119,20 +171,25 @@ bool ChannelGroups::LoadChannelGroups()
 
   m_channelGroups.clear();
 
-  std::string serviceReference;
-  std::string groupName;
-
   for (; pNode != nullptr; pNode = pNode->NextSiblingElement("e2service"))
   {
     ChannelGroup newChannelGroup;
 
-    if (!newChannelGroup.UpdateFrom(pNode))
+    if (!newChannelGroup.UpdateFrom(pNode, false))
       continue;
  
     AddChannelGroup(newChannelGroup);
 
     Logger::Log(LEVEL_INFO, "%s Loaded channelgroup: %s", __FUNCTION__, newChannelGroup.GetGroupName().c_str());
   }
+
+  //Now add a radio channel group
+  ChannelGroup newChannelGroup;
+  newChannelGroup.SetRadio(true);
+  newChannelGroup.SetGroupName("Radio");
+  newChannelGroup.SetServiceReference("1:7:1:0:0:0:0:0:0:0:FROM BOUQUET \"userbouquet.favourites.radio\" ORDER BY bouquet");
+  AddChannelGroup(newChannelGroup);
+  Logger::Log(LEVEL_INFO, "%s Loaded channelgroup: %s", __FUNCTION__, newChannelGroup.GetGroupName().c_str());  
 
   Logger::Log(LEVEL_INFO, "%s Loaded %d Channelgroups", __FUNCTION__, m_channelGroups.size());
   return true;

--- a/src/enigma2/ChannelGroups.h
+++ b/src/enigma2/ChannelGroups.h
@@ -21,7 +21,9 @@
  *
  */
 
+#include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "data/Channel.h"
@@ -35,19 +37,23 @@ namespace enigma2
   {
   public:
     void GetChannelGroups(std::vector<PVR_CHANNEL_GROUP> &channelGroups) const;
+    PVR_ERROR GetChannelGroupMembers(std::vector<PVR_CHANNEL_GROUP_MEMBER> &channelGroupMembers, const std::string &groupName);
 
     int GetChannelGroupUniqueId(const std::string &groupName) const;
     std::string GetChannelGroupServiceReference(const std::string &groupName);
-    enigma2::data::ChannelGroup& GetChannelGroup(int uniqueId);
+    std::shared_ptr<enigma2::data::ChannelGroup> GetChannelGroup(int uniqueId);
+    std::shared_ptr<enigma2::data::ChannelGroup> GetChannelGroup(std::string groupName);
     bool IsValid(int uniqueId) const;
+    bool IsValid(std::string groupName);
     int GetNumChannelGroups() const;
     void ClearChannelGroups();
-    std::vector<enigma2::data::ChannelGroup>& GetChannelGroupsList();
+    std::vector<std::shared_ptr<enigma2::data::ChannelGroup>>& GetChannelGroupsList();
     bool LoadChannelGroups();
 
   private:   
     void AddChannelGroup(enigma2::data::ChannelGroup& channelGroup);
 
-    std::vector<enigma2::data::ChannelGroup> m_channelGroups;
+    std::vector<std::shared_ptr<enigma2::data::ChannelGroup>> m_channelGroups;
+    std::unordered_map<std::string, std::shared_ptr<enigma2::data::ChannelGroup>> m_channelGroupsNameMap;
   };
 } //namespace enigma2

--- a/src/enigma2/ChannelGroups.h
+++ b/src/enigma2/ChannelGroups.h
@@ -36,7 +36,7 @@ namespace enigma2
   class ChannelGroups
   {
   public:
-    void GetChannelGroups(std::vector<PVR_CHANNEL_GROUP> &channelGroups) const;
+    void GetChannelGroups(std::vector<PVR_CHANNEL_GROUP> &channelGroups, bool radio) const;
     PVR_ERROR GetChannelGroupMembers(std::vector<PVR_CHANNEL_GROUP_MEMBER> &channelGroupMembers, const std::string &groupName);
 
     int GetChannelGroupUniqueId(const std::string &groupName) const;
@@ -51,6 +51,10 @@ namespace enigma2
     bool LoadChannelGroups();
 
   private:   
+    bool LoadTVChannelGroups();
+    bool LoadRadioChannelGroups();
+    void AddTVFavouritesChannelGroup();
+    void AddRadioFavouritesChannelGroup();
     void AddChannelGroup(enigma2::data::ChannelGroup& channelGroup);
 
     std::vector<std::shared_ptr<enigma2::data::ChannelGroup>> m_channelGroups;

--- a/src/enigma2/Channels.h
+++ b/src/enigma2/Channels.h
@@ -21,7 +21,9 @@
  *
  */
 
+#include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "data/Channel.h"
@@ -32,25 +34,33 @@ namespace enigma2
 {
   class ChannelGroups;
 
+  namespace data
+  {
+    class ChannelGroup;
+  }
+
   class Channels
   {
   public:
     void GetChannels(std::vector<PVR_CHANNEL> &timers, bool bRadio) const;
 
-    int GetChannelUniqueId(const std::string strServiceReference) const;
-    enigma2::data::Channel& GetChannel(int uniqueId);
+    int GetChannelUniqueId(const std::string &channelServiceReference);
+    std::shared_ptr<enigma2::data::Channel> GetChannel(int uniqueId);
+    std::shared_ptr<enigma2::data::Channel> GetChannel(const std::string &channelServiceReference);
     bool IsValid(int uniqueId) const;
+    bool IsValid(const std::string &channelServiceReference);
     int GetNumChannels() const;
     void ClearChannels();
-    std::vector<enigma2::data::Channel>& GetChannelsList();
+    std::vector<std::shared_ptr<enigma2::data::Channel>>& GetChannelsList();
     bool CheckIfAllChannelsHaveInitialEPG() const;
     std::string GetChannelIconPath(std::string strChannelName);
     bool LoadChannels(enigma2::ChannelGroups &channelGroups);
 
   private:   
-    void AddChannel(enigma2::data::Channel& channel);
-    bool LoadChannels(std::string groupServiceReference, std::string groupName);
+    void AddChannel(enigma2::data::Channel &channel, std::shared_ptr<enigma2::data::ChannelGroup> &channelGroup);
+    bool LoadChannels(const std::string groupServiceReference, const std::string groupName, std::shared_ptr<enigma2::data::ChannelGroup> &channelGroup);
 
-    std::vector<enigma2::data::Channel> m_channels;
+    std::vector<std::shared_ptr<enigma2::data::Channel>> m_channels;
+    std::unordered_map<std::string, std::shared_ptr<enigma2::data::Channel>> m_channelsServiceReferenceMap;
   };
 } //namespace enigma2

--- a/src/enigma2/Epg.cpp
+++ b/src/enigma2/Epg.cpp
@@ -51,8 +51,8 @@ void Epg::TriggerEpgUpdatesForChannels()
 {
   for (auto& channel : m_channels.GetChannelsList())
   {
-    Logger::Log(LEVEL_DEBUG, "%s - Trigger EPG update for channel '%d'", __FUNCTION__, channel.GetUniqueId());
-    PVR->TriggerEpgUpdate(channel.GetUniqueId());
+    Logger::Log(LEVEL_DEBUG, "%s - Trigger EPG update for channel '%d'", __FUNCTION__, channel->GetUniqueId());
+    PVR->TriggerEpgUpdate(channel->GetUniqueId());
   }  
 }
 
@@ -64,14 +64,14 @@ PVR_ERROR Epg::GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL &channel,
     return PVR_ERROR_NO_ERROR;
   }
 
-  Channel& myChannel = m_channels.GetChannel(channel.iUniqueId);
+  std::shared_ptr<Channel> myChannel = m_channels.GetChannel(channel.iUniqueId);
 
-  Logger::Log(LEVEL_DEBUG, "%s Getting EPG for channel '%s'", __FUNCTION__, myChannel.GetChannelName().c_str());
+  Logger::Log(LEVEL_DEBUG, "%s Getting EPG for channel '%s'", __FUNCTION__, myChannel->GetChannelName().c_str());
 
   // Check if the initial short import has already been done for this channel
-  if (myChannel.IsRequiresInitialEPG())
+  if (myChannel->RequiresInitialEPG())
   {
-    myChannel.SetRequiresInitialEPG(false);
+    myChannel->SetRequiresInitialEPG(false);
 
     if (!m_allChannelsHaveInitialEPG)
       m_allChannelsHaveInitialEPG = m_channels.CheckIfAllChannelsHaveInitialEPG();
@@ -88,7 +88,7 @@ PVR_ERROR Epg::GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL &channel,
   }
 
   const std::string url = StringUtils::Format("%s%s%s",  Settings::GetInstance().GetConnectionURL().c_str(), "web/epgservice?sRef=",  
-                                              WebUtils::URLEncodeInline(myChannel.GetServiceReference()).c_str());
+                                              WebUtils::URLEncodeInline(myChannel->GetServiceReference()).c_str());
  
   const std::string strXML = WebUtils::GetHttpXML(url);
 
@@ -151,10 +151,10 @@ PVR_ERROR Epg::GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL &channel,
   return PVR_ERROR_NO_ERROR;
 }
 
-bool Epg::GetInitialEPGForGroup(ChannelGroup &group)
+bool Epg::GetInitialEPGForGroup(std::shared_ptr<ChannelGroup> group)
 {
   const std::string url = StringUtils::Format("%s%s%s",  Settings::GetInstance().GetConnectionURL().c_str(), "web/epgnownext?bRef=",  
-                                                WebUtils::URLEncodeInline(group.GetServiceReference()).c_str());
+                                                WebUtils::URLEncodeInline(group->GetServiceReference()).c_str());
  
   const std::string strXML = WebUtils::GetHttpXML(url);
 
@@ -203,58 +203,54 @@ bool Epg::GetInitialEPGForGroup(ChannelGroup &group)
 
     iNumEPG++; 
     
-    group.GetInitialEPG().emplace_back(entry);
+    group->GetInitialEPG().emplace_back(entry);
   }
 
-  Logger::Log(LEVEL_INFO, "%s Loaded %u EPG Entries for group '%s'", __FUNCTION__, iNumEPG, group.GetGroupName().c_str());
+  Logger::Log(LEVEL_INFO, "%s Loaded %u EPG Entries for group '%s'", __FUNCTION__, iNumEPG, group->GetGroupName().c_str());
   return true;
 }
 
-PVR_ERROR Epg::GetInitialEPGForChannel(ADDON_HANDLE handle, const Channel &channel, time_t iStart, time_t iEnd)
+PVR_ERROR Epg::GetInitialEPGForChannel(ADDON_HANDLE handle, const std::shared_ptr<Channel> &channel, time_t iStart, time_t iEnd)
 {
   if (m_channelGroups.GetNumChannelGroups() < 1)
     return PVR_ERROR_SERVER_ERROR;
 
-  if (channel.IsRadio())
+  if (channel->IsRadio())
   {
-    Logger::Log(LEVEL_DEBUG, "%s Channel '%s' is a radio channel so no Initial EPG", __FUNCTION__, channel.GetChannelName().c_str());
+    Logger::Log(LEVEL_DEBUG, "%s Channel '%s' is a radio channel so no Initial EPG", __FUNCTION__, channel->GetChannelName().c_str());
     return PVR_ERROR_NO_ERROR;
   }
 
-  Logger::Log(LEVEL_DEBUG, "%s Checking for initialEPG for group '%s', num groups %d, channel %s", __FUNCTION__, channel.GetGroupName().c_str(), m_channelGroups.GetNumChannelGroups(), channel.GetChannelName().c_str());
-
-  bool retrievedInitialEPGForGroup = false;
-  ChannelGroup *myGroupPtr = nullptr;
-  for (auto& group : m_channelGroups.GetChannelGroupsList())
+  std::shared_ptr<ChannelGroup> myGroupPtr = nullptr;
+  for (auto& group : channel->GetChannelGroupList())
   {
-    Logger::Log(LEVEL_DEBUG, "%s Looking for channel %s group %s",  __FUNCTION__, channel.GetChannelName().c_str(), channel.GetGroupName().c_str());
-    if (group.GetGroupName() == channel.GetGroupName())
-    {
-      myGroupPtr = &group;
+    bool retrievedInitialEPGForGroup = false;
 
-      if (myGroupPtr->GetInitialEPG().size() == 0)
-      {
-        Logger::Log(LEVEL_DEBUG, "%s Fetching initialEPG for group '%s'", __FUNCTION__, channel.GetGroupName().c_str());
-        retrievedInitialEPGForGroup = GetInitialEPGForGroup(group);
-      }
-      break;
+    Logger::Log(LEVEL_DEBUG, "%s Checking for initialEPG for group '%s', num groups %d, channel %s", __FUNCTION__, group->GetGroupName().c_str(), m_channelGroups.GetNumChannelGroups(), channel->GetChannelName().c_str());
+
+    myGroupPtr = group;
+
+    if (group->GetInitialEPG().size() == 0)
+    {
+      Logger::Log(LEVEL_DEBUG, "%s Fetching initialEPG for group '%s'", __FUNCTION__, group->GetGroupName().c_str());
+      retrievedInitialEPGForGroup = GetInitialEPGForGroup(group);
     }
+
+    if (retrievedInitialEPGForGroup)
+      Logger::Log(LEVEL_DEBUG, "%s InitialEPG size for group '%s' is now '%d'", __FUNCTION__, group->GetGroupName().c_str(), myGroupPtr->GetInitialEPG().size());
+    else
+      Logger::Log(LEVEL_DEBUG, "%s Already have initialEPG for group '%s', it's size is '%d'", __FUNCTION__, group->GetGroupName().c_str(), myGroupPtr->GetInitialEPG().size());
   }
 
   if (!myGroupPtr)
   {
-    Logger::Log(LEVEL_DEBUG, "%s No group found for channel '%s' group '%s' sp no Initial EPG",  __FUNCTION__, channel.GetChannelName().c_str(), channel.GetGroupName().c_str());
+    Logger::Log(LEVEL_DEBUG, "%s No groups found for channel '%s' so no Initial EPG",  __FUNCTION__, channel->GetChannelName().c_str());
     return PVR_ERROR_NO_ERROR;
   }
 
-  if (retrievedInitialEPGForGroup)
-    Logger::Log(LEVEL_DEBUG, "%s InitialEPG size for group '%s' is now '%d'", __FUNCTION__, channel.GetGroupName().c_str(), myGroupPtr->GetInitialEPG().size());
-  else
-    Logger::Log(LEVEL_DEBUG, "%s Already have initialEPG for group '%s', it's size is '%d'", __FUNCTION__, channel.GetGroupName().c_str(), myGroupPtr->GetInitialEPG().size());
-
   for (const auto& entry : myGroupPtr->GetInitialEPG())
   {
-    if (channel.GetServiceReference() == entry.GetServiceReference()) 
+    if (channel->GetServiceReference() == entry.GetServiceReference()) 
     {
       EPG_TAG broadcast;
       memset(&broadcast, 0, sizeof(EPG_TAG));

--- a/src/enigma2/Epg.h
+++ b/src/enigma2/Epg.h
@@ -46,8 +46,8 @@ namespace enigma2
   private:   
     void InitialiseEpgReadyFile();
 
-    bool GetInitialEPGForGroup(enigma2::data::ChannelGroup &group);
-    PVR_ERROR GetInitialEPGForChannel(ADDON_HANDLE handle, const enigma2::data::Channel &channel, time_t iStart, time_t iEnd);
+    bool GetInitialEPGForGroup(std::shared_ptr<enigma2::data::ChannelGroup> group);
+    PVR_ERROR GetInitialEPGForChannel(ADDON_HANDLE handle, const std::shared_ptr<enigma2::data::Channel> &channel, time_t iStart, time_t iEnd);
     
     enigma2::Channels &m_channels;
     enigma2::ChannelGroups &m_channelGroups;  

--- a/src/enigma2/Settings.cpp
+++ b/src/enigma2/Settings.cpp
@@ -179,6 +179,7 @@ void Settings::ReadFromAddon()
 
   // Now that we've read all the settings construct the connection URL
   
+  m_connectionURL.clear();
   // simply add user@pass in front of the URL if username/password is set
   if ((m_username.length() > 0) && (m_password.length() > 0))
     m_connectionURL = StringUtils::Format("%s:%s@", m_username.c_str(), m_password.c_str());
@@ -192,104 +193,101 @@ ADDON_STATUS Settings::SetValue(const std::string &settingName, const void *sett
 {
   //Connection
   if (settingName == "host")
-    return SetStringSetting(settingName, settingValue, m_hostname, ADDON_STATUS_NEED_RESTART);
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_hostname, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "webport")
-    return SetSetting<int>(settingName, settingValue, m_portWeb, ADDON_STATUS_NEED_RESTART);
+    return SetSetting<int, ADDON_STATUS>(settingName, settingValue, m_portWeb, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "use_secure")
-    return SetSetting<bool>(settingName, settingValue, m_useSecureHTTP, ADDON_STATUS_NEED_RESTART);
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_useSecureHTTP, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "user")
-    return SetStringSetting(settingName, settingValue, m_username, ADDON_STATUS_OK);
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_username, ADDON_STATUS_OK, ADDON_STATUS_OK);
   else if (settingName == "pass")
-    return SetStringSetting(settingName, settingValue, m_password, ADDON_STATUS_OK);
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_password, ADDON_STATUS_OK, ADDON_STATUS_OK);
   else if (settingName == "autoconfig")
-    return SetSetting<bool>(settingName, settingValue, m_autoConfig, ADDON_STATUS_OK);
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_autoConfig, ADDON_STATUS_OK, ADDON_STATUS_OK);
   else if (settingName == "streamport")
-    return SetSetting<int>(settingName, settingValue, m_portStream, ADDON_STATUS_NEED_RESTART);
+    return SetSetting<int, ADDON_STATUS>(settingName, settingValue, m_portStream, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "use_secure_stream")
-    return SetSetting<bool>(settingName, settingValue, m_useSecureHTTPStream, ADDON_STATUS_NEED_RESTART);
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_useSecureHTTPStream, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "use_login_stream")
-    return SetSetting<bool>(settingName, settingValue, m_useLoginStream, ADDON_STATUS_NEED_RESTART);
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_useLoginStream, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   //General
   else if (settingName == "onlinepicons")
-    return SetSetting<bool>(settingName, settingValue, m_onlinePicons, ADDON_STATUS_NEED_RESTART);
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_onlinePicons, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "usepiconseuformat")
-    return SetSetting<bool>(settingName, settingValue, m_usePiconsEuFormat, ADDON_STATUS_NEED_RESTART);
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_usePiconsEuFormat, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "iconpath")
-    return SetStringSetting(settingName, settingValue, m_iconPath, ADDON_STATUS_NEED_RESTART);
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_iconPath, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "updateint")
-    return SetSetting<int>(settingName, settingValue, m_updateInterval, ADDON_STATUS_OK);
+    return SetSetting<int, ADDON_STATUS>(settingName, settingValue, m_updateInterval, ADDON_STATUS_OK, ADDON_STATUS_OK);
   //Channels
   else if (settingName == "zap")
-    return SetSetting<bool>(settingName, settingValue, m_zap, ADDON_STATUS_OK);
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_zap, ADDON_STATUS_OK, ADDON_STATUS_OK);
   else if (settingName == "tvgroupmode")
-    return SetSetting<ChannelGroupMode>(settingName, settingValue, m_tvChannelGroupMode, ADDON_STATUS_NEED_RESTART);
+    return SetSetting<ChannelGroupMode, ADDON_STATUS>(settingName, settingValue, m_tvChannelGroupMode, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "onetvgroup")
-    return SetStringSetting(settingName, settingValue, m_oneTVGroup, ADDON_STATUS_NEED_RESTART);
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_oneTVGroup, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "tvfavouritesmode")
-    return SetSetting<FavouritesGroupMode>(settingName, settingValue, m_tvFavouritesMode, ADDON_STATUS_NEED_RESTART);
+    return SetSetting<FavouritesGroupMode, ADDON_STATUS>(settingName, settingValue, m_tvFavouritesMode, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "radiogroupmode")
-    return SetSetting<ChannelGroupMode>(settingName, settingValue, m_radioChannelGroupMode, ADDON_STATUS_NEED_RESTART);
+    return SetSetting<ChannelGroupMode, ADDON_STATUS>(settingName, settingValue, m_radioChannelGroupMode, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "oneradiogroup")
-    return SetStringSetting(settingName, settingValue, m_oneRadioGroup, ADDON_STATUS_NEED_RESTART);
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_oneRadioGroup, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "radiofavouritesmode")
-    return SetSetting<FavouritesGroupMode>(settingName, settingValue, m_radioFavouritesMode, ADDON_STATUS_NEED_RESTART);
+    return SetSetting<FavouritesGroupMode, ADDON_STATUS>(settingName, settingValue, m_radioFavouritesMode, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   //EPG
   else if (settingName == "extractepginfoenabled")
-    return SetSetting<bool>(settingName, settingValue, m_extractShowInfo, ADDON_STATUS_NEED_RESTART);
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_extractShowInfo, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "extractepginfofile")
-    return SetStringSetting(settingName, settingValue, m_extractShowInfoFile, ADDON_STATUS_NEED_RESTART);
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_extractShowInfoFile, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "genreidmapenabled")
-    return SetSetting<bool>(settingName, settingValue, m_mapGenreIds, ADDON_STATUS_NEED_RESTART);
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_mapGenreIds, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "genreidmapfile")
-    return SetStringSetting(settingName, settingValue, m_mapGenreIdsFile, ADDON_STATUS_NEED_RESTART);
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_mapGenreIdsFile, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "rytecgenretextmapenabled")
-    return SetSetting<bool>(settingName, settingValue, m_mapRytecTextGenres, ADDON_STATUS_NEED_RESTART);
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_mapRytecTextGenres, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "rytecgenretextmapfile")
-    return SetStringSetting(settingName, settingValue, m_mapRytecTextGenresFile, ADDON_STATUS_NEED_RESTART);
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_mapRytecTextGenresFile, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "logmissinggenremapping")
-    return SetSetting<bool>(settingName, settingValue, m_logMissingGenreMappings, ADDON_STATUS_OK);
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_logMissingGenreMappings, ADDON_STATUS_OK, ADDON_STATUS_OK);
   //Recordings and Timers
   else if (settingName == "recordingpath")
-    return SetStringSetting(settingName, settingValue, m_recordingPath, ADDON_STATUS_NEED_RESTART);
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_recordingPath, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "onlycurrent")
-    return SetSetting<bool>(settingName, settingValue, m_onlyCurrentLocation, ADDON_STATUS_OK);
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_onlyCurrentLocation, ADDON_STATUS_OK, ADDON_STATUS_OK);
   else if (settingName == "keepfolders")
-    return SetSetting<bool>(settingName, settingValue, m_keepFolders, ADDON_STATUS_OK);
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_keepFolders, ADDON_STATUS_OK, ADDON_STATUS_OK);
   else if (settingName == "enablegenrepeattimers")
-    return SetSetting<bool>(settingName, settingValue, m_enableAutoTimers, ADDON_STATUS_OK);
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_enableAutoTimers, ADDON_STATUS_OK, ADDON_STATUS_OK);
   else if (settingName == "numgenrepeattimers")
-    return SetSetting<int>(settingName, settingValue, m_numGenRepeatTimers, ADDON_STATUS_OK);
+    return SetSetting<int, ADDON_STATUS>(settingName, settingValue, m_numGenRepeatTimers, ADDON_STATUS_OK, ADDON_STATUS_OK);
   else if (settingName == "enableautotimers")
-    return SetSetting<bool>(settingName, settingValue, m_enableAutoTimers, ADDON_STATUS_NEED_RESTART);
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_enableAutoTimers, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "timerlistcleanup")
-    return SetSetting<bool>(settingName, settingValue, m_automaticTimerlistCleanup, ADDON_STATUS_OK);
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_automaticTimerlistCleanup, ADDON_STATUS_OK, ADDON_STATUS_OK);
   //Timeshift
   else if (settingName == "enabletimeshift")
-    return SetSetting<Timeshift>(settingName, settingValue, m_timeshift, ADDON_STATUS_NEED_RESTART);
+    return SetSetting<Timeshift, ADDON_STATUS>(settingName, settingValue, m_timeshift, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "timeshiftbufferpath")
-    return SetStringSetting(settingName, settingValue, m_timeshiftBufferPath, ADDON_STATUS_OK);
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_timeshiftBufferPath, ADDON_STATUS_OK, ADDON_STATUS_OK);
   //Advanced
   else if (settingName == "prependoutline")
-    return SetSetting<PrependOutline>(settingName, settingValue, m_prependOutline, ADDON_STATUS_NEED_RESTART);
+    return SetSetting<PrependOutline, ADDON_STATUS>(settingName, settingValue, m_prependOutline, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "setpowerstate")
-    return SetSetting<bool>(settingName, settingValue, m_setPowerstate, ADDON_STATUS_OK);
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_setPowerstate, ADDON_STATUS_OK, ADDON_STATUS_OK);
   else if (settingName == "readtimeout")
-    return SetSetting<int>(settingName, settingValue, m_readTimeout, ADDON_STATUS_NEED_RESTART);
+    return SetSetting<int, ADDON_STATUS>(settingName, settingValue, m_readTimeout, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "streamreadchunksize")
-    return SetSetting<int>(settingName, settingValue, m_streamReadChunkSize, ADDON_STATUS_OK);
-
-  return ADDON_STATUS_OK;
-}
-
-ADDON_STATUS Settings::SetStringSetting(const std::string &settingName, const void* settingValue, std::string &currentValue, ADDON_STATUS returnValueIfChanged)
-{
-  const std::string strSettingValue = static_cast<const char*>(settingValue);
-
-  if (strSettingValue != currentValue)
+    return SetSetting<int, ADDON_STATUS>(settingName, settingValue, m_streamReadChunkSize, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  //Backend
+  else if (settingName == "globalstartpaddingstb")
   {
-    Logger::Log(LEVEL_NOTICE, "%s - Changed Setting '%s' from %s to %s", __FUNCTION__, settingName.c_str(), currentValue.c_str(), strSettingValue.c_str());
-    currentValue = strSettingValue;
-    return returnValueIfChanged;
+    if (SetSetting<int, bool>(settingName, settingValue, m_globalStartPaddingStb, true, false))
+      m_admin->SendGlobalRecordingStartMarginSetting(m_globalStartPaddingStb);
+  }
+  else if (settingName == "globalendpaddingstb")
+  {
+    if (SetSetting<int, bool>(settingName, settingValue, m_globalEndPaddingStb, true, false))
+      m_admin->SendGlobalRecordingEndMarginSetting(m_globalEndPaddingStb);
   }
 
   return ADDON_STATUS_OK;

--- a/src/enigma2/Settings.cpp
+++ b/src/enigma2/Settings.cpp
@@ -168,8 +168,8 @@ void Settings::ReadFromAddon()
   if (!XBMC->GetSetting("prependoutline", &m_prependOutline))
     m_prependOutline = PrependOutline::IN_EPG;
 
-  if (!XBMC->GetSetting("setpowerstate", &m_setPowerstate))
-    m_setPowerstate = false;
+  if (!XBMC->GetSetting("powerstatemode", &m_powerstateMode))
+    m_powerstateMode = PowerstateMode::DISABLED;
   
   if (!XBMC->GetSetting("readtimeout", &m_readTimeout))
     m_readTimeout = 0;
@@ -272,8 +272,8 @@ ADDON_STATUS Settings::SetValue(const std::string &settingName, const void *sett
   //Advanced
   else if (settingName == "prependoutline")
     return SetSetting<PrependOutline, ADDON_STATUS>(settingName, settingValue, m_prependOutline, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
-  else if (settingName == "setpowerstate")
-    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_setPowerstate, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  else if (settingName == "powerstatemode")
+    return SetSetting<PowerstateMode, ADDON_STATUS>(settingName, settingValue, m_powerstateMode, ADDON_STATUS_OK, ADDON_STATUS_OK);
   else if (settingName == "readtimeout")
     return SetSetting<int, ADDON_STATUS>(settingName, settingValue, m_readTimeout, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "streamreadchunksize")

--- a/src/enigma2/Settings.cpp
+++ b/src/enigma2/Settings.cpp
@@ -71,17 +71,32 @@ void Settings::ReadFromAddon()
     m_updateInterval = DEFAULT_UPDATE_INTERVAL;
 
   //Channels
-  if (!XBMC->GetSetting("onlyonegroup", &m_onlyOneGroup))
-    m_onlyOneGroup = false;
-  
-  if (XBMC->GetSetting("onegroup", buffer))
-    m_oneGroup = buffer;
-  else
-    m_oneGroup = "";
-  buffer[0] = 0;
-
   if (!XBMC->GetSetting("zap", &m_zap))
     m_zap = false;
+
+  if (!XBMC->GetSetting("tvgroupmode", &m_tvChannelGroupMode))
+    m_tvChannelGroupMode = ChannelGroupMode::ALL_GROUPS;
+  
+  if (XBMC->GetSetting("onetvgroup", buffer))
+    m_oneTVGroup = buffer;
+  else
+    m_oneTVGroup = "";
+  buffer[0] = 0;
+
+  if (!XBMC->GetSetting("tvfavouritesmode", &m_tvFavouritesMode))
+    m_tvFavouritesMode = FavouritesGroupMode::DISABLED;
+
+  if (!XBMC->GetSetting("radiogroupmode", &m_radioChannelGroupMode))
+    m_radioChannelGroupMode = ChannelGroupMode::FAVOURITES_GROUP;
+  
+  if (XBMC->GetSetting("oneradiogroup", buffer))
+    m_oneRadioGroup = buffer;
+  else
+    m_oneRadioGroup = "";
+  buffer[0] = 0;
+
+  if (!XBMC->GetSetting("radiofavouritesmode", &m_radioFavouritesMode))
+    m_radioFavouritesMode = FavouritesGroupMode::DISABLED;
 
   //EPG
   if (!XBMC->GetSetting("extractshowinfoenabled", &m_extractShowInfo))
@@ -204,12 +219,20 @@ ADDON_STATUS Settings::SetValue(const std::string &settingName, const void *sett
   else if (settingName == "updateint")
     return SetSetting<int>(settingName, settingValue, m_updateInterval, ADDON_STATUS_OK);
   //Channels
-  else if (settingName == "onlyonegroup")
-    return SetSetting<bool>(settingName, settingValue, m_onlyOneGroup, ADDON_STATUS_NEED_RESTART);
-  else if (settingName == "onegroup")
-    return SetStringSetting(settingName, settingValue, m_oneGroup, ADDON_STATUS_NEED_RESTART);
   else if (settingName == "zap")
     return SetSetting<bool>(settingName, settingValue, m_zap, ADDON_STATUS_OK);
+  else if (settingName == "tvgroupmode")
+    return SetSetting<ChannelGroupMode>(settingName, settingValue, m_tvChannelGroupMode, ADDON_STATUS_NEED_RESTART);
+  else if (settingName == "onetvgroup")
+    return SetStringSetting(settingName, settingValue, m_oneTVGroup, ADDON_STATUS_NEED_RESTART);
+  else if (settingName == "tvfavouritesmode")
+    return SetSetting<FavouritesGroupMode>(settingName, settingValue, m_tvFavouritesMode, ADDON_STATUS_NEED_RESTART);
+  else if (settingName == "radiogroupmode")
+    return SetSetting<ChannelGroupMode>(settingName, settingValue, m_radioChannelGroupMode, ADDON_STATUS_NEED_RESTART);
+  else if (settingName == "oneradiogroup")
+    return SetStringSetting(settingName, settingValue, m_oneRadioGroup, ADDON_STATUS_NEED_RESTART);
+  else if (settingName == "radiofavouritesmode")
+    return SetSetting<FavouritesGroupMode>(settingName, settingValue, m_radioFavouritesMode, ADDON_STATUS_NEED_RESTART);
   //EPG
   else if (settingName == "extractepginfoenabled")
     return SetSetting<bool>(settingName, settingValue, m_extractShowInfo, ADDON_STATUS_NEED_RESTART);
@@ -264,7 +287,7 @@ ADDON_STATUS Settings::SetStringSetting(const std::string &settingName, const vo
 
   if (strSettingValue != currentValue)
   {
-    Logger::Log(LEVEL_INFO, "%s - Changed Setting '%s' from %s to %s", __FUNCTION__, settingName.c_str(), currentValue.c_str(), strSettingValue.c_str());
+    Logger::Log(LEVEL_NOTICE, "%s - Changed Setting '%s' from %s to %s", __FUNCTION__, settingName.c_str(), currentValue.c_str(), strSettingValue.c_str());
     currentValue = strSettingValue;
     return returnValueIfChanged;
   }

--- a/src/enigma2/Settings.cpp
+++ b/src/enigma2/Settings.cpp
@@ -70,6 +70,9 @@ void Settings::ReadFromAddon()
   if (!XBMC->GetSetting("updateint", &m_updateInterval))
     m_updateInterval = DEFAULT_UPDATE_INTERVAL;
 
+  if (!XBMC->GetSetting("updatemode", &m_updateMode))
+    m_updateMode = UpdateMode::TIMERS_AND_RECORDINGS;
+
   //Channels
   if (!XBMC->GetSetting("zap", &m_zap))
     m_zap = false;
@@ -218,7 +221,9 @@ ADDON_STATUS Settings::SetValue(const std::string &settingName, const void *sett
   else if (settingName == "iconpath")
     return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_iconPath, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "updateint")
-    return SetSetting<int, ADDON_STATUS>(settingName, settingValue, m_updateInterval, ADDON_STATUS_OK, ADDON_STATUS_OK);
+    return SetSetting<unsigned int, ADDON_STATUS>(settingName, settingValue, m_updateInterval, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  else if (settingName == "updatemode")
+    return SetSetting<UpdateMode, ADDON_STATUS>(settingName, settingValue, m_updateMode, ADDON_STATUS_OK, ADDON_STATUS_OK);
   //Channels
   else if (settingName == "zap")
     return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_zap, ADDON_STATUS_OK, ADDON_STATUS_OK);

--- a/src/enigma2/Settings.h
+++ b/src/enigma2/Settings.h
@@ -24,6 +24,13 @@ namespace enigma2
   static const std::string DEFAULT_GENRE_TEXT_MAP_FILE = "special://userdata/addon_data/pvr.vuplus/genres/genreTextMappings/Rytec-UK-Ireland";
   static const int DEFAULT_NUM_GEN_REPEAT_TIMERS = 1;
 
+  enum class UpdateMode
+    : int // same type as addon settings
+  {
+    TIMERS_AND_RECORDINGS = 0,
+    TIMERS_ONLY
+  };
+
   enum class ChannelGroupMode
     : int // same type as addon settings
   {
@@ -96,7 +103,8 @@ namespace enigma2
     bool UseOnlinePicons() const { return m_onlinePicons; }
     bool UsePiconsEuFormat() const { return m_usePiconsEuFormat; }
     const std::string& GetIconPath() const { return m_iconPath; }
-    int GetUpdateIntervalMins() const { return m_updateInterval; }
+    unsigned int GetUpdateIntervalMins() const { return m_updateInterval; }
+    UpdateMode GetUpdateMode() const { return m_updateMode; }
 
     //Channel
     bool GetZapBeforeChannelSwitch() const { return m_zap; }
@@ -208,7 +216,8 @@ namespace enigma2
     bool m_onlinePicons = true;
     bool m_usePiconsEuFormat = false;
     std::string m_iconPath = "";
-    int m_updateInterval = DEFAULT_UPDATE_INTERVAL;
+    unsigned int m_updateInterval = DEFAULT_UPDATE_INTERVAL;
+    UpdateMode m_updateMode = UpdateMode::TIMERS_AND_RECORDINGS;
     
     //Channel
     bool m_zap = false;

--- a/src/enigma2/Settings.h
+++ b/src/enigma2/Settings.h
@@ -57,6 +57,15 @@ namespace enigma2
     ALWAYS
   };
 
+  enum class PowerstateMode
+    : int // same type as addon settings
+  {
+    DISABLED = 0,
+    STANDBY,
+    DEEP_STANDBY,
+    WAKEUP_THEN_STANDBY
+  };
+
   class Settings
   {
   public:
@@ -123,7 +132,7 @@ namespace enigma2
 
     //Advanced
     const PrependOutline& GetPrependOutline() const { return m_prependOutline; }
-    bool GetDeepStandbyOnAddonExit() const { return m_setPowerstate; }
+    PowerstateMode GetPowerstateModeOnAddonExit() const { return m_powerstateMode; }
     int GetReadTimeoutSecs() const { return m_readTimeout; }
     int GetStreamReadChunkSizeKb() const { return m_streamReadChunkSize; }
 
@@ -234,7 +243,7 @@ namespace enigma2
 
     //Advanced
     PrependOutline m_prependOutline = PrependOutline::IN_EPG;
-    bool m_setPowerstate = false;
+    PowerstateMode m_powerstateMode = PowerstateMode::DISABLED;
     int m_readTimeout = 0;
     int m_streamReadChunkSize = 0;
 

--- a/src/enigma2/Settings.h
+++ b/src/enigma2/Settings.h
@@ -22,6 +22,22 @@ namespace enigma2
   static const std::string DEFAULT_GENRE_TEXT_MAP_FILE = "special://userdata/addon_data/pvr.vuplus/genres/genreTextMappings/Rytec-UK-Ireland";
   static const int DEFAULT_NUM_GEN_REPEAT_TIMERS = 1;
 
+  enum class ChannelGroupMode
+    : int // same type as addon settings
+  {
+    ALL_GROUPS = 0,
+    ONLY_ONE_GROUP,
+    FAVOURITES_GROUP
+  };
+
+  enum class FavouritesGroupMode
+    : int // same type as addon settings
+  {
+    DISABLED = 0,
+    AS_FIRST_GROUP,
+    AS_LAST_GROUP
+  };
+
   enum class Timeshift
     : int // same type as addon settings
   {
@@ -72,9 +88,13 @@ namespace enigma2
     int GetUpdateIntervalMins() const { return m_updateInterval; }
 
     //Channel
-    bool GetOneGroupOnly() const { return m_onlyOneGroup; }
-    const std::string& GetOneGroupName() const { return m_oneGroup; }
     bool GetZapBeforeChannelSwitch() const { return m_zap; }
+    const ChannelGroupMode& GetTVChannelGroupMode() const { return m_tvChannelGroupMode; }
+    const std::string& GetOneTVGroupName() const { return m_oneTVGroup; }
+    const FavouritesGroupMode& GetTVFavouritesMode() const { return m_tvFavouritesMode; }
+    const ChannelGroupMode& GetRadioChannelGroupMode() const { return m_radioChannelGroupMode; }
+    const std::string& GetOneRadioGroupName() const { return m_oneRadioGroup; }
+    const FavouritesGroupMode& GetRadioFavouritesMode() const { return m_radioFavouritesMode; }
    
     //EPG
     bool GetExtractShowInfo() const { return m_extractShowInfo; }
@@ -156,9 +176,13 @@ namespace enigma2
     int m_updateInterval = DEFAULT_UPDATE_INTERVAL;
     
     //Channel
-    bool m_onlyOneGroup = false;
-    std::string m_oneGroup = "";
     bool m_zap = false;
+    ChannelGroupMode m_tvChannelGroupMode = ChannelGroupMode::ALL_GROUPS;
+    std::string m_oneTVGroup = "";
+    FavouritesGroupMode m_tvFavouritesMode = FavouritesGroupMode::DISABLED;
+    ChannelGroupMode m_radioChannelGroupMode = ChannelGroupMode::FAVOURITES_GROUP;
+    std::string m_oneRadioGroup = "";
+    FavouritesGroupMode m_radioFavouritesMode = FavouritesGroupMode::DISABLED;
 
     //EPG
     bool m_extractShowInfo = true;

--- a/src/enigma2/Timers.cpp
+++ b/src/enigma2/Timers.cpp
@@ -458,7 +458,7 @@ PVR_ERROR Timers::AddTimer(const PVR_TIMER &timer)
     tags = TAG_FOR_MANUAL_TIMER;
 
   std::string strTmp;
-  std::string strServiceReference = m_channels.GetChannel(timer.iClientChannelUid).GetServiceReference().c_str();
+  std::string strServiceReference = m_channels.GetChannel(timer.iClientChannelUid)->GetServiceReference().c_str();
 
   time_t startTime, endTime;
   startTime = timer.startTime - (timer.iMarginStart * 60);
@@ -544,7 +544,7 @@ PVR_ERROR Timers::AddAutoTimer(const PVR_TIMER &timer)
   if (timer.iClientChannelUid != PVR_TIMER_ANY_CHANNEL)
   {
     //single channel
-    strTmp += StringUtils::Format("&services=%s", WebUtils::URLEncodeInline(m_channels.GetChannel(timer.iClientChannelUid).GetServiceReference()).c_str());
+    strTmp += StringUtils::Format("&services=%s", WebUtils::URLEncodeInline(m_channels.GetChannel(timer.iClientChannelUid)->GetServiceReference()).c_str());
   }
 
   strTmp += Timers::BuildAddUpdateAutoTimerIncludeParams(timer.iWeekdays);
@@ -569,7 +569,7 @@ PVR_ERROR Timers::UpdateTimer(const PVR_TIMER &timer)
   Logger::Log(LEVEL_DEBUG, "%s timer channelid '%d'", __FUNCTION__, timer.iClientChannelUid);
 
   std::string strTmp;
-  std::string strServiceReference = m_channels.GetChannel(timer.iClientChannelUid).GetServiceReference().c_str();  
+  std::string strServiceReference = m_channels.GetChannel(timer.iClientChannelUid)->GetServiceReference().c_str();  
 
   const auto it = std::find_if(m_timers.cbegin(), m_timers.cend(), [timer](const Timer& myTimer)
   {
@@ -579,7 +579,7 @@ PVR_ERROR Timers::UpdateTimer(const PVR_TIMER &timer)
   if (it != m_timers.cend())
   {
     Timer oldTimer = *it;
-    std::string strOldServiceReference = m_channels.GetChannel(oldTimer.GetChannelId()).GetServiceReference().c_str();  
+    std::string strOldServiceReference = m_channels.GetChannel(oldTimer.GetChannelId())->GetServiceReference().c_str();  
     Logger::Log(LEVEL_DEBUG, "%s old timer channelid '%d'", __FUNCTION__, oldTimer.GetChannelId());
 
     int iDisabled = 0;
@@ -676,7 +676,7 @@ PVR_ERROR Timers::UpdateAutoTimer(const PVR_TIMER &timer)
     if (timerToUpdate.GetAnyChannel() && timer.iClientChannelUid != PVR_TIMER_ANY_CHANNEL)
     {
       //move to single channel
-      strTmp += StringUtils::Format("&services=%s", WebUtils::URLEncodeInline(m_channels.GetChannel(timer.iClientChannelUid).GetServiceReference()).c_str());
+      strTmp += StringUtils::Format("&services=%s", WebUtils::URLEncodeInline(m_channels.GetChannel(timer.iClientChannelUid)->GetServiceReference()).c_str());
     }
     else if (!timerToUpdate.GetAnyChannel() && timer.iClientChannelUid == PVR_TIMER_ANY_CHANNEL)
     {
@@ -735,7 +735,7 @@ PVR_ERROR Timers::DeleteTimer(const PVR_TIMER &timer)
     return DeleteAutoTimer(timer);
 
   std::string strTmp;
-  std::string strServiceReference = m_channels.GetChannel(timer.iClientChannelUid).GetServiceReference().c_str();
+  std::string strServiceReference = m_channels.GetChannel(timer.iClientChannelUid)->GetServiceReference().c_str();
 
   time_t startTime, endTime;
   startTime = timer.startTime - (timer.iMarginStart * 60);

--- a/src/enigma2/Timers.h
+++ b/src/enigma2/Timers.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include <string>
-#include <memory>
-#include <functional>
+#include <atomic>
 #include <ctime>
+#include <functional>
+#include <memory>
+#include <string>
 #include <type_traits>
 
 #include "data/Timer.h"
@@ -20,7 +21,7 @@ namespace enigma2
     Timers(Channels &channels, std::vector<std::string> &locations)
       : m_channels(channels), m_locations(locations)
     {
-        m_clientIndexCounter = 1;
+      m_clientIndexCounter = 1;
     };
     
     void GetTimerTypes(std::vector<PVR_TIMER_TYPE> &types) const;
@@ -44,8 +45,9 @@ namespace enigma2
     PVR_ERROR DeleteAutoTimer(const PVR_TIMER &timer);
 
     void ClearTimers();
-    void TimerUpdates();
+    bool TimerUpdates();
     void RunAutoTimerListCleanup();
+    void AddTimerChangeWatcher(std::atomic_bool* watcher);
 
   private:
     //templates
@@ -66,6 +68,8 @@ namespace enigma2
 
     // members
     unsigned int m_clientIndexCounter;
+    std::vector<std::atomic_bool*> m_timerChangeWatchers;
+
     enigma2::Settings &m_settings = enigma2::Settings::GetInstance();
     std::vector<enigma2::data::Timer> m_timers;
     std::vector<enigma2::data::AutoTimer> m_autotimers;

--- a/src/enigma2/data/AutoTimer.cpp
+++ b/src/enigma2/data/AutoTimer.cpp
@@ -159,7 +159,7 @@ bool AutoTimer::UpdateFrom(TiXmlElement* autoTimerNode, Channels &channels)
           return false;
         }
 
-        m_channelName = channels.GetChannel(m_channelId).GetChannelName();  
+        m_channelName = channels.GetChannel(m_channelId)->GetChannelName();  
       }
     }
     else //otherwise set to any channel

--- a/src/enigma2/data/Channel.cpp
+++ b/src/enigma2/data/Channel.cpp
@@ -2,6 +2,7 @@
 
 #include <regex>
 
+#include "ChannelGroup.h"
 #include "../Settings.h"
 #include "../utilities/WebUtils.h"
 
@@ -96,4 +97,9 @@ void Channel::UpdateTo(PVR_CHANNEL &left) const
   left.iEncryptionSystem = 0;
   left.bIsHidden = false;
   strncpy(left.strIconPath, m_iconPath.c_str(), sizeof(left.strIconPath));
+}
+
+void Channel::AddChannelGroup(std::shared_ptr<ChannelGroup> &channelGroup)
+{
+  m_channelGroupList.emplace_back(channelGroup);
 }

--- a/src/enigma2/data/Channel.h
+++ b/src/enigma2/data/Channel.h
@@ -21,7 +21,9 @@
  *
  */
 
+#include <memory>
 #include <string>
+#include <vector>
 
 #include "libXBMC_pvr.h"
 #include "tinyxml.h"
@@ -30,16 +32,24 @@ namespace enigma2
 {
   namespace data
   {
+    class ChannelGroup;
+
     class Channel
     {
     public:
       const std::string SERVICE_REF_ICON_PREFIX = "1:0:1:";
       const std::string SERVICE_REF_ICON_POSTFIX = ":0:0:0";
 
+      Channel() = default;
+      Channel(Channel &c) : m_radio(c.IsRadio()), m_uniqueId(c.GetUniqueId()), m_channelNumber(c.GetChannelNumber()),
+        m_channelName(c.GetChannelName()), m_serviceReference(c.GetServiceReference()),
+        m_streamURL(c.GetStreamURL()), m_m3uURL(c.GetM3uURL()), m_iconPath(c.GetIconPath()) {};
+      ~Channel() = default;
+
       bool IsRadio() const { return m_radio; }
       void SetRadio(bool value) { m_radio = value; }      
 
-      bool IsRequiresInitialEPG() const { return m_requiresInitialEPG; }
+      bool RequiresInitialEPG() const { return m_requiresInitialEPG; }
       void SetRequiresInitialEPG(bool value) { m_requiresInitialEPG = value; }      
 
       int GetUniqueId() const { return m_uniqueId; }
@@ -47,9 +57,6 @@ namespace enigma2
 
       int GetChannelNumber() const { return m_channelNumber; }
       void SetChannelNumber(int value) { m_channelNumber = value; }      
-
-      const std::string& GetGroupName() const { return m_groupName; }
-      void SetGroupName(const std::string& value ) { m_groupName = value; }      
 
       const std::string& GetChannelName() const { return m_channelName; }
       void SetChannelName(const std::string& value ) { m_channelName = value; }      
@@ -69,17 +76,21 @@ namespace enigma2
       bool UpdateFrom(TiXmlElement* channelNode, const std::string &enigmaURL); 
       void UpdateTo(PVR_CHANNEL &left) const;
 
+      void AddChannelGroup(std::shared_ptr<enigma2::data::ChannelGroup> &channelGroup);
+      std::vector<std::shared_ptr<enigma2::data::ChannelGroup>> GetChannelGroupList() { return m_channelGroupList; };
+
     private:   
       bool m_radio;
       bool m_requiresInitialEPG = true;
       int m_uniqueId;
       int m_channelNumber;
-      std::string m_groupName;
       std::string m_channelName;
       std::string m_serviceReference;
       std::string m_streamURL;
       std::string m_m3uURL;
       std::string m_iconPath;
+
+      std::vector<std::shared_ptr<enigma2::data::ChannelGroup>> m_channelGroupList;
     };
   } //namespace data
 } //namespace enigma2

--- a/src/enigma2/data/ChannelGroup.cpp
+++ b/src/enigma2/data/ChannelGroup.cpp
@@ -7,7 +7,7 @@ using namespace enigma2;
 using namespace enigma2::data;
 using namespace enigma2::utilities;
 
-bool ChannelGroup::UpdateFrom(TiXmlElement* groupNode)
+bool ChannelGroup::UpdateFrom(TiXmlElement* groupNode, bool radio)
 {
   std::string serviceReference;
   std::string groupName;
@@ -16,27 +16,42 @@ bool ChannelGroup::UpdateFrom(TiXmlElement* groupNode)
     return false;
   
   // Check whether the current element is not just a label
-  if (serviceReference.compare(0,5,"1:64:") == 0)
+  if (serviceReference.compare(0, 5, "1:64:") == 0)
     return false;
 
   if (!XMLUtils::GetString(groupNode, "e2servicename", groupName)) 
     return false;
 
-  if (Settings::GetInstance().GetOneGroupOnly() && Settings::GetInstance().GetOneGroupName() != groupName) 
+  // Check if the current element is hidden, a separator or last scanned
+  if (groupName == "<n/a>" || groupName.compare(groupName.length() - 12, 12, " - Separator") == 0 || groupName == "Last Scanned")
+    return false;
+
+  if (!radio && Settings::GetInstance().GetOneTVGroupOnly() && Settings::GetInstance().GetOneTVGroupName() != groupName)
   {
-    Logger::Log(LEVEL_INFO, "%s Only one group is set, but current e2servicename '%s' does not match requested name '%s'", __FUNCTION__, serviceReference.c_str(), Settings::GetInstance().GetOneGroupName().c_str());
+    Logger::Log(LEVEL_DEBUG, "%s Only one TV group is set, but current e2servicename '%s' does not match requested name '%s'", __FUNCTION__, serviceReference.c_str(), Settings::GetInstance().GetOneTVGroupName().c_str());
+    return false;
+  } 
+  else if (radio && Settings::GetInstance().GetOneRadioGroupOnly() && Settings::GetInstance().GetOneRadioGroupName() != groupName)
+  {
+    Logger::Log(LEVEL_DEBUG, "%s Only one Radio group is set, but current e2servicename '%s' does not match requested name '%s'", __FUNCTION__, serviceReference.c_str(), Settings::GetInstance().GetOneRadioGroupName().c_str());
     return false;
   }
 
   m_serviceReference = serviceReference;
   m_groupName = groupName;
+  m_radio = radio;
 
   return true;
 }
 
 void ChannelGroup::UpdateTo(PVR_CHANNEL_GROUP &left) const
 {
-  left.bIsRadio = false;
+  left.bIsRadio = m_radio;
   left.iPosition = 0; // groups default order, unused
   strncpy(left.strGroupName, m_groupName.c_str(), sizeof(left.strGroupName));
+}
+
+void ChannelGroup::AddChannel(std::shared_ptr<Channel> channel)
+{
+  m_channelList.emplace_back(channel);
 }

--- a/src/enigma2/data/ChannelGroup.cpp
+++ b/src/enigma2/data/ChannelGroup.cpp
@@ -26,12 +26,14 @@ bool ChannelGroup::UpdateFrom(TiXmlElement* groupNode, bool radio)
   if (groupName == "<n/a>" || groupName.compare(groupName.length() - 12, 12, " - Separator") == 0 || groupName == "Last Scanned")
     return false;
 
-  if (!radio && Settings::GetInstance().GetOneTVGroupOnly() && Settings::GetInstance().GetOneTVGroupName() != groupName)
+  if (!radio && Settings::GetInstance().GetTVChannelGroupMode() == ChannelGroupMode::ONLY_ONE_GROUP && 
+        Settings::GetInstance().GetOneTVGroupName() != groupName)
   {
     Logger::Log(LEVEL_DEBUG, "%s Only one TV group is set, but current e2servicename '%s' does not match requested name '%s'", __FUNCTION__, serviceReference.c_str(), Settings::GetInstance().GetOneTVGroupName().c_str());
     return false;
   } 
-  else if (radio && Settings::GetInstance().GetOneRadioGroupOnly() && Settings::GetInstance().GetOneRadioGroupName() != groupName)
+  else if (radio && Settings::GetInstance().GetRadioChannelGroupMode() == ChannelGroupMode::ONLY_ONE_GROUP && 
+            Settings::GetInstance().GetOneRadioGroupName() != groupName)
   {
     Logger::Log(LEVEL_DEBUG, "%s Only one Radio group is set, but current e2servicename '%s' does not match requested name '%s'", __FUNCTION__, serviceReference.c_str(), Settings::GetInstance().GetOneRadioGroupName().c_str());
     return false;

--- a/src/enigma2/data/ChannelGroup.h
+++ b/src/enigma2/data/ChannelGroup.h
@@ -21,9 +21,11 @@
  *
  */
 
+#include <memory>
 #include <string>
 #include <vector>
 
+#include "Channel.h"
 #include "EpgEntry.h"
 
 #include "libXBMC_pvr.h"
@@ -35,7 +37,15 @@ namespace enigma2
   {
     class ChannelGroup 
     {
-    public:           
+    public:
+      ChannelGroup() = default;
+      ChannelGroup(ChannelGroup &c) : m_radio(c.IsRadio()), m_uniqueId(c.GetUniqueId()),
+        m_groupName(c.GetGroupName()), m_serviceReference(c.GetServiceReference()) {};
+      ~ChannelGroup() = default;
+
+      bool IsRadio() const { return m_radio; }
+      void SetRadio(bool value) { m_radio = value; }      
+
       int GetUniqueId() const { return m_uniqueId; }
       void SetUniqueId(int value) { m_uniqueId = value; }  
 
@@ -48,17 +58,24 @@ namespace enigma2
       int GetGroupState() const { return m_groupState; }
       void SetGroupState(int value) { m_groupState = value; }      
 
+      void AddChannel(std::shared_ptr<enigma2::data::Channel> channel);
+
       std::vector<EpgEntry>& GetInitialEPG() { return m_initialEPG; }
 
-      bool UpdateFrom(TiXmlElement* groupNode); 
+      bool UpdateFrom(TiXmlElement* groupNode, bool radio); 
       void UpdateTo(PVR_CHANNEL_GROUP &left) const;
 
+      std::vector<std::shared_ptr<enigma2::data::Channel>> GetChannelList() { return m_channelList; };
+
     private:
+      bool m_radio;
       int m_uniqueId;
       std::string m_serviceReference;
       std::string m_groupName;
       int m_groupState;
       std::vector<EpgEntry> m_initialEPG; 
+
+      std::vector<std::shared_ptr<enigma2::data::Channel>> m_channelList;
     };
   } //namespace data
 } //namespace enigma2

--- a/src/enigma2/data/EpgEntry.cpp
+++ b/src/enigma2/data/EpgEntry.cpp
@@ -37,7 +37,7 @@ void EpgEntry::UpdateTo(EPG_TAG &left) const
   left.iFlags              = EPG_TAG_FLAG_UNDEFINED;
 }
 
-bool EpgEntry::UpdateFrom(TiXmlElement* eventNode, Channels channels)
+bool EpgEntry::UpdateFrom(TiXmlElement* eventNode, Channels &channels)
 {
   std::string strTmp; 
 
@@ -58,12 +58,12 @@ bool EpgEntry::UpdateFrom(TiXmlElement* eventNode, Channels channels)
     return false;
   }
 
-  const Channel& myChannel = channels.GetChannel(m_channelId);;
+  const std::shared_ptr<Channel> myChannel = channels.GetChannel(m_channelId);;
 
   return UpdateFrom(eventNode, myChannel, 0, 0);
 }
 
-bool EpgEntry::UpdateFrom(TiXmlElement* eventNode, const Channel channel, time_t iStart, time_t iEnd)
+bool EpgEntry::UpdateFrom(TiXmlElement* eventNode, const std::shared_ptr<Channel> &channel, time_t iStart, time_t iEnd)
 {
   std::string strTmp;
 
@@ -91,14 +91,14 @@ bool EpgEntry::UpdateFrom(TiXmlElement* eventNode, const Channel channel, time_t
     return false;
 
   m_eventId = iTmp;
-  m_channelId = channel.GetUniqueId();
+  m_channelId = channel->GetUniqueId();
   
   if(!XMLUtils::GetString(eventNode, "e2eventtitle", strTmp))
     return false;
 
   m_title = strTmp;
   
-  m_serviceReference = channel.GetServiceReference().c_str();
+  m_serviceReference = channel->GetServiceReference().c_str();
 
   // Check that it's not an empty record
   if (m_eventId == 0 && m_title == "None")

--- a/src/enigma2/data/EpgEntry.h
+++ b/src/enigma2/data/EpgEntry.h
@@ -53,8 +53,8 @@ namespace enigma2
       void SetEndTime(time_t value) { m_endTime = value; }    
 
       void UpdateTo(EPG_TAG &left) const;
-      bool UpdateFrom(TiXmlElement* eventNode, enigma2::Channels channels); 
-      bool UpdateFrom(TiXmlElement* eventNode, Channel channel, time_t iStart, time_t iEnd); 
+      bool UpdateFrom(TiXmlElement* eventNode, enigma2::Channels &channels); 
+      bool UpdateFrom(TiXmlElement* eventNode, const std::shared_ptr<enigma2::data::Channel> &channel, time_t iStart, time_t iEnd);
 
     private:    
       int m_eventId;

--- a/src/enigma2/data/RecordingEntry.cpp
+++ b/src/enigma2/data/RecordingEntry.cpp
@@ -127,13 +127,13 @@ void RecordingEntry::UpdateTo(PVR_RECORDING &left, Channels &channels, bool isIn
 
   for (const auto& channel : channels.GetChannelsList())
   {
-    if (m_channelName == channel.GetChannelName())
+    if (m_channelName == channel->GetChannelName())
     {
       /* PVR API 5.0.0: iChannelUid in recordings */
-      left.iChannelUid = channel.GetUniqueId();
+      left.iChannelUid = channel->GetUniqueId();
 
       /* PVR API 5.1.0: Support channel type in recordings */
-      if (channel.IsRadio())
+      if (channel->IsRadio())
         left.channelType = PVR_RECORDING_CHANNEL_TYPE_RADIO;
       else
         left.channelType = PVR_RECORDING_CHANNEL_TYPE_TV;

--- a/src/enigma2/data/Timer.cpp
+++ b/src/enigma2/data/Timer.cpp
@@ -156,7 +156,7 @@ bool Timer::UpdateFrom(TiXmlElement* timerNode, Channels &channels)
     return false;
   }
 
-  m_channelName = channels.GetChannel(m_channelId).GetChannelName();  
+  m_channelName = channels.GetChannel(m_channelId)->GetChannelName();  
 
   if (!XMLUtils::GetInt(timerNode, "e2timebegin", iTmp)) 
     return false; 

--- a/src/enigma2/data/Timer.cpp
+++ b/src/enigma2/data/Timer.cpp
@@ -48,6 +48,7 @@ void Timer::UpdateFrom(const Timer &right)
   m_weekdays = right.m_weekdays;
   m_epgId = right.m_epgId;
   m_tags = right.m_tags;
+  m_state = right.m_state;
 }
 
 void Timer::UpdateTo(PVR_TIMER &left) const

--- a/src/enigma2/utilities/CurlFile.cpp
+++ b/src/enigma2/utilities/CurlFile.cpp
@@ -23,6 +23,8 @@
 
 #include <cstdarg>
 
+#include "Logger.h"
+
 using namespace enigma2::utilities;
 
 bool CurlFile::Get(const std::string &strURL, std::string &strResult)
@@ -36,5 +38,35 @@ bool CurlFile::Get(const std::string &strURL, std::string &strResult)
     XBMC->CloseFile(fileHandle);
     return true;
   }
+  return false;
+}
+
+bool CurlFile::Post(const std::string &strURL, std::string &strResult)
+{
+  void *fileHandle = XBMC->CURLCreate(strURL.c_str());
+
+  if (!fileHandle)
+  {
+    Logger::Log(LEVEL_DEBUG, "%s Unable to create curl handle for %s", __FUNCTION__, strURL.c_str());
+    return false;
+  }
+
+  XBMC->CURLAddOption(fileHandle, XFILE::CURL_OPTION_PROTOCOL, "postdata", "POST");
+
+  if (!XBMC->CURLOpen(fileHandle, XFILE::READ_NO_CACHE))
+  {
+    Logger::Log(LEVEL_DEBUG, "%s Unable to open url: %s", __FUNCTION__, strURL.c_str());
+    XBMC->CloseFile(fileHandle);
+    return false;
+  }
+
+  char buffer[1024];
+  while (XBMC->ReadFileString(fileHandle, buffer, 1024))
+    strResult.append(buffer);
+  XBMC->CloseFile(fileHandle);  
+
+  if (!strResult.empty())
+    return true;
+
   return false;
 }

--- a/src/enigma2/utilities/CurlFile.h
+++ b/src/enigma2/utilities/CurlFile.h
@@ -36,6 +36,7 @@ namespace enigma2
       ~CurlFile(void) {};
 
       bool Get(const std::string &strURL, std::string &strResult);
+      bool Post(const std::string &strURL, std::string &strResult);
     };
   }
 }

--- a/src/enigma2/utilities/DeviceSettings.h
+++ b/src/enigma2/utilities/DeviceSettings.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <regex>
+
+namespace enigma2
+{
+  namespace utilities
+  {
+    class DeviceSettings
+    {
+    public:
+      DeviceSettings() = default;
+
+      bool IsAddTagAutoTimerToTagsEnabled() const { return m_addTagAutoTimerToTagsEnabled; }
+      void SetAddTagAutoTimerToTagsEnabled(bool value) { m_addTagAutoTimerToTagsEnabled = value; }      
+
+      bool IsAddAutoTimerNameToTagsEnabled() const { return m_addAutoTimerNameToTagsEnabled; }
+      void SetAddAutoTimerNameToTagsEnabled(bool value) { m_addAutoTimerNameToTagsEnabled = value; }    
+
+      int GetGlobalRecordingStartMargin() const { return m_globalRecrordingStartMargin; }
+      void SetGlobalRecordingStartMargin(int value) { m_globalRecrordingStartMargin = value; }    
+
+      int GetGlobalRecordingEndMargin() const { return m_globalRecrordingEndMargin; }
+      void SetGlobalRecordingEndMargin(int value) { m_globalRecrordingEndMargin = value; }    
+
+    private:
+      bool m_addTagAutoTimerToTagsEnabled = false;
+      bool m_addAutoTimerNameToTagsEnabled = false;
+      int m_globalRecrordingStartMargin = 0;
+      int m_globalRecrordingEndMargin = 0;
+    };
+  } //namespace utilities
+} //namespace enigma2

--- a/src/enigma2/utilities/FileUtils.cpp
+++ b/src/enigma2/utilities/FileUtils.cpp
@@ -70,6 +70,28 @@ bool FileUtils::CopyFile(const std::string &sourceFile, const std::string &targe
   return copySuccessful;
 }
 
+bool FileUtils::WriteStringToFile(const std::string &fileContents, const std::string &targetFile)
+{
+  bool writeSuccessful = true;
+
+  Logger::Log(LEVEL_DEBUG, "%s Writing strig to file: %s", __FUNCTION__, targetFile.c_str());
+
+  void* targetFileHandle = XBMC->OpenFileForWrite(targetFile.c_str(), true);
+
+  if (targetFileHandle)
+  {
+    XBMC->WriteFile(targetFileHandle, fileContents.c_str(), fileContents.length());
+    XBMC->CloseFile(targetFileHandle);
+  }
+  else
+  {
+    Logger::Log(LEVEL_ERROR, "%s Could not open target file to write to: %s", __FUNCTION__, targetFile.c_str());
+    writeSuccessful = false;
+  }
+
+  return writeSuccessful;
+}
+
 std::string FileUtils::ReadXmlFileToString(const std::string &sourceFile)
 {
   return ReadFileToString(sourceFile) + "\n";

--- a/src/enigma2/utilities/FileUtils.h
+++ b/src/enigma2/utilities/FileUtils.h
@@ -34,6 +34,7 @@ namespace enigma2
 
       static bool FileExists(const std::string &file);
       static bool CopyFile(const std::string &sourceFile, const std::string &targetFile);
+      static bool WriteStringToFile(const std::string &fileContents, const std::string &targetFile);
       static std::string ReadFileToString(const std::string &sourceFile);
       static std::string ReadXmlFileToString(const std::string &sourceFile);
       static bool CopyDirectory(const std::string &sourceDir, const std::string &targetDir, bool recursiveCopy);

--- a/src/enigma2/utilities/WebUtils.cpp
+++ b/src/enigma2/utilities/WebUtils.cpp
@@ -106,6 +106,29 @@ std::string WebUtils::GetHttpXML(const std::string& url)
   return strTmp;
 }
 
+std::string WebUtils::PostHttpJson(const std::string& url)
+{
+  Logger::Log(LEVEL_INFO, "%s Open webAPI with URL: '%s'", __FUNCTION__, url.c_str());
+
+  std::string strTmp;
+
+  CurlFile http;
+  if(!http.Post(url, strTmp))
+  {
+    Logger::Log(LEVEL_DEBUG, "%s - Could not open webAPI.", __FUNCTION__);
+    return "";
+  }
+
+  // If there is no newline add it as it not being there will cause a parse error
+  // TODO: Remove once bug is fixed in Open WebIf
+  if (strTmp.back() != '\n')
+    strTmp += "\n";
+
+  Logger::Log(LEVEL_INFO, "%s Got result. Length: %u", __FUNCTION__, strTmp.length());
+  
+  return strTmp;
+}
+
 bool WebUtils::SendSimpleCommand(const std::string& strCommandURL, std::string& strResultText, bool bIgnoreResult)
 {
   const std::string url = StringUtils::Format("%s%s", Settings::GetInstance().GetConnectionURL().c_str(), strCommandURL.c_str()); 
@@ -154,6 +177,29 @@ bool WebUtils::SendSimpleCommand(const std::string& strCommandURL, std::string& 
 
     return bTmp;
   }
+  return true;
+}
+
+bool WebUtils::SendSimpleJsonPostCommand(const std::string& strCommandURL, std::string& strResultText, bool bIgnoreResult)
+{
+  const std::string url = StringUtils::Format("%s%s", Settings::GetInstance().GetConnectionURL().c_str(), strCommandURL.c_str()); 
+
+  std::string strJson = WebUtils::PostHttpJson(url);
+  
+  if (!bIgnoreResult)
+  {
+    if (strJson.find("true") != std::string::npos) 
+    {
+      strResultText = "Success!";
+    }
+    else
+    {
+      strResultText = StringUtils::Format("Invalid Command");
+      Logger::Log(LEVEL_ERROR, "%s Error message from backend: '%s'", __FUNCTION__, strResultText.c_str());
+      return false;
+    }
+  }
+
   return true;
 }
 

--- a/src/enigma2/utilities/WebUtils.h
+++ b/src/enigma2/utilities/WebUtils.h
@@ -33,7 +33,9 @@ namespace enigma2
 
       static std::string URLEncodeInline(const std::string &sStr);
       static std::string GetHttpXML(const std::string& url);
+      static std::string PostHttpJson(const std::string& url);
       static bool SendSimpleCommand(const std::string& strCommandURL, std::string& strResultText, bool bIgnoreResult=false);
+      static bool SendSimpleJsonPostCommand(const std::string& strCommandURL, std::string& strResultText, bool bIgnoreResult=false);
       static std::string& Escape(std::string &s, const std::string from, const std::string to);
     };
   }


### PR DESCRIPTION
v3.15.0
- Added: Support for Radio Groups
- Added: Create unique list of channels instead of a copy of each channel per group, fixes #101
- Fixed: hdd free space is wrong,  fixes #122
- Added: Device Settings - AutoTimer and Padding
- Added: PowerstateMode on exit, fixes #128
- Fixed: Store timer state on update, fixes #131
- Fixed: Updates not occuring at specified time and immediate update on timer event, fixes #130
- Added: Support different update modes for timers and recordings, fixes #125