### PR TITLE
Playback recording fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ set(VUPLUS_HEADERS src/client.h
                    src/enigma2/utilities/UpdateState.h
                    src/enigma2/utilities/FileUtils.h
                    src/enigma2/utilities/Logger.h
+                   src/enigma2/utilities/SignalStatus.h
                    src/enigma2/utilities/Tuner.h
                    src/enigma2/utilities/WebUtils.h)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,13 @@
 
 Enigma2 is a open source TV-receiver/DVR platform which Linux-based firmware (OS images) can be loaded onto many Linux-based set-top boxes (satellite, terrestrial, cable or a combination of these) from different manufacturers.
 
-This addon leverage the OpenWebIf project: (https://github.com/E2OpenPlugins/e2openplugin-OpenWebif)
+This addon leverages the OpenWebIf project to interact with the Enigma2 device via Restful APIs: (https://github.com/E2OpenPlugins/e2openplugin-OpenWebif)
+
+**Note:** Some images do not use OpenWebIf as the default web interface. In these images some standard functionality may still work but is not guaranteed. Some features that would not function include:
+* Autotimers
+* Drive Space Reporting
+* Embedded EPG Genre IDs
+* Full Tuner Signal Support (Including Service Providers) 
 
 # Enigma2 PVR
 VuPlus PVR client addon for [Kodi] (https://kodi.tv)
@@ -43,7 +49,7 @@ Webinterface Port: This option defines the port that should be used to access th
 Within this tab general options are configured.
 
 * **Fetch picons from web interface**: Fetch the picons straight from the Enigma 2 set-top box.
-* **Use picons.eu file formate**: Assume all picons files fetched from the set-top box start with `1_1_1_` and end with `_0_0_0`
+* **Use picons.eu file format**: Assume all picons files fetched from the set-top box start with `1_1_1_` and end with `_0_0_0`
 * **Use OpenWebIf picon path**: Fetch the picon path from OpenWebIf instead of constructing from ServiceRef. Requires OpenWebIf 1.3.x or higher.
 * **Icon path**: In order to have Kodi display channel logos you have to copy the picons from your set-top box onto your OpenELEC machine. You then need to specify this path in this property.
 * **Update interval**: As the set-top box can also be used to modify timers, delete recordings etc. and the set-top box does not notify the Kodi installation, the addon needs to regularly check for updates (new channels, new/changed/deletes timers, deleted recordings, etc.) This property defines how often the addon checks for updates.

--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="3.16.0"
+  version="3.16.1"
   name="Enigma2 Client"
   provider-name="Joerg Dembski and Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>
@@ -175,6 +175,12 @@
     <disclaimer lang="zh_TW">這是測試版軟體！其原創作者並無法對於以下情況負責，包含：錄影失敗，不正確的定時設定，多餘時數，或任何產生的其它不良影響...</disclaimer>
     <platform>@PLATFORM@</platform>
     <news>
+v3.16.1
+- Fixed: Backend polled too often for Signal Quality, fixes #165
+- Fixed: SNR and Signal showing as zero in PVR info overlay, fixes #164
+- Fixed: When playing a current recording duration at end time is wrong, fixes #160
+- Fixed: Plugin won't load channels after upgrade to 3.16.0, fixes #161
+
 v3.16.0
 - Added: Tuners and SignalStatus
 - Added: Use Picon Path from OpenWebIf

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,3 +1,9 @@
+v3.16.1
+- Fixed: Backend polled too often for Signal Quality, fixes #165
+- Fixed: SNR and Signal showing as zero in PVR info overlay, fixes #164
+- Fixed: When playing a current recording duration at end time is wrong, fixes #160
+- Fixed: Plugin won't load channels after upgrade to 3.16.0, fixes #161
+
 v3.16.0
 - Added: Tuners and SignalStatus
 - Added: Use Picon Path from OpenWebIf

--- a/src/Enigma2.h
+++ b/src/Enigma2.h
@@ -39,6 +39,7 @@
 #include "enigma2/data/EpgEntry.h"
 #include "enigma2/data/RecordingEntry.h"
 #include "enigma2/extract/EpgEntryExtractor.h"
+#include "enigma2/utilities/SignalStatus.h"
 
 #include "tinyxml.h"
 #include "p8-platform/threads/threads.h"
@@ -100,6 +101,7 @@ private:
   time_t m_lastUpdateTimeSeconds;
   int m_currentChannel = -1;
   std::atomic_bool m_dueRecordingUpdate{true};
+  time_t m_lastSignalStatusUpdateSeconds;
 
   enigma2::Channels m_channels;
   enigma2::ChannelGroups m_channelGroups;
@@ -110,6 +112,7 @@ private:
   enigma2::Admin m_admin;
   enigma2::Epg m_epg = enigma2::Epg(m_channels, m_channelGroups, m_entryExtractor);
   enigma2::extract::EpgEntryExtractor m_entryExtractor;
+  enigma2::utilities::SignalStatus m_signalStatus;
 
   P8PLATFORM::CMutex m_mutex;
   P8PLATFORM::CCondition<bool> m_started;

--- a/src/Enigma2.h
+++ b/src/Enigma2.h
@@ -43,6 +43,7 @@
 #include "tinyxml.h"
 #include "p8-platform/threads/threads.h"
 
+// The windows build defines this but it breaks nlohmann/json.hpp's reference to std::snprintf
 #if defined(snprintf)
 #undef snprintf
 #endif

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -257,7 +257,8 @@ PVR_ERROR SignalStatus(PVR_SIGNAL_STATUS &signalStatus)
 
   Logger::Log(LEVEL_DEBUG, "%s Tuner Details - name: %s, status: %s", __FUNCTION__, signalStatus.strAdapterName, signalStatus.strAdapterStatus);
   Logger::Log(LEVEL_DEBUG, "%s Service Details - service: %s, provider: %s", __FUNCTION__, signalStatus.strServiceName, signalStatus.strProviderName);
-  Logger::Log(LEVEL_DEBUG, "%s Signal - snrPercent: %d, ber: %u, signal strength: %d", __FUNCTION__, signalStatus.iSNR, signalStatus.iBER, signalStatus.iSignal);
+  // For some reason the iSNR and iSignal values need to multiplied by 655!
+  Logger::Log(LEVEL_DEBUG, "%s Signal - snrPercent: %d, ber: %u, signal strength: %d", __FUNCTION__, signalStatus.iSNR / 655, signalStatus.iBER, signalStatus.iSignal / 655);
 
   return PVR_ERROR_NO_ERROR;
 }

--- a/src/enigma2/Admin.cpp
+++ b/src/enigma2/Admin.cpp
@@ -619,9 +619,10 @@ PVR_ERROR Admin::GetTunerSignal(PVR_SIGNAL_STATUS &signalStatus)
   std::regex regexReplacePercent (" %");
   std::string regexReplace = "";
 
-  signalStatus.iSNR = atoi(regex_replace(snrPercentage, regexReplacePercent, regexReplace).c_str());
+  // For some reason the iSNR and iSignal values need to multiplied by 655!
+  signalStatus.iSNR = atoi(regex_replace(snrPercentage, regexReplacePercent, regexReplace).c_str()) * 655;
   signalStatus.iBER = atol(ber.c_str());
-  signalStatus.iSignal = atoi(regex_replace(signalStrength, regexReplacePercent, regexReplace).c_str());
+  signalStatus.iSignal = atoi(regex_replace(signalStrength, regexReplacePercent, regexReplace).c_str()) * 655;
 
   if (CanUseJsonApi())
   {

--- a/src/enigma2/Admin.h
+++ b/src/enigma2/Admin.h
@@ -26,6 +26,7 @@
 
 #include "utilities/DeviceInfo.h"
 #include "utilities/DeviceSettings.h"
+#include "utilities/SignalStatus.h"
 #include "utilities/Tuner.h"
 
 #include "libXBMC_pvr.h"
@@ -49,7 +50,7 @@ namespace enigma2
     const std::string& GetImageVersion() const { return m_deviceInfo.GetImageVersion(); }
     const std::string& GetWebIfVersion() const { return m_deviceInfo.GetWebIfVersion(); }
     unsigned int GetWebIfVersionAsNum() const { return m_deviceInfo.GetWebIfVersionAsNum(); }
-    PVR_ERROR GetTunerSignal(PVR_SIGNAL_STATUS &signalStatus);
+    bool GetTunerSignal(utilities::SignalStatus &signalStatus, const std::string &serviceReference);
 
     static bool CanUseJsonApi();  
 
@@ -59,7 +60,7 @@ namespace enigma2
     bool LoadRecordingMarginSettings();
     unsigned int ParseWebIfVersion(const std::string &webIfVersion);
     long long GetKbFromString(const std::string &stringInMbGbTb) const;
-    void GetTunerDetails(PVR_SIGNAL_STATUS &signalStatus);
+    void GetTunerDetails(utilities::SignalStatus &signalStatus, const std::string &serviceReference);
 
     enigma2::utilities::DeviceInfo m_deviceInfo;
     enigma2::utilities::DeviceSettings m_deviceSettings;

--- a/src/enigma2/Channels.cpp
+++ b/src/enigma2/Channels.cpp
@@ -222,16 +222,22 @@ bool Channels::LoadChannels(const std::string groupServiceReference, const std::
 
           if (channel)
           {
-            Logger::Log(LEVEL_DEBUG, "%s For Channel %s, set provider name to %s", __FUNCTION__, jsonChannel["servicename"].get<std::string>().c_str(), jsonChannel["provider"].get<std::string>().c_str());          
-            channel->SetProviderlName(jsonChannel["provider"].get<std::string>());
+            if (!jsonChannel["provider"].empty())
+            {
+              Logger::Log(LEVEL_DEBUG, "%s For Channel %s, set provider name to %s", __FUNCTION__, jsonChannel["servicename"].get<std::string>().c_str(), jsonChannel["provider"].get<std::string>().c_str());          
+              channel->SetProviderlName(jsonChannel["provider"].get<std::string>());
+            }
 
             if (Settings::GetInstance().UseOpenWebIfPiconPath())
             {
-              std::string connectionURL = Settings::GetInstance().GetConnectionURL();
-              connectionURL = connectionURL.substr(0, connectionURL.size()-1);
-              channel->SetIconPath(StringUtils::Format("%s%s", connectionURL.c_str(), jsonChannel["picon"].get<std::string>().c_str()));
+              if (!jsonChannel["picon"].empty())
+              {
+                std::string connectionURL = Settings::GetInstance().GetConnectionURL();
+                connectionURL = connectionURL.substr(0, connectionURL.size()-1);
+                channel->SetIconPath(StringUtils::Format("%s%s", connectionURL.c_str(), jsonChannel["picon"].get<std::string>().c_str()));
 
-              Logger::Log(LEVEL_DEBUG, "%s For Channel %s, using OpenWebPiconPath: %s", __FUNCTION__, jsonChannel["servicename"].get<std::string>().c_str(), channel->GetIconPath().c_str());
+                Logger::Log(LEVEL_DEBUG, "%s For Channel %s, using OpenWebPiconPath: %s", __FUNCTION__, jsonChannel["servicename"].get<std::string>().c_str(), channel->GetIconPath().c_str());
+              }
             }
           }
         }

--- a/src/enigma2/RecordingReader.cpp
+++ b/src/enigma2/RecordingReader.cpp
@@ -18,6 +18,13 @@ RecordingReader::RecordingReader(const std::string &streamURL, std::time_t start
   (void)XBMC->CURLOpen(m_readHandle, XFILE::READ_NO_CACHE);
   m_len = XBMC->GetFileLength(m_readHandle);
   m_nextReopen = time(nullptr) + REOPEN_INTERVAL;
+
+  //If this is an ongoing recording set the duration to the eventual length of the recording
+  if (start > 0 && end > 0)
+  {
+    m_duration = static_cast<int>(end - start);
+  }
+
   Logger::Log(LEVEL_DEBUG, "RecordingReader: Started; url=%s, start=%u, end=%u, duration=%d",
       m_streamURL.c_str(), m_start, m_end, m_duration);
 }

--- a/src/enigma2/utilities/SignalStatus.h
+++ b/src/enigma2/utilities/SignalStatus.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <string>
+
+namespace enigma2
+{
+  namespace utilities
+  {
+    static const int POLL_INTERVAL_SECONDS = 10;
+
+    struct SignalStatus
+    {
+      int m_snrPercentage;
+      long m_ber;
+      int m_signalStrength;
+      std::string m_adapterName;
+      std::string m_adapterStatus;
+    };
+  } //namespace utilities
+} //namespace enigma2


### PR DESCRIPTION
v3.16.1
- Fixed: Backend polled too often for Signal Quality, fixes #165
- Fixed: SNR and Signal showing as zero in PVR info overlay, fixes #164
- Fixed: When playing a current recording duration at end time is wrong, fixes #160
- Fixed: Plugin won't load channels after upgrade to 3.16.0, fixes #161