### PR TITLE
Load config if enabled

### DIFF
--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -179,6 +179,7 @@ v3.15.2
 - Fixed: Only load Season info extractor and genre mappers config when enabled, fixes #136
 - Fixed: 3.15.1 dont load/work on old DM800se, fixes #139
 - Fixed: Missing default value from timeshift buffer path, fixes #140
+- Fixed: Channel Group Member Order not preserved, fixes #141 
 
 v3.15.1
 - Fixed: since 3.15.0 pvr manager cant start #134

--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -178,6 +178,7 @@
 v3.15.2
 - Fixed: Only load Season info extractor and genre mappers config when enabled, fixes #136
 - Fixed: 3.15.1 dont load/work on old DM800se, fixes #139
+- Fixed: Missing default value from timeshift buffer path, fixes #140
 
 v3.15.1
 - Fixed: since 3.15.0 pvr manager cant start #134

--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="3.15.1"
+  version="3.15.2"
   name="Enigma2 Client"
   provider-name="Joerg Dembski and Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>
@@ -175,6 +175,9 @@
     <disclaimer lang="zh_TW">這是測試版軟體！其原創作者並無法對於以下情況負責，包含：錄影失敗，不正確的定時設定，多餘時數，或任何產生的其它不良影響...</disclaimer>
     <platform>@PLATFORM@</platform>
     <news>
+v3.15.2
+- Fixed: Only load Season info extractor and genre mappers config when enabled, fixes #136
+
 v3.15.1
 - Fixed: since 3.15.0 pvr manager cant start #134
 - Added: Log Distro Version

--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -177,6 +177,7 @@
     <news>
 v3.15.2
 - Fixed: Only load Season info extractor and genre mappers config when enabled, fixes #136
+- Fixed: 3.15.1 dont load/work on old DM800se, fixes #139
 
 v3.15.1
 - Fixed: since 3.15.0 pvr manager cant start #134

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,3 +1,6 @@
+v3.15.2
+- Fixed: Only load Season info extractor and genre mappers config when enabled, fixes #136
+
 v3.15.1
 - Fixed: since 3.15.0 pvr manager cant start #134
 - Added: Log Distro Version

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -2,6 +2,7 @@ v3.15.2
 - Fixed: Only load Season info extractor and genre mappers config when enabled, fixes #136
 - Fixed: 3.15.1 dont load/work on old DM800se, fixes #139
 - Fixed: Missing default value from timeshift buffer path, fixes #140
+- Fixed: Channel Group Member Order not preserved, fixes #141 
 
 v3.15.1
 - Fixed: since 3.15.0 pvr manager cant start #134

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,6 +1,7 @@
 v3.15.2
 - Fixed: Only load Season info extractor and genre mappers config when enabled, fixes #136
 - Fixed: 3.15.1 dont load/work on old DM800se, fixes #139
+- Fixed: Missing default value from timeshift buffer path, fixes #140
 
 v3.15.1
 - Fixed: since 3.15.0 pvr manager cant start #134

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,5 +1,6 @@
 v3.15.2
 - Fixed: Only load Season info extractor and genre mappers config when enabled, fixes #136
+- Fixed: 3.15.1 dont load/work on old DM800se, fixes #139
 
 v3.15.1
 - Fixed: since 3.15.0 pvr manager cant start #134

--- a/pvr.vuplus/resources/settings.xml
+++ b/pvr.vuplus/resources/settings.xml
@@ -392,7 +392,7 @@
         </setting>
         <setting id="timeshiftbufferpath" type="path" parent="enabletimeshift" label="30062">
           <level>0</level>
-          <default></default>
+          <default>special://userdata/addon_data/pvr.vuplus</default>
           <constraints>
             <allowempty>true</allowempty>
             <writable>true</writable>

--- a/src/Enigma2.cpp
+++ b/src/Enigma2.cpp
@@ -299,11 +299,10 @@ bool Enigma2::OpenLiveStream(const PVR_CHANNEL &channelinfo)
       // Zapping is set to true, so send the zapping command to the PVR box
       std::string strServiceReference = m_channels.GetChannel(channelinfo.iUniqueId)->GetServiceReference().c_str();
 
-      std::string strTmp;
-      strTmp = StringUtils::Format("web/zap?sRef=%s", WebUtils::URLEncodeInline(strServiceReference).c_str());
+      std::string strCmd = StringUtils::Format("web/zap?sRef=%s", WebUtils::URLEncodeInline(strServiceReference).c_str());
 
       std::string strResult;
-      if(!WebUtils::SendSimpleCommand(strTmp, strResult))
+      if(!WebUtils::SendSimpleCommand(strCmd, strResult))
         return false;
     }
   }
@@ -340,10 +339,8 @@ const std::string Enigma2::GetLiveStreamURL(const PVR_CHANNEL &channelinfo)
   */
 std::string Enigma2::GetStreamURL(const std::string& strM3uURL)
 {
-  std::string strTmp;
-  strTmp = strM3uURL;
-  std::string strM3U;
-  strM3U = WebUtils::GetHttpXML(strTmp);
+  std::string strTmp = strM3uURL;
+  std::string strM3U = WebUtils::GetHttpXML(strTmp);
   std::istringstream streamM3U(strM3U);
   std::string strURL = "";
   while (std::getline(streamM3U, strURL))

--- a/src/enigma2/Admin.cpp
+++ b/src/enigma2/Admin.cpp
@@ -128,10 +128,13 @@ bool Admin::LoadDeviceInfo()
   // Get DistroVersion
   if (!XMLUtils::GetString(pElem, "e2distroversion", strTmp)) 
   {
-    Logger::Log(LEVEL_ERROR, "%s Could not parse e2distroversion from result!", __FUNCTION__);
-    return false;
+    Logger::Log(LEVEL_NOTICE, "%s Could not parse e2distroversion from result, continuing as not available in all images!", __FUNCTION__);
+    strTmp = LocalizedString(60081); //unknown
   }
-  distroVersion = strTmp.c_str();
+  else
+  {
+    distroVersion = strTmp.c_str();
+  }
   Logger::Log(LEVEL_NOTICE, "%s - E2DistroVersion: %s", __FUNCTION__, distroVersion.c_str());
 
   // Get WebIfVersion

--- a/src/enigma2/ChannelGroups.cpp
+++ b/src/enigma2/ChannelGroups.cpp
@@ -18,6 +18,8 @@ using namespace enigma2::utilities;
 
 void ChannelGroups::GetChannelGroups(std::vector<PVR_CHANNEL_GROUP> &kodiChannelGroups, bool radio) const
 {
+  Logger::Log(LEVEL_DEBUG, "%s - Starting to get ChannelGroups for PVR", __FUNCTION__);
+
   for (const auto& channelGroup : m_channelGroups)
   {
     Logger::Log(LEVEL_DEBUG, "%s - Transfer channelGroup '%s', ChannelGroupIndex '%d'", __FUNCTION__, channelGroup->GetGroupName().c_str(), channelGroup->GetUniqueId());
@@ -32,6 +34,8 @@ void ChannelGroups::GetChannelGroups(std::vector<PVR_CHANNEL_GROUP> &kodiChannel
       kodiChannelGroups.emplace_back(kodiChannelGroup);
     }
   }
+
+  Logger::Log(LEVEL_DEBUG, "%s - Finished getting ChannelGroups for PVR", __FUNCTION__);
 }
 
 PVR_ERROR ChannelGroups::GetChannelGroupMembers(std::vector<PVR_CHANNEL_GROUP_MEMBER> &channelGroupMembers, const std::string &groupName)
@@ -39,7 +43,15 @@ PVR_ERROR ChannelGroups::GetChannelGroupMembers(std::vector<PVR_CHANNEL_GROUP_ME
   std::shared_ptr<ChannelGroup> channelGroup = GetChannelGroup(groupName);
 
   if (!channelGroup)
+  {
+    Logger::Log(LEVEL_DEBUG, "%s - Channel Group not found, could not get ChannelGroupsMembers for PVR for group: %s", __FUNCTION__, groupName.c_str());
+
     return PVR_ERROR_NO_ERROR;
+  }
+  else
+  {
+    Logger::Log(LEVEL_DEBUG, "%s - Starting to get ChannelGroupsMembers for PVR for group: %s", __FUNCTION__, groupName.c_str());
+  }
 
   for (const auto& channel : channelGroup->GetChannelList())
   {
@@ -55,6 +67,8 @@ PVR_ERROR ChannelGroups::GetChannelGroupMembers(std::vector<PVR_CHANNEL_GROUP_ME
 
     channelGroupMembers.emplace_back(tag);
   }
+
+  Logger::Log(LEVEL_DEBUG, "%s - Finished getting ChannelGroupsMembers for PVR for group: %s", __FUNCTION__, groupName.c_str());
 
   return PVR_ERROR_NO_ERROR;
 }
@@ -151,6 +165,8 @@ bool ChannelGroups::LoadChannelGroups()
 
 bool ChannelGroups::LoadTVChannelGroups()
 {
+  int tempNumChannelGroups = m_channelGroups.size();
+
   if ((Settings::GetInstance().GetTVFavouritesMode() == FavouritesGroupMode::AS_FIRST_GROUP &&
       Settings::GetInstance().GetTVChannelGroupMode() != ChannelGroupMode::FAVOURITES_GROUP) ||
       Settings::GetInstance().GetTVChannelGroupMode() == ChannelGroupMode::FAVOURITES_GROUP)
@@ -212,12 +228,14 @@ bool ChannelGroups::LoadTVChannelGroups()
     AddTVFavouritesChannelGroup();
   }
 
-  Logger::Log(LEVEL_INFO, "%s Loaded %d TV Channelgroups", __FUNCTION__, m_channelGroups.size());
+  Logger::Log(LEVEL_INFO, "%s Loaded %d TV Channelgroups", __FUNCTION__, m_channelGroups.size() - tempNumChannelGroups);
   return true;
 }
 
 bool ChannelGroups::LoadRadioChannelGroups()
 {
+  int tempNumChannelGroups = m_channelGroups.size();
+
   if ((Settings::GetInstance().GetRadioFavouritesMode() == FavouritesGroupMode::AS_FIRST_GROUP &&
       Settings::GetInstance().GetRadioChannelGroupMode() != ChannelGroupMode::FAVOURITES_GROUP) ||
       Settings::GetInstance().GetRadioChannelGroupMode() == ChannelGroupMode::FAVOURITES_GROUP)
@@ -279,7 +297,7 @@ bool ChannelGroups::LoadRadioChannelGroups()
     AddRadioFavouritesChannelGroup();
   }
 
-  Logger::Log(LEVEL_INFO, "%s Loaded %d Radio Channelgroups", __FUNCTION__, m_channelGroups.size());
+  Logger::Log(LEVEL_INFO, "%s Loaded %d Radio Channelgroups", __FUNCTION__, m_channelGroups.size() - tempNumChannelGroups);
   return true;
 }
 

--- a/src/enigma2/ChannelGroups.cpp
+++ b/src/enigma2/ChannelGroups.cpp
@@ -53,6 +53,8 @@ PVR_ERROR ChannelGroups::GetChannelGroupMembers(std::vector<PVR_CHANNEL_GROUP_ME
     Logger::Log(LEVEL_DEBUG, "%s - Starting to get ChannelGroupsMembers for PVR for group: %s", __FUNCTION__, groupName.c_str());
   }
 
+  int channelNumberInGroup = 1;
+
   for (const auto& channel : channelGroup->GetChannelList())
   {
     PVR_CHANNEL_GROUP_MEMBER tag;
@@ -60,12 +62,14 @@ PVR_ERROR ChannelGroups::GetChannelGroupMembers(std::vector<PVR_CHANNEL_GROUP_ME
 
     strncpy(tag.strGroupName, groupName.c_str(), sizeof(tag.strGroupName));
     tag.iChannelUniqueId = channel->GetUniqueId();
-    tag.iChannelNumber   = channel->GetChannelNumber();
+    tag.iChannelNumber   = channelNumberInGroup; //Keep the channels in list order as per the groups on the STB
 
     Logger::Log(LEVEL_DEBUG, "%s - add channel %s (%d) to group '%s' channel number %d",
         __FUNCTION__, channel->GetChannelName().c_str(), tag.iChannelUniqueId, groupName.c_str(), channel->GetChannelNumber());
 
     channelGroupMembers.emplace_back(tag);
+
+    channelNumberInGroup++;
   }
 
   Logger::Log(LEVEL_DEBUG, "%s - Finished getting ChannelGroupsMembers for PVR for group: %s", __FUNCTION__, groupName.c_str());

--- a/src/enigma2/Channels.cpp
+++ b/src/enigma2/Channels.cpp
@@ -153,8 +153,7 @@ bool Channels::LoadChannels(const std::string groupServiceReference, const std::
 {
   Logger::Log(LEVEL_INFO, "%s loading channel group: '%s'", __FUNCTION__, groupName.c_str());
 
-  std::string strTmp;
-  strTmp = StringUtils::Format("%sweb/getservices?sRef=%s", Settings::GetInstance().GetConnectionURL().c_str(), WebUtils::URLEncodeInline(groupServiceReference).c_str());
+  std::string strTmp = StringUtils::Format("%sweb/getservices?sRef=%s", Settings::GetInstance().GetConnectionURL().c_str(), WebUtils::URLEncodeInline(groupServiceReference).c_str());
 
   std::string strXML = WebUtils::GetHttpXML(strTmp);  
   

--- a/src/enigma2/Recordings.cpp
+++ b/src/enigma2/Recordings.cpp
@@ -133,8 +133,7 @@ bool Recordings::LoadLocations()
 
   for (; pNode != nullptr; pNode = pNode->NextSiblingElement("e2location"))
   {
-    std::string strTmp;
-    strTmp = pNode->GetText();
+    std::string strTmp = pNode->GetText();
 
     m_locations.emplace_back(strTmp);
 
@@ -176,8 +175,7 @@ bool Recordings::GetRecordingsFromLocation(std::string recordingLocation)
     directory = recordingLocation;
   }
  
-  std::string strXML;
-  strXML = WebUtils::GetHttpXML(url);
+  std::string strXML = WebUtils::GetHttpXML(url);
 
   TiXmlDocument xmlDoc;
   if (!xmlDoc.Parse(strXML.c_str()))

--- a/src/enigma2/Timers.cpp
+++ b/src/enigma2/Timers.cpp
@@ -464,7 +464,7 @@ PVR_ERROR Timers::AddTimer(const PVR_TIMER &timer)
   startTime = timer.startTime - (timer.iMarginStart * 60);
   endTime = timer.endTime + (timer.iMarginEnd * 60);
   
-  if (!m_settings.GetRecordingPath().compare(""))
+  if (!m_settings.GetRecordingPath().empty())
     strTmp = StringUtils::Format("web/timeradd?sRef=%s&repeated=%d&begin=%d&end=%d&name=%s&description=%s&eit=%d&tags=%s&dirname=&s", 
               WebUtils::URLEncodeInline(strServiceReference).c_str(), timer.iWeekdays, startTime, endTime, 
               WebUtils::URLEncodeInline(timer.strTitle).c_str(), WebUtils::URLEncodeInline(timer.strSummary).c_str(), timer.iEpgUid, 
@@ -568,7 +568,6 @@ PVR_ERROR Timers::UpdateTimer(const PVR_TIMER &timer)
     
   Logger::Log(LEVEL_DEBUG, "%s timer channelid '%d'", __FUNCTION__, timer.iClientChannelUid);
 
-  std::string strTmp;
   std::string strServiceReference = m_channels.GetChannel(timer.iClientChannelUid)->GetServiceReference().c_str();  
 
   const auto it = std::find_if(m_timers.cbegin(), m_timers.cend(), [timer](const Timer& myTimer)
@@ -586,7 +585,7 @@ PVR_ERROR Timers::UpdateTimer(const PVR_TIMER &timer)
     if (timer.state == PVR_TIMER_STATE_CANCELLED)
       iDisabled = 1;
 
-    strTmp = StringUtils::Format("web/timerchange?sRef=%s&begin=%d&end=%d&name=%s&eventID=&description=%s&tags=%s&afterevent=3&eit=0&disabled=%d&justplay=0&repeated=%d&channelOld=%s&beginOld=%d&endOld=%d&deleteOldOnSave=1", 
+    std::string strTmp = StringUtils::Format("web/timerchange?sRef=%s&begin=%d&end=%d&name=%s&eventID=&description=%s&tags=%s&afterevent=3&eit=0&disabled=%d&justplay=0&repeated=%d&channelOld=%s&beginOld=%d&endOld=%d&deleteOldOnSave=1", 
                                     WebUtils::URLEncodeInline(strServiceReference).c_str(), timer.startTime, timer.endTime, 
                                     WebUtils::URLEncodeInline(timer.strTitle).c_str(), WebUtils::URLEncodeInline(timer.strSummary).c_str(), 
                                     WebUtils::URLEncodeInline(oldTimer.GetTags()).c_str(), iDisabled, timer.iWeekdays, 
@@ -734,14 +733,13 @@ PVR_ERROR Timers::DeleteTimer(const PVR_TIMER &timer)
   if (IsAutoTimer(timer))
     return DeleteAutoTimer(timer);
 
-  std::string strTmp;
   std::string strServiceReference = m_channels.GetChannel(timer.iClientChannelUid)->GetServiceReference().c_str();
 
   time_t startTime, endTime;
   startTime = timer.startTime - (timer.iMarginStart * 60);
   endTime = timer.endTime + (timer.iMarginEnd * 60);
   
-  strTmp = StringUtils::Format("web/timerdelete?sRef=%s&begin=%d&end=%d", WebUtils::URLEncodeInline(strServiceReference).c_str(), startTime, endTime);
+  std::string strTmp = StringUtils::Format("web/timerdelete?sRef=%s&begin=%d&end=%d", WebUtils::URLEncodeInline(strServiceReference).c_str(), startTime, endTime);
 
   std::string strResult;
   if (!WebUtils::SendSimpleCommand(strTmp, strResult)) 
@@ -766,8 +764,7 @@ PVR_ERROR Timers::DeleteAutoTimer(const PVR_TIMER &timer)
   {
     AutoTimer timerToDelete = *it;
 
-    std::string strTmp;
-    strTmp = StringUtils::Format("autotimer/remove?id=%u", timerToDelete.GetBackendId());
+    std::string strTmp = StringUtils::Format("autotimer/remove?id=%u", timerToDelete.GetBackendId());
 
     std::string strResult;
     if (!WebUtils::SendSimpleCommand(strTmp, strResult)) 

--- a/src/enigma2/data/ChannelGroup.cpp
+++ b/src/enigma2/data/ChannelGroup.cpp
@@ -30,13 +30,13 @@ bool ChannelGroup::UpdateFrom(TiXmlElement* groupNode, bool radio)
   if (!radio && Settings::GetInstance().GetTVChannelGroupMode() == ChannelGroupMode::ONLY_ONE_GROUP && 
         Settings::GetInstance().GetOneTVGroupName() != groupName)
   {
-    Logger::Log(LEVEL_DEBUG, "%s Only one TV group is set, but current e2servicename '%s' does not match requested name '%s'", __FUNCTION__, serviceReference.c_str(), Settings::GetInstance().GetOneTVGroupName().c_str());
+    Logger::Log(LEVEL_DEBUG, "%s Only one TV group is set, but current e2servicename '%s' does not match requested name '%s'", __FUNCTION__, groupName.c_str(), Settings::GetInstance().GetOneTVGroupName().c_str());
     return false;
   } 
   else if (radio && Settings::GetInstance().GetRadioChannelGroupMode() == ChannelGroupMode::ONLY_ONE_GROUP && 
             Settings::GetInstance().GetOneRadioGroupName() != groupName)
   {
-    Logger::Log(LEVEL_DEBUG, "%s Only one Radio group is set, but current e2servicename '%s' does not match requested name '%s'", __FUNCTION__, serviceReference.c_str(), Settings::GetInstance().GetOneRadioGroupName().c_str());
+    Logger::Log(LEVEL_DEBUG, "%s Only one Radio group is set, but current e2servicename '%s' does not match requested name '%s'", __FUNCTION__, groupName.c_str(), Settings::GetInstance().GetOneRadioGroupName().c_str());
     return false;
   }
 

--- a/src/enigma2/extract/EpgEntryExtractor.cpp
+++ b/src/enigma2/extract/EpgEntryExtractor.cpp
@@ -14,10 +14,14 @@ EpgEntryExtractor::EpgEntryExtractor()
   : IExtractor()
 {
   FileUtils::CopyDirectory(FileUtils::GetResourceDataPath() + GENRE_DIR, GENRE_ADDON_DATA_BASE_DIR, true);
+  FileUtils::CopyDirectory(FileUtils::GetResourceDataPath() + SHOW_INFO_DIR, SHOW_INFO_ADDON_DATA_BASE_DIR, true);
   
-  m_extractors.emplace_back(new GenreIdMapper());
-  m_extractors.emplace_back(new GenreRytecTextMapper());
-  m_extractors.emplace_back(new ShowInfoExtractor());
+  if (Settings::GetInstance().GetMapGenreIds())
+    m_extractors.emplace_back(new GenreIdMapper());
+  if (Settings::GetInstance().GetMapRytecTextGenres())
+    m_extractors.emplace_back(new GenreRytecTextMapper());
+  if (Settings::GetInstance().GetExtractShowInfo())
+    m_extractors.emplace_back(new ShowInfoExtractor());
 
   m_anyExtractorEnabled = false;
   for (auto& extractor : m_extractors)

--- a/src/enigma2/extract/EpgEntryExtractor.h
+++ b/src/enigma2/extract/EpgEntryExtractor.h
@@ -11,7 +11,10 @@ namespace enigma2
   namespace extract
   {
     static const std::string GENRE_DIR = "/genres";
-    static const std::string GENRE_ADDON_DATA_BASE_DIR = "special://userdata/addon_data/pvr.vuplus" + GENRE_DIR;
+    static const std::string ADDON_DATA_BASE_DIR = "special://userdata/addon_data/pvr.vuplus";
+    static const std::string GENRE_ADDON_DATA_BASE_DIR = ADDON_DATA_BASE_DIR + GENRE_DIR;
+    static const std::string SHOW_INFO_DIR = "/showInfo";
+    static const std::string SHOW_INFO_ADDON_DATA_BASE_DIR = ADDON_DATA_BASE_DIR + SHOW_INFO_DIR;
 
     class EpgEntryExtractor
       : public IExtractor

--- a/src/enigma2/extract/ShowInfoExtractor.cpp
+++ b/src/enigma2/extract/ShowInfoExtractor.cpp
@@ -13,8 +13,6 @@ using namespace enigma2::utilities;
 ShowInfoExtractor::ShowInfoExtractor() 
   : IExtractor()
 {
-  FileUtils::CopyDirectory(FileUtils::GetResourceDataPath() + SHOW_INFO_DIR, SHOW_INFO_ADDON_DATA_BASE_DIR, true);
-
   if (!LoadShowInfoPatternsFile(Settings::GetInstance().GetExtractShowInfoFile(), m_episodeSeasonPatterns, m_yearPatterns))
     Logger::Log(LEVEL_ERROR, "%s Could not load show info patterns file: %s", __FUNCTION__, Settings::GetInstance().GetExtractShowInfoFile().c_str());
 }

--- a/src/enigma2/extract/ShowInfoExtractor.h
+++ b/src/enigma2/extract/ShowInfoExtractor.h
@@ -10,9 +10,6 @@
 
 namespace enigma2
 {
-    static const std::string SHOW_INFO_DIR = "/showInfo";
-    static const std::string SHOW_INFO_ADDON_DATA_BASE_DIR = "special://userdata/addon_data/pvr.vuplus" + SHOW_INFO_DIR;
-
   namespace extract
   {
     // (S4E37) (S04E37) (S2 Ep3/6) (S2 Ep7)


### PR DESCRIPTION
v3.15.2
- Fixed: Only load Season info extractor and genre mappers config when enabled, fixes #136 
- Fixed: 3.15.1 dont load/work on old DM800se, fixes #139
- Fixed: Missing default value from timeshift buffer path, fixes #140
- Fixed: Channel Group Member Order not preserved, fixes #141