### PR TITLE
Stream details

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ set(VUPLUS_HEADERS src/client.h
                    src/enigma2/utilities/FileUtils.h
                    src/enigma2/utilities/Logger.h
                    src/enigma2/utilities/SignalStatus.h
+                   src/enigma2/utilities/StreamStatus.h
                    src/enigma2/utilities/Tuner.h
                    src/enigma2/utilities/WebUtils.h)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,9 @@ set(DEPLIBS ${kodiplatform_LIBRARIES}
             ${p8-platform_LIBRARIES}
             ${TINYXML_LIBRARIES})
 
+addon_version(pvr.vuplus VUPLUS)
+add_definitions(-DVUPLUS_VERSION=${VUPLUS_VERSION})
+
 build_addon(pvr.vuplus VUPLUS DEPLIBS)
 
 include(CPack)

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Information on customising the extraction and mapper configs can be found in the
 * **Enable Rytec genre text mappings**: If you use Rytec XMLTV EPG data this option can be used to map the text genres to DVB standard IDs. 
 * **Rytec genre text mappings file**: The config used to map Rytec Genre Text to DVB IDs. The default file is `Rytec-UK-Ireland.xml`. 
 * **Log missing genre text mappings**: If you would like missing genre mappings to be logged so you can report them enable this option. Note: any genres found that don't have a mapping will still be extracted and sent to Kodi as strings. Currently genres are extracted by looking for text between square brackets, e.g. [TV Drama], or for major, minor genres using a dot (.) to separate [TV Drama. Soap Opera]
+* **EPG update delay per channel**: For older Enigma2 devices EPG updates can effect streaming quality (such as buffer timeouts). A delay of between 250ms and 5000ms can be introduced to improve quality. Only recommended for older devices. Choose the lowest value that avoids buffer timeouts.
 
 ### Recordings & Timers
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Within this tab more uncommon and advanced options can be configured.
     - `Wakeup, then standby` - Similar to standby but first sends a wakeup command. Can be useful if you want to ensure all streams have stopped. Note: if you use CEC this could cause your TV to wake.
 * **Custom live TV timeout (0 to use default)**: The timemout to use when trying to read live streams
 * **Stream read chunk size**: The chunk size used by Kodi for streams. Default 0 to leave it to Kodi to decide.
+* **Enable trace logging in debug mode**: Very detailed and verbose log statements will display in addition to standard debug statements
 
 ## Customising Config Files
 

--- a/README.md
+++ b/README.md
@@ -119,11 +119,13 @@ Information on customising the extraction and mapper configs can be found in the
 * **Automatic timerlist cleanup**: If this option is set then the addon will send the command to delete completed timers from the set-top box after each update interval.
 
 ### Timeshift
+Timeshifting allows you to pause live TV as well as move back and forward from your current position similar to playing back a recording. The buffer is deleted each time a channel is changed or stopped.
+
 * **Enable timeshift**: What timeshift option do you want:
     - `Disabled` - No timeshifting
     - `On Pause` - Timeshifting starts when a live stream is paused. E.g. you want to continue from where you were at after pausing.
     - `On Playback` - Timeshifting starts when a live stream is opened. E.g. You can go to any point in the stream since it was opened.
-* **Timeshift buffer path**: The path used to store the timeshoft buffer. The default is the addon data folder in userdata
+* **Timeshift buffer path**: The path used to store the timeshift buffer. The default is the `addon_data/pvr.vuplus` folder in userdata. 
 
 ### Advanced
 Within this tab more uncommon and advanced options can be configured.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This addon leverages the OpenWebIf project to interact with the Enigma2 device v
 * Full Tuner Signal Support (Including Service Providers) 
 
 # Enigma2 PVR
-VuPlus PVR client addon for [Kodi] (https://kodi.tv)
+VuPlus PVR client addon for [Kodi](https://kodi.tv)
 
 ## Build instructions
 
@@ -24,10 +24,19 @@ VuPlus PVR client addon for [Kodi] (https://kodi.tv)
 4. `cmake -DADDONS_TO_BUILD=pvr.vuplus -DADDON_SRC_PREFIX=../.. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../../xbmc/addons -DPACKAGE_ZIP=1 ../../xbmc/cmake/addons`
 5. `make`
 
-##### Useful links
+## Support 
 
-* [Kodi's PVR user support] (https://forum.kodi.tv/forumdisplay.php?fid=167)
-* [Kodi's PVR development support] (https://forum.kodi.tv/forumdisplay.php?fid=136)
+### Useful links
+
+* [Kodi's PVR user support forum](https://forum.kodi.tv/forumdisplay.php?fid=167)
+* [Report an issue on Github](https://github.com/kodi-pvr/pvr.vuplus/issues)
+* [Kodi's PVR development support forum](https://forum.kodi.tv/forumdisplay.php?fid=136)
+
+### Logging
+
+When reporting issues a debug log should always be supplied. You can use the following guide: [Easy way to submit Kodi debug logs](https://kodi.wiki/view/Log_file/Easy)
+
+For more detailed info on logging please see the appendix [here](#logging-detailed)
 
 ## Configuring the addon
 
@@ -171,3 +180,67 @@ The following files are currently available with the addon:
     - `Rytec-UK-Ireland.xml`
 
 Note: the config file can contain as many mappings as is required. Currently genres are extracted by looking for text between square brackets, e.g. [TV Drama], or for major, minor genres using a dot (.) to separate [TV Drama. Soap Opera]. The config file maps the text to a kodi DVB genre ID. If the full text cannot be matched it attempts to match just the major genre, i.e. "TV Drama" in the previous example. If a mapping cannot be found the text between the brackets will be used instead. However there will be no colouring in the Kodi EPG in this case.
+
+## Appendix
+
+### Logging detailed
+
+Some of the most useful information in your log are the details output at the start of the log, both for Kodi and the addon.
+
+The first 5 lines of the log give details on the exact kodi flavour and version you are running:
+
+```
+01:10:45.744 T:140736264741760  NOTICE: -----------------------------------------------------------------------
+01:10:45.744 T:140736264741760  NOTICE: Starting Kodi (18.0-BETA2 Git:20180903-5d7e1dbd9c-dirty). Platform: OS X x86 64-bit
+01:10:45.744 T:140736264741760  NOTICE: Using Debug Kodi x64 build
+01:10:45.744 T:140736264741760  NOTICE: Kodi compiled Sep  5 2018 by Clang 9.1.0 (clang-902.0.39.2) for OS X x86 64-bit version 10.9.0 (1090)
+01:10:45.745 T:140736264741760  NOTICE: Running on Apple Inc. MacBook10,1 with OS X 10.13.6, kernel: Darwin x86 64-bit version 17.7.0
+```
+
+Secondly all the information of the Enigma2 image, web interface version etc. is also output:
+
+```
+12:36:55.888 T:123145422725120  NOTICE: AddOnLog: Enigma2 Client: pvr.vuplus - Open - VU+ Addon Configuration options
+12:36:55.888 T:123145422725120  NOTICE: AddOnLog: Enigma2 Client: pvr.vuplus - Open - Hostname: '192.168.1.201'
+12:36:55.888 T:123145422725120  NOTICE: AddOnLog: Enigma2 Client: pvr.vuplus - Open - WebPort: '80'
+12:36:55.888 T:123145422725120  NOTICE: AddOnLog: Enigma2 Client: pvr.vuplus - Open - StreamPort: '8001'
+12:36:55.888 T:123145422725120  NOTICE: AddOnLog: Enigma2 Client: pvr.vuplus - Open Use HTTPS: 'false'
+12:36:56.308 T:123145422725120  NOTICE: AddOnLog: Enigma2 Client: pvr.vuplus - LoadDeviceInfo - DeviceInfo
+12:36:56.308 T:123145422725120  NOTICE: AddOnLog: Enigma2 Client: pvr.vuplus - LoadDeviceInfo - E2EnigmaVersion: 2019-01-03
+12:36:56.308 T:123145422725120  NOTICE: AddOnLog: Enigma2 Client: pvr.vuplus - LoadDeviceInfo - E2ImageVersion: 5.2.022
+12:36:56.309 T:123145422725120  NOTICE: AddOnLog: Enigma2 Client: pvr.vuplus - LoadDeviceInfo - E2DistroVersion: openvix
+12:36:56.309 T:123145422725120  NOTICE: AddOnLog: Enigma2 Client: pvr.vuplus - LoadDeviceInfo - E2WebIfVersion: OWIF 1.3.5
+12:36:56.309 T:123145422725120  NOTICE: AddOnLog: Enigma2 Client: pvr.vuplus - LoadDeviceInfo - E2DeviceName: Ultimo4K
+```
+
+#### Description of Log levels
+
+* **Error**: Something that will require intervention to resolve
+* **Notice**: Could be an important piece of information or a warning that something has occurred that might be undesirable but has not affected normal operation
+* **Info**: Some information on normal operation
+* **Debug**: More detailed information that can aid in diagnosing issues.
+* **Trace**: Extremely verbose logging, should rarely be required. Note: can only be enabled from the addon settings in the ```Advanced``` section.
+
+#### Cleaning up the log
+
+(If you have a fresh install of version 3.15.0 or later you can ignore this)
+
+As the addon was upgraded over time some old settings are no longer required. These old settings can create a lot of extra logging on startup. To date there are four of these and they will present like this in your log:
+
+```
+23:17:22.696 T:3990016880   DEBUG: CSettingsManager: requested setting (extracteventinfo) was not found.
+23:17:22.696 T:3990016880   DEBUG: CAddonSettings[pvr.vuplus]: failed to find definition for setting extracteventinfo. Creating a setting on-the-fly...
+23:17:22.696 T:3990016880   DEBUG: CSettingsManager: requested setting (onegroup) was not found.
+23:17:22.696 T:3990016880   DEBUG: CAddonSettings[pvr.vuplus]: failed to find definition for setting onegroup. Creating a setting on-the-fly...
+23:17:22.696 T:3990016880   DEBUG: CSettingsManager: requested setting (onlyonegroup) was not found.
+23:17:22.696 T:3990016880   DEBUG: CAddonSettings[pvr.vuplus]: failed to find definition for setting onlyonegroup. Creating a setting on-the-fly...
+23:17:22.697 T:3990016880   DEBUG: CSettingsManager: requested setting (setpowerstate) was not found.
+23:17:22.697 T:3990016880   DEBUG: CAddonSettings[pvr.vuplus]: failed to find definition for setting setpowerstate. Creating a setting on-the-fly...
+```
+
+If you see these in debug mode and would like to clean them up you can either: 
+
+1. Remove the offending lines from you settings.xml file OR
+2. Delete you settings.xml and restart kodi. Note that if you use this option you will need to reconfigure the addon from scratch.
+
+Your settings.xml file can be found here: ```userdata/addon_data/pvr.vuplus/settings.xml```

--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -175,6 +175,16 @@
     <disclaimer lang="zh_TW">這是測試版軟體！其原創作者並無法對於以下情況負責，包含：錄影失敗，不正確的定時設定，多餘時數，或任何產生的其它不良影響...</disclaimer>
     <platform>@PLATFORM@</platform>
     <news>
+v3.16.2
+- Fixed: Seg fault on shutdown - Timer Updates thread accessing released object, fixes #172
+- Fixed: Incorrectly used time_t instead int64 in GetStreamTimes, fixes #171
+- Added: Load Addon Version
+- Fixed: Clean up/partition addon debug log, fixes #159
+- Added: Add user defined delay between EPG Channel Updates, fixes #158
+- Added: Enable Trace Logging in debug mode
+- Added: Integrate Stream API details with Tuners
+- Fixed: JSON API requires version 1.3.5+ of OpenWebIf, fixes #169
+
 v3.16.1
 - Fixed: Backend polled too often for Signal Quality, fixes #165
 - Fixed: SNR and Signal showing as zero in PVR info overlay, fixes #164

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,3 +1,13 @@
+v3.16.2
+- Fixed: Seg fault on shutdown - Timer Updates thread accessing released object, fixes #172
+- Fixed: Incorrectly used time_t instead int64 in GetStreamTimes, fixes #171
+- Added: Load Addon Version
+- Fixed: Clean up/partition addon debug log, fixes #159
+- Added: Add user defined delay between EPG Channel Updates, fixes #158
+- Added: Enable Trace Logging in debug mode
+- Added: Integrate Stream API details with Tuners
+- Fixed: JSON API requires version 1.3.5+ of OpenWebIf, fixes #169
+
 v3.16.1
 - Fixed: Backend polled too often for Signal Quality, fixes #165
 - Fixed: SNR and Signal showing as zero in PVR info overlay, fixes #164

--- a/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
@@ -432,7 +432,11 @@ msgctxt "#30103"
 msgid "Use OpenWebIf picon path"
 msgstr ""
 
-#empty strings from id 30104 to 30409
+msgctxt "#30104"
+msgid "Enable trace logging in debug mode"
+msgstr ""
+
+#empty strings from id 30105 to 30409
 
 msgctxt "#30410"
 msgid "Automatic"

--- a/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
@@ -436,7 +436,15 @@ msgctxt "#30104"
 msgid "Enable trace logging in debug mode"
 msgstr ""
 
-#empty strings from id 30105 to 30409
+msgctxt "#30105"
+msgid "Other"
+msgstr ""
+
+msgctxt "#30106"
+msgid "EPG update delay per channel"
+msgstr ""
+
+#empty strings from id 30107 to 30409
 
 msgctxt "#30410"
 msgid "Automatic"

--- a/pvr.vuplus/resources/settings.xml
+++ b/pvr.vuplus/resources/settings.xml
@@ -467,6 +467,11 @@
             <formatlabel>14049</formatlabel>
           </control>
         </setting>
+        <setting id="tracedebug" type="boolean" label="30104">
+          <level>0</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
       </group>
     </category>
 

--- a/pvr.vuplus/resources/settings.xml
+++ b/pvr.vuplus/resources/settings.xml
@@ -266,7 +266,7 @@
             <writable>false</writable>
           </constraints>
           <dependencies>
-            <dependency type="enable" setting="extractshowinfoenabled">true</dependency>
+            <dependency type="visible" setting="extractshowinfoenabled" operator="is">true</dependency>
           </dependencies>
           <control type="button" format="file">
             <heading>1033</heading>
@@ -287,7 +287,7 @@
             <writable>false</writable>
           </constraints>
           <dependencies>
-            <dependency type="enable" setting="genreidmapenabled">true</dependency>
+            <dependency type="visible" setting="genreidmapenabled" operator="is">true</dependency>
           </dependencies>
           <control type="button" format="file">
             <heading>1033</heading>
@@ -308,7 +308,7 @@
             <writable>false</writable>
           </constraints>
           <dependencies>
-            <dependency type="enable" setting="rytecgenretextmapenabled">true</dependency>
+            <dependency type="visible" setting="rytecgenretextmapenabled" operator="is">true</dependency>
           </dependencies>
           <control type="button" format="file">
             <heading>1033</heading>
@@ -318,9 +318,24 @@
           <level>0</level>
           <default>false</default>
           <dependencies>
-            <dependency type="enable" setting="rytecgenretextmapenabled">true</dependency>
+            <dependency type="visible" setting="rytecgenretextmapenabled" operator="is">true</dependency>
           </dependencies>
           <control type="toggle" />
+        </setting>
+      </group>
+      <group id="4" label="30105">
+        <setting id="epgdelayperchannel" type="integer" label="30106">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>250</step>
+            <maximum>5000</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>true</popup>
+            <formatlabel>14046</formatlabel>
+          </control>
         </setting>
       </group>
     </category>

--- a/pvr.vuplus/resources/settings.xml
+++ b/pvr.vuplus/resources/settings.xml
@@ -92,7 +92,7 @@
           <default>true</default>
           <control type="toggle" />
         </setting>
-        <setting id="usepiconseuformat" type="boolean" parent="onlinepicons" label="30035">
+        <setting id="useopenwebifpiconpath" type="boolean" parent="onlinepicons" label="30103">
           <level>0</level>
           <default>false</default>
           <dependencies>
@@ -100,12 +100,9 @@
           </dependencies>
           <control type="toggle" />
         </setting>
-        <setting id="useopenwebifpiconpath" type="boolean" parent="onlinepicons" label="30103">
+        <setting id="usepiconseuformat" type="boolean" label="30035">
           <level>0</level>
           <default>false</default>
-          <dependencies>
-            <dependency type="enable" setting="onlinepicons">true</dependency>
-          </dependencies>
           <control type="toggle" />
         </setting>
         <setting id="iconpath" type="path" label="30008">

--- a/src/Enigma2.cpp
+++ b/src/Enigma2.cpp
@@ -170,20 +170,24 @@ void *Enigma2::Process()
     if (m_dueRecordingUpdate || m_updateTimer >= (m_settings.GetUpdateIntervalMins() * 60)) 
     {
       m_updateTimer = 0;
- 
+
       // Trigger Timer and Recording updates acording to the addon settings
       CLockObject lock(m_mutex);
-      Logger::Log(LEVEL_INFO, "%s Perform Updates!", __FUNCTION__);
-
-      if (m_settings.GetAutoTimerListCleanupEnabled()) 
+      // We need to check this again in case StopThread is called (in destroying Enigma2) during the sleep, otherwise TimerUpdates could be called after the object is released
+      if (!IsStopped()) 
       {
-        m_timers.RunAutoTimerListCleanup();
+        Logger::Log(LEVEL_INFO, "%s Perform Updates!", __FUNCTION__);
+
+        if (m_settings.GetAutoTimerListCleanupEnabled()) 
+        {
+          m_timers.RunAutoTimerListCleanup();
+        }
+        m_timers.TimerUpdates();
+
+        m_dueRecordingUpdate = false;
+
+        PVR->TriggerRecordingUpdate();
       }
-      m_timers.TimerUpdates();
-
-      m_dueRecordingUpdate = false;
-
-      PVR->TriggerRecordingUpdate();
     }
   }
 

--- a/src/Enigma2.cpp
+++ b/src/Enigma2.cpp
@@ -288,6 +288,9 @@ PVR_ERROR Enigma2::GetChannels(ADDON_HANDLE handle, bool bRadio)
 
 PVR_ERROR Enigma2::GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL &channel, time_t iStart, time_t iEnd)
 {
+  if (m_epg.IsInitialEpgCompleted() && m_settings.GetEPGDelayPerChannelDelay() != 0)
+    Sleep(m_settings.GetEPGDelayPerChannelDelay());
+
   return m_epg.GetEPGForChannel(handle, channel, iStart, iEnd);
 }
 

--- a/src/Enigma2.cpp
+++ b/src/Enigma2.cpp
@@ -35,7 +35,6 @@
 #include "enigma2/utilities/Logger.h"
 #include "enigma2/utilities/WebUtils.h"
 
-
 #include "util/XMLUtils.h"
 #include <p8-platform/util/StringUtils.h>
 

--- a/src/Enigma2.cpp
+++ b/src/Enigma2.cpp
@@ -490,7 +490,7 @@ PVR_ERROR Enigma2::GetTunerSignal(PVR_SIGNAL_STATUS &signalStatus)
     {
       Logger::Log(LEVEL_DEBUG, "%s - Calling backend for Signal Status after interval of %d seconds", __FUNCTION__, POLL_INTERVAL_SECONDS);
 
-      if (!m_admin.GetTunerSignal(m_signalStatus, channel->GetServiceReference()))
+      if (!m_admin.GetTunerSignal(m_signalStatus, channel))
       {
         return PVR_ERROR_SERVER_ERROR;
       }

--- a/src/Enigma2.cpp
+++ b/src/Enigma2.cpp
@@ -429,7 +429,7 @@ void Enigma2::GetTimerTypes(PVR_TIMER_TYPE types[], int *size)
   for (auto &timerType : timerTypes)
     types[i++] = timerType;
   *size = timerTypes.size();
-  Logger::Log(LEVEL_NOTICE, "Transfered %u timer types", *size);
+  Logger::Log(LEVEL_NOTICE, "%s Transfered %u timer types", __FUNCTION__, *size);
 }
 
 int Enigma2::GetTimersAmount()

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -419,6 +419,8 @@ PVR_ERROR GetStreamTimes(PVR_STREAM_TIMES *times)
     times->ptsEnd = (!streamReader->IsTimeshifting()) ? 0
       : (streamReader->TimeEnd() - streamReader->TimeStart()) * DVD_TIME_BASE;
     
+    Logger::Log(LEVEL_DEBUG, "%s Live StartTime: %ld, ptsStart: %ld, ptsBegin: %ld, ptsEnd: %ld", __FUNCTION__, times->startTime, times->ptsStart, times->ptsBegin, times->ptsEnd);
+
     return PVR_ERROR_NO_ERROR;
   }  
   else if (recordingReader)
@@ -427,6 +429,8 @@ PVR_ERROR GetStreamTimes(PVR_STREAM_TIMES *times)
     times->ptsStart = 0;
     times->ptsBegin = 0;
     times->ptsEnd = static_cast<std::time_t>(recordingReader->CurrentDuration()) * DVD_TIME_BASE;
+
+    Logger::Log(LEVEL_DEBUG, "%s Playback StartTime: %ld, ptsStart: %ld, ptsBegin: %ld, ptsEnd: %ld", __FUNCTION__, times->startTime, times->ptsStart, times->ptsBegin, times->ptsEnd);
 
     return PVR_ERROR_NO_ERROR;
   }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -419,8 +419,6 @@ PVR_ERROR GetStreamTimes(PVR_STREAM_TIMES *times)
     times->ptsEnd = (!streamReader->IsTimeshifting()) ? 0
       : (streamReader->TimeEnd() - streamReader->TimeStart()) * DVD_TIME_BASE;
     
-    Logger::Log(LEVEL_DEBUG, "%s Live StartTime: %ld, ptsStart: %ld, ptsBegin: %ld, ptsEnd: %ld", __FUNCTION__, times->startTime, times->ptsStart, times->ptsBegin, times->ptsEnd);
-
     return PVR_ERROR_NO_ERROR;
   }  
   else if (recordingReader)
@@ -428,9 +426,7 @@ PVR_ERROR GetStreamTimes(PVR_STREAM_TIMES *times)
     times->startTime = 0;
     times->ptsStart = 0;
     times->ptsBegin = 0;
-    times->ptsEnd = static_cast<std::time_t>(recordingReader->CurrentDuration()) * DVD_TIME_BASE;
-
-    Logger::Log(LEVEL_DEBUG, "%s Playback StartTime: %ld, ptsStart: %ld, ptsBegin: %ld, ptsEnd: %ld", __FUNCTION__, times->startTime, times->ptsStart, times->ptsBegin, times->ptsEnd);
+    times->ptsEnd = static_cast<int64_t>(recordingReader->CurrentDuration()) * DVD_TIME_BASE;
 
     return PVR_ERROR_NO_ERROR;
   }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -106,8 +106,8 @@ ADDON_STATUS ADDON_Create(void* hdl, void* props)
     }
 
     /* Don't log trace messages unless told so */
-    //if (level == LogLevel::LEVEL_TRACE && !Settings::GetInstance().GetTraceDebug())
-      //return;
+    if (level == LogLevel::LEVEL_TRACE && !Settings::GetInstance().GetTraceDebug())
+      return;
 
     XBMC->Log(addonLevel, "%s", message);
   });

--- a/src/client.h
+++ b/src/client.h
@@ -24,8 +24,8 @@
 #include "libXBMC_addon.h"
 #include "libXBMC_pvr.h"
 
-extern ADDON::CHelper_libXBMC_addon *   XBMC;
-extern CHelper_libXBMC_pvr *     PVR;
+extern ADDON::CHelper_libXBMC_addon *XBMC;
+extern CHelper_libXBMC_pvr *PVR;
 
 /*!
  * @brief PVR macros for string exchange

--- a/src/enigma2/Admin.cpp
+++ b/src/enigma2/Admin.cpp
@@ -633,7 +633,7 @@ bool Admin::GetTunerSignal(SignalStatus &signalStatus, const std::string &servic
 
 bool Admin::CanUseJsonApi()
 {
-  return Settings::GetInstance().GetWebIfVersionAsNum() >= Settings::GetInstance().GenerateWebIfVersionAsNum(1, 3, 0) && StringUtils::StartsWith(Settings::GetInstance().GetWebIfVersion(), "OWIF");
+  return Settings::GetInstance().GetWebIfVersionAsNum() >= Settings::GetInstance().GenerateWebIfVersionAsNum(1, 3, 5) && StringUtils::StartsWith(Settings::GetInstance().GetWebIfVersion(), "OWIF");
 }
 
 void Admin::GetTunerDetails(SignalStatus &signalStatus, const std::string &serviceReference)

--- a/src/enigma2/Admin.cpp
+++ b/src/enigma2/Admin.cpp
@@ -671,6 +671,6 @@ void Admin::GetTunerDetails(SignalStatus &signalStatus, const std::string &servi
   }
   catch (nlohmann::detail::parse_error)
   {
-    Logger::Log(LEVEL_DEBUG, "%s Invalid JSON received, cannot load extra tunerdetails from OpenWebIf", __FUNCTION__);
+    Logger::Log(LEVEL_DEBUG, "%s Invalid JSON received, cannot load extra tuner details from OpenWebIf", __FUNCTION__);
   }
 }

--- a/src/enigma2/Admin.cpp
+++ b/src/enigma2/Admin.cpp
@@ -161,6 +161,8 @@ bool Admin::LoadDeviceInfo()
 
   m_deviceInfo = DeviceInfo(serverName, enigmaVersion, imageVersion, distroVersion, webIfVersion, webIfVersionAsNum);
 
+  Logger::Log(LEVEL_NOTICE, "%s - AddonVersion: %s", __FUNCTION__, m_addonVersion.c_str());
+
   hRoot = TiXmlHandle(pElem);
 
   TiXmlElement* pNode = hRoot.FirstChildElement("e2frontends").Element();

--- a/src/enigma2/Admin.cpp
+++ b/src/enigma2/Admin.cpp
@@ -82,7 +82,7 @@ bool Admin::LoadDeviceInfo()
   TiXmlDocument xmlDoc;
   if (!xmlDoc.Parse(strXML.c_str()))
   {
-    Logger::Log(LEVEL_DEBUG, "Unable to parse XML: %s at line %d", xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
+    Logger::Log(LEVEL_ERROR, "%s Unable to parse XML: %s at line %d", __FUNCTION__, xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
     return false;
   }
 
@@ -190,12 +190,12 @@ bool Admin::LoadDeviceInfo()
     }  
     else
     {
-      Logger::Log(LEVEL_DEBUG, "Could not find <e2frontend> element");
+      Logger::Log(LEVEL_DEBUG, "%s Could not find <e2frontend> element", __FUNCTION__);
     }
   }
   else
   {
-    Logger::Log(LEVEL_DEBUG, "Could not find <e2frontends> element");
+    Logger::Log(LEVEL_DEBUG, "%s Could not find <e2frontends> element", __FUNCTION__);
   }
 
   return true;
@@ -291,7 +291,7 @@ bool Admin::LoadAutoTimerSettings()
   TiXmlDocument xmlDoc;
   if (!xmlDoc.Parse(strXML.c_str()))
   {
-    Logger::Log(LEVEL_DEBUG, "Unable to parse XML: %s at line %d", xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
+    Logger::Log(LEVEL_ERROR, "%s Unable to parse XML: %s at line %d", __FUNCTION__, xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
     return false;
   }
 
@@ -311,7 +311,7 @@ bool Admin::LoadAutoTimerSettings()
 
   if (!pNode)
   {
-    Logger::Log(LEVEL_DEBUG, "Could not find <e2setting> element");
+    Logger::Log(LEVEL_ERROR, "%s Could not find <e2setting> element", __FUNCTION__);
     return false;
   }
 
@@ -356,7 +356,7 @@ bool Admin::LoadRecordingMarginSettings()
   TiXmlDocument xmlDoc;
   if (!xmlDoc.Parse(strXML.c_str()))
   {
-    Logger::Log(LEVEL_ERROR, "Unable to parse XML: %s at line %d", xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
+    Logger::Log(LEVEL_ERROR, "%s Unable to parse XML: %s at line %d", __FUNCTION__, xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
     return false;
   }
 
@@ -366,7 +366,7 @@ bool Admin::LoadRecordingMarginSettings()
 
   if (!pElem)
   {
-    Logger::Log(LEVEL_DEBUG, "%s Could not find <e2settings> element!", __FUNCTION__);
+    Logger::Log(LEVEL_ERROR, "%s Could not find <e2settings> element!", __FUNCTION__);
     return false;
   }
 
@@ -376,7 +376,7 @@ bool Admin::LoadRecordingMarginSettings()
 
   if (!pNode)
   {
-    Logger::Log(LEVEL_DEBUG, "Could not find <e2setting> element");
+    Logger::Log(LEVEL_ERROR, "%s Could not find <e2setting> element", __FUNCTION__);
     return false;
   }
 
@@ -473,7 +473,7 @@ PVR_ERROR Admin::GetDriveSpace(long long *iTotal, long long *iUsed, std::vector<
   TiXmlDocument xmlDoc;
   if (!xmlDoc.Parse(strXML.c_str()))
   {
-    Logger::Log(LEVEL_DEBUG, "Unable to parse XML: %s at line %d", xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
+    Logger::Log(LEVEL_ERROR, "%s Unable to parse XML: %s at line %d", __FUNCTION__, xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
     return PVR_ERROR_SERVER_ERROR;
   }
 
@@ -493,7 +493,7 @@ PVR_ERROR Admin::GetDriveSpace(long long *iTotal, long long *iUsed, std::vector<
 
   if (!pNode)
   {
-    Logger::Log(LEVEL_DEBUG, "Could not find <e2hdds> element");
+    Logger::Log(LEVEL_ERROR, "%s Could not find <e2hdds> element", __FUNCTION__);
     return PVR_ERROR_SERVER_ERROR;
   }
 
@@ -501,7 +501,7 @@ PVR_ERROR Admin::GetDriveSpace(long long *iTotal, long long *iUsed, std::vector<
 
   if (!hddNode)
   {
-    Logger::Log(LEVEL_DEBUG, "Could not find <e2hdd> element");
+    Logger::Log(LEVEL_ERROR, "%s Could not find <e2hdd> element", __FUNCTION__);
     return PVR_ERROR_SERVER_ERROR;
   }
 
@@ -531,7 +531,7 @@ PVR_ERROR Admin::GetDriveSpace(long long *iTotal, long long *iUsed, std::vector<
   *iTotal = totalKb;
   *iUsed = totalKb - freeKb;
 
-  Logger::Log(LEVEL_INFO, "GetDriveSpace Total: %lld, Used %lld", *iTotal, *iUsed);
+  Logger::Log(LEVEL_INFO, "%s Space Total: %lld, Used %lld", __FUNCTION__, *iTotal, *iUsed);
 
   return PVR_ERROR_NO_ERROR;
 }
@@ -572,7 +572,7 @@ bool Admin::GetTunerSignal(SignalStatus &signalStatus, const std::shared_ptr<dat
   TiXmlDocument xmlDoc;
   if (!xmlDoc.Parse(strXML.c_str()))
   {
-    Logger::Log(LEVEL_ERROR, "Unable to parse XML: %s at line %d", xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
+    Logger::Log(LEVEL_ERROR, "%s Unable to parse XML: %s at line %d", __FUNCTION__, xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
     return false;
   }
 
@@ -698,7 +698,7 @@ StreamStatus Admin::GetStreamDetails(const std::shared_ptr<data::Channel> &chann
   }
   catch (nlohmann::detail::parse_error)
   {
-    Logger::Log(LEVEL_DEBUG, "%s Invalid JSON received, cannot load extra stream details from OpenWebIf", __FUNCTION__);
+    Logger::Log(LEVEL_ERROR, "%s Invalid JSON received, cannot load extra stream details from OpenWebIf", __FUNCTION__);
   }
 
   return streamStatus;
@@ -739,6 +739,6 @@ void Admin::GetTunerDetails(SignalStatus &signalStatus, const std::shared_ptr<da
   }
   catch (nlohmann::detail::parse_error)
   {
-    Logger::Log(LEVEL_DEBUG, "%s Invalid JSON received, cannot load extra tuner details from OpenWebIf", __FUNCTION__);
+    Logger::Log(LEVEL_ERROR, "%s Invalid JSON received, cannot load extra tuner details from OpenWebIf", __FUNCTION__);
   }
 }

--- a/src/enigma2/Admin.cpp
+++ b/src/enigma2/Admin.cpp
@@ -627,7 +627,8 @@ bool Admin::GetTunerSignal(SignalStatus &signalStatus, const std::shared_ptr<dat
 
   if (CanUseJsonApi())
   {
-    StreamStatus streamStatus = GetStreamDetails(channel);
+    //TODO: Cross reference against tuners once OpenWebIf API is updated. 
+    //StreamStatus streamStatus = GetStreamDetails(channel);
     GetTunerDetails(signalStatus, channel);
   }
 

--- a/src/enigma2/Admin.h
+++ b/src/enigma2/Admin.h
@@ -35,10 +35,11 @@
 
 namespace enigma2
 {
-
   class Admin
   {
   public:
+    Admin() : m_addonVersion(STR(VUPLUS_VERSION)) {};
+
     void SendPowerstate();
     bool Initialise();
     bool LoadDeviceSettings();
@@ -52,6 +53,7 @@ namespace enigma2
     const std::string& GetImageVersion() const { return m_deviceInfo.GetImageVersion(); }
     const std::string& GetWebIfVersion() const { return m_deviceInfo.GetWebIfVersion(); }
     unsigned int GetWebIfVersionAsNum() const { return m_deviceInfo.GetWebIfVersionAsNum(); }
+    const std::string& GetAddonVersion() const { return m_addonVersion; }
     bool GetTunerSignal(utilities::SignalStatus &signalStatus, const std::shared_ptr<data::Channel> &channel);
 
     static bool CanUseJsonApi();  
@@ -65,6 +67,7 @@ namespace enigma2
     utilities::StreamStatus GetStreamDetails(const std::shared_ptr<data::Channel> &channel);
     void GetTunerDetails(utilities::SignalStatus &signalStatus, const std::shared_ptr<data::Channel> &channel);
 
+    const std::string m_addonVersion;
     enigma2::utilities::DeviceInfo m_deviceInfo;
     enigma2::utilities::DeviceSettings m_deviceSettings;
     std::vector<enigma2::utilities::Tuner> m_tuners;

--- a/src/enigma2/Admin.h
+++ b/src/enigma2/Admin.h
@@ -24,9 +24,11 @@
 #include <string>
 #include <vector>
 
+#include "data/Channel.h"
 #include "utilities/DeviceInfo.h"
 #include "utilities/DeviceSettings.h"
 #include "utilities/SignalStatus.h"
+#include "utilities/StreamStatus.h"
 #include "utilities/Tuner.h"
 
 #include "libXBMC_pvr.h"
@@ -50,7 +52,7 @@ namespace enigma2
     const std::string& GetImageVersion() const { return m_deviceInfo.GetImageVersion(); }
     const std::string& GetWebIfVersion() const { return m_deviceInfo.GetWebIfVersion(); }
     unsigned int GetWebIfVersionAsNum() const { return m_deviceInfo.GetWebIfVersionAsNum(); }
-    bool GetTunerSignal(utilities::SignalStatus &signalStatus, const std::string &serviceReference);
+    bool GetTunerSignal(utilities::SignalStatus &signalStatus, const std::shared_ptr<data::Channel> &channel);
 
     static bool CanUseJsonApi();  
 
@@ -60,7 +62,8 @@ namespace enigma2
     bool LoadRecordingMarginSettings();
     unsigned int ParseWebIfVersion(const std::string &webIfVersion);
     long long GetKbFromString(const std::string &stringInMbGbTb) const;
-    void GetTunerDetails(utilities::SignalStatus &signalStatus, const std::string &serviceReference);
+    utilities::StreamStatus GetStreamDetails(const std::shared_ptr<data::Channel> &channel);
+    void GetTunerDetails(utilities::SignalStatus &signalStatus, const std::shared_ptr<data::Channel> &channel);
 
     enigma2::utilities::DeviceInfo m_deviceInfo;
     enigma2::utilities::DeviceSettings m_deviceSettings;

--- a/src/enigma2/ChannelGroups.cpp
+++ b/src/enigma2/ChannelGroups.cpp
@@ -44,7 +44,7 @@ PVR_ERROR ChannelGroups::GetChannelGroupMembers(std::vector<PVR_CHANNEL_GROUP_ME
 
   if (!channelGroup)
   {
-    Logger::Log(LEVEL_DEBUG, "%s - Channel Group not found, could not get ChannelGroupsMembers for PVR for group: %s", __FUNCTION__, groupName.c_str());
+    Logger::Log(LEVEL_NOTICE, "%s - Channel Group not found, could not get ChannelGroupsMembers for PVR for group: %s", __FUNCTION__, groupName.c_str());
 
     return PVR_ERROR_NO_ERROR;
   }
@@ -187,7 +187,7 @@ bool ChannelGroups::LoadTVChannelGroups()
     TiXmlDocument xmlDoc;
     if (!xmlDoc.Parse(strXML.c_str()))
     {
-      Logger::Log(LEVEL_DEBUG, "Unable to parse XML: %s at line %d", xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
+      Logger::Log(LEVEL_ERROR, "%s Unable to parse XML: %s at line %d", __FUNCTION__, xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
       return false;
     }
 
@@ -197,7 +197,7 @@ bool ChannelGroups::LoadTVChannelGroups()
 
     if (!pElem)
     {
-      Logger::Log(LEVEL_DEBUG, "%s Could not find <e2servicelist> element!", __FUNCTION__);
+      Logger::Log(LEVEL_ERROR, "%s Could not find <e2servicelist> element!", __FUNCTION__);
       return false;
     }
 
@@ -207,7 +207,7 @@ bool ChannelGroups::LoadTVChannelGroups()
 
     if (!pNode)
     {
-      Logger::Log(LEVEL_DEBUG, "%s Could not find <e2service> element", __FUNCTION__);
+      Logger::Log(LEVEL_ERROR, "%s Could not find <e2service> element", __FUNCTION__);
       return false;
     }
 
@@ -254,7 +254,7 @@ bool ChannelGroups::LoadRadioChannelGroups()
     TiXmlDocument xmlDoc;
     if (!xmlDoc.Parse(strXML.c_str()))
     {
-      Logger::Log(LEVEL_DEBUG, "Unable to parse XML: %s at line %d", xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
+      Logger::Log(LEVEL_ERROR, "%s Unable to parse XML: %s at line %d", __FUNCTION__, xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
       return false;
     }
 
@@ -264,7 +264,7 @@ bool ChannelGroups::LoadRadioChannelGroups()
 
     if (!pElem)
     {
-      Logger::Log(LEVEL_DEBUG, "%s Could not find <e2servicelistrecursive> element!", __FUNCTION__);
+      Logger::Log(LEVEL_ERROR, "%s Could not find <e2servicelistrecursive> element for radio groups!", __FUNCTION__);
       return false;
     }
 
@@ -274,7 +274,7 @@ bool ChannelGroups::LoadRadioChannelGroups()
 
     if (!pNode)
     {
-      Logger::Log(LEVEL_DEBUG, "%s Could not find <e2bouquet> element", __FUNCTION__);
+      Logger::Log(LEVEL_ERROR, "%s Could not find <e2bouquet> element for radio groups", __FUNCTION__);
       return false;
     }
 

--- a/src/enigma2/ChannelGroups.cpp
+++ b/src/enigma2/ChannelGroups.cpp
@@ -133,6 +133,7 @@ int ChannelGroups::GetNumChannelGroups() const
 void ChannelGroups::ClearChannelGroups()
 {
   m_channelGroups.clear();
+  m_channelGroupsNameMap.clear();
 }
 
 void ChannelGroups::AddChannelGroup(ChannelGroup& newChannelGroup)

--- a/src/enigma2/Channels.cpp
+++ b/src/enigma2/Channels.cpp
@@ -163,7 +163,7 @@ bool Channels::LoadChannels(const std::string groupServiceReference, const std::
   TiXmlDocument xmlDoc;
   if (!xmlDoc.Parse(strXML.c_str()))
   {
-    Logger::Log(LEVEL_DEBUG, "Unable to parse XML: %s at line %d", xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
+    Logger::Log(LEVEL_ERROR, "%s Unable to parse XML: %s at line %d", __FUNCTION__, xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
     return false;
   }
 
@@ -173,7 +173,7 @@ bool Channels::LoadChannels(const std::string groupServiceReference, const std::
 
   if (!pElem)
   {
-    Logger::Log(LEVEL_DEBUG, "%s Could not find <e2servicelist> element!", __FUNCTION__);
+    Logger::Log(LEVEL_ERROR, "%s Could not find <e2servicelist> element!", __FUNCTION__);
     return false;
   }
 
@@ -183,7 +183,7 @@ bool Channels::LoadChannels(const std::string groupServiceReference, const std::
 
   if (!pNode)
   {
-    Logger::Log(LEVEL_DEBUG, "Could not find <e2service> element");
+    Logger::Log(LEVEL_ERROR, "%s Could not find <e2service> element", __FUNCTION__);
     return false;
   }
   
@@ -245,7 +245,7 @@ bool Channels::LoadChannels(const std::string groupServiceReference, const std::
     }
     catch (nlohmann::detail::parse_error)
     {
-      Logger::Log(LEVEL_DEBUG, "%s Invalid JSON received, cannot load provider or picon paths from OpenWebIf", __FUNCTION__);
+      Logger::Log(LEVEL_ERROR, "%s Invalid JSON received, cannot load provider or picon paths from OpenWebIf", __FUNCTION__);
     }
   }
 

--- a/src/enigma2/Channels.cpp
+++ b/src/enigma2/Channels.cpp
@@ -82,6 +82,7 @@ int Channels::GetNumChannels() const
 void Channels::ClearChannels()
 {
   m_channels.clear();
+  m_channelsServiceReferenceMap.clear();
 }
 
 void Channels::AddChannel(Channel &newChannel, std::shared_ptr<ChannelGroup> &channelGroup)

--- a/src/enigma2/Channels.cpp
+++ b/src/enigma2/Channels.cpp
@@ -192,7 +192,7 @@ bool Channels::LoadChannels(const std::string groupServiceReference, const std::
     Channel newChannel;
     newChannel.SetRadio(channelGroup->IsRadio());
 
-    if (!newChannel.UpdateFrom(pNode, Settings::GetInstance().GetConnectionURL()))
+    if (!newChannel.UpdateFrom(pNode))
       continue;
 
     AddChannel(newChannel, channelGroup);

--- a/src/enigma2/Epg.cpp
+++ b/src/enigma2/Epg.cpp
@@ -76,7 +76,7 @@ PVR_ERROR Epg::GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL &channel,
   TiXmlDocument xmlDoc;
   if (!xmlDoc.Parse(strXML.c_str()))
   {
-    Logger::Log(LEVEL_DEBUG, "Unable to parse XML: %s at line %d", xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
+    Logger::Log(LEVEL_ERROR, "%s Unable to parse XML: %s at line %d", __FUNCTION__, xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
     return PVR_ERROR_SERVER_ERROR;
   }
 
@@ -86,7 +86,7 @@ PVR_ERROR Epg::GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL &channel,
  
   if (!pElem)
   {
-    Logger::Log(LEVEL_DEBUG, "%s could not find <e2eventlist> element!", __FUNCTION__);
+    Logger::Log(LEVEL_NOTICE, "%s could not find <e2eventlist> element!", __FUNCTION__);
     // Return "NO_ERROR" as the EPG could be empty for this channel
     return PVR_ERROR_NO_ERROR;
   }
@@ -97,7 +97,7 @@ PVR_ERROR Epg::GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL &channel,
 
   if (!pNode)
   {
-    Logger::Log(LEVEL_DEBUG, "Could not find <e2event> element");
+    Logger::Log(LEVEL_NOTICE, "%s Could not find <e2event> element", __FUNCTION__);
     // RETURN "NO_ERROR" as the EPG could be empty for this channel
     return PVR_ERROR_SERVER_ERROR;
   }
@@ -121,7 +121,7 @@ PVR_ERROR Epg::GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL &channel,
 
     iNumEPG++; 
 
-    Logger::Log(LEVEL_DEBUG, "%s loaded EPG entry '%d:%s' channel '%d' start '%d' end '%d'", __FUNCTION__, broadcast.iUniqueBroadcastId, broadcast.strTitle, entry.GetChannelId(), entry.GetStartTime(), entry.GetEndTime());
+    Logger::Log(LEVEL_TRACE, "%s loaded EPG entry '%d:%s' channel '%d' start '%d' end '%d'", __FUNCTION__, broadcast.iUniqueBroadcastId, broadcast.strTitle, entry.GetChannelId(), entry.GetStartTime(), entry.GetEndTime());
   }
 
   Logger::Log(LEVEL_INFO, "%s Loaded %u EPG Entries for channel '%s'", __FUNCTION__, iNumEPG, channel.strChannelName);
@@ -140,7 +140,7 @@ bool Epg::GetInitialEPGForGroup(std::shared_ptr<ChannelGroup> group)
   TiXmlDocument xmlDoc;
   if (!xmlDoc.Parse(strXML.c_str()))
   {
-    Logger::Log(LEVEL_DEBUG, "Unable to parse XML: %s at line %d", xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
+    Logger::Log(LEVEL_ERROR, "%s Unable to parse XML: %s at line %d", __FUNCTION__, xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
     return false;
   }
 
@@ -150,7 +150,7 @@ bool Epg::GetInitialEPGForGroup(std::shared_ptr<ChannelGroup> group)
  
   if (!pElem)
   {
-    Logger::Log(LEVEL_DEBUG, "%s could not find <e2eventlist> element!", __FUNCTION__);
+    Logger::Log(LEVEL_NOTICE, "%s could not find <e2eventlist> element!", __FUNCTION__);
     // Return "NO_ERROR" as the EPG could be empty for this channel
     return false;
   }
@@ -161,7 +161,7 @@ bool Epg::GetInitialEPGForGroup(std::shared_ptr<ChannelGroup> group)
 
   if (!pNode)
   {
-    Logger::Log(LEVEL_DEBUG, "Could not find <e2event> element");
+    Logger::Log(LEVEL_DEBUG, "%s Could not find <e2event> element", __FUNCTION__);
     // RETURN "NO_ERROR" as the EPG could be empty for this channel
     return false;
   }

--- a/src/enigma2/Epg.cpp
+++ b/src/enigma2/Epg.cpp
@@ -16,29 +16,13 @@ using namespace enigma2::extract;
 using namespace enigma2::utilities;
 
 Epg::Epg (enigma2::Channels &channels, enigma2::ChannelGroups &channelGroups, enigma2::extract::EpgEntryExtractor &entryExtractor)
-      : m_channels(channels), m_channelGroups(channelGroups), m_entryExtractor(entryExtractor)
-{
-  InitialiseEpgReadyFile();
-}
-
-void Epg::InitialiseEpgReadyFile()
-{
-  m_writeHandle = XBMC->OpenFileForWrite(INITIAL_EPG_READY_FILE.c_str(), true);
-  XBMC->WriteFile(m_writeHandle, "Y", 1);
-  XBMC->CloseFile(m_writeHandle);  
-}
+      : m_channels(channels), m_channelGroups(channelGroups), m_entryExtractor(entryExtractor) {}
 
 bool Epg::IsInitialEpgCompleted()
 {
-  m_readHandle = XBMC->OpenFile(INITIAL_EPG_READY_FILE.c_str(), 0);
-  char buf[1];
-  XBMC->ReadFile(m_readHandle, buf, 1);
-  XBMC->CloseFile(m_readHandle);
-  char buf2[] = { "N" };
-  if (buf[0] == buf2[0])
+  if (m_allChannelsHaveInitialEPG)
   {
-    Logger::Log(LEVEL_DEBUG, "%s - Intial EPG update COMPLETE!", __FUNCTION__);
-    return true;
+    return m_allChannelsHaveInitialEPG;
   }
   else
   {
@@ -77,12 +61,7 @@ PVR_ERROR Epg::GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL &channel,
       m_allChannelsHaveInitialEPG = m_channels.CheckIfAllChannelsHaveInitialEPG();
 
     if (m_allChannelsHaveInitialEPG)
-    {
-      const std::string initialEPGReady = "special://userdata/addon_data/pvr.vuplus/initialEPGReady";
-      m_writeHandle = XBMC->OpenFileForWrite(initialEPGReady.c_str(), true);
-      XBMC->WriteFile(m_writeHandle, "N", 1);
-      XBMC->CloseFile(m_writeHandle);
-    }
+      Logger::Log(LEVEL_DEBUG, "%s - Intial EPG update COMPLETE!", __FUNCTION__);
 
     return GetInitialEPGForChannel(handle, myChannel, iStart, iEnd);
   }

--- a/src/enigma2/RecordingReader.cpp
+++ b/src/enigma2/RecordingReader.cpp
@@ -25,7 +25,7 @@ RecordingReader::RecordingReader(const std::string &streamURL, std::time_t start
     m_duration = static_cast<int>(end - start);
   }
 
-  Logger::Log(LEVEL_DEBUG, "RecordingReader: Started; url=%s, start=%u, end=%u, duration=%d",
+  Logger::Log(LEVEL_DEBUG, "%s RecordingReader: Started - url=%s, start=%u, end=%u, duration=%d", __FUNCTION__,
       m_streamURL.c_str(), m_start, m_end, m_duration);
 }
 
@@ -33,7 +33,7 @@ RecordingReader::~RecordingReader(void)
 {
   if (m_readHandle)
     XBMC->CloseFile(m_readHandle);
-  Logger::Log(LEVEL_DEBUG, "RecordingReader: Stopped");
+  Logger::Log(LEVEL_DEBUG, "%s RecordingReader: Stopped", __FUNCTION__);
 }
 
 bool RecordingReader::Start()
@@ -50,7 +50,7 @@ ssize_t RecordingReader::ReadData(unsigned char *buffer, unsigned int size)
     if (m_pos == m_len || now > m_nextReopen)
     {
       /* reopen stream */
-      Logger::Log(LEVEL_DEBUG, "RecordingReader: Reopening stream...");
+      Logger::Log(LEVEL_DEBUG, "%s RecordingReader: Reopening stream...", __FUNCTION__);
       (void)XBMC->CURLOpen(m_readHandle, XFILE::READ_REOPEN | XFILE::READ_NO_CACHE);
       m_len = XBMC->GetFileLength(m_readHandle);
       XBMC->SeekFile(m_readHandle, m_pos, SEEK_SET);
@@ -98,9 +98,11 @@ int RecordingReader::CurrentDuration()
 
     if (now < m_end)
     {
+      Logger::Log(LEVEL_DEBUG, "%s RecordingReader - Partial: %d", __FUNCTION__, static_cast<int>(now - m_start));
       return now - m_start;
     }
   }
 
+  Logger::Log(LEVEL_DEBUG, "%s RecordingReader - Full: %d", __FUNCTION__, m_duration);
   return m_duration;
 }

--- a/src/enigma2/Recordings.cpp
+++ b/src/enigma2/Recordings.cpp
@@ -105,7 +105,7 @@ bool Recordings::LoadLocations()
   TiXmlDocument xmlDoc;
   if (!xmlDoc.Parse(strXML.c_str()))
   {
-    Logger::Log(LEVEL_DEBUG, "Unable to parse XML: %s at line %d", xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
+    Logger::Log(LEVEL_ERROR, "%s Unable to parse XML: %s at line %d", __FUNCTION__, xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
     return false;
   }
 
@@ -115,7 +115,7 @@ bool Recordings::LoadLocations()
 
   if (!pElem)
   {
-    Logger::Log(LEVEL_DEBUG, "Could not find <e2locations> element");
+    Logger::Log(LEVEL_ERROR, "%s Could not find <e2locations> element", __FUNCTION__);
     return false;
   }
 
@@ -125,7 +125,7 @@ bool Recordings::LoadLocations()
 
   if (!pNode)
   {
-    Logger::Log(LEVEL_DEBUG, "Could not find <e2location> element");
+    Logger::Log(LEVEL_ERROR, "%s Could not find <e2location> element", __FUNCTION__);
     return false;
   }
 
@@ -178,7 +178,7 @@ bool Recordings::GetRecordingsFromLocation(std::string recordingLocation)
   TiXmlDocument xmlDoc;
   if (!xmlDoc.Parse(strXML.c_str()))
   {
-    Logger::Log(LEVEL_DEBUG, "Unable to parse XML: %s at line %d", xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
+    Logger::Log(LEVEL_ERROR, "%s Unable to parse XML: %s at line %d", __FUNCTION__, xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
     return false;
   }
 
@@ -188,7 +188,7 @@ bool Recordings::GetRecordingsFromLocation(std::string recordingLocation)
 
   if (!pElem)
   {
-    Logger::Log(LEVEL_DEBUG, "%s Could not find <e2movielist> element!", __FUNCTION__);
+    Logger::Log(LEVEL_ERROR, "%s Could not find <e2movielist> element!", __FUNCTION__);
     return false;
   }
 
@@ -200,7 +200,7 @@ bool Recordings::GetRecordingsFromLocation(std::string recordingLocation)
 
   if (!pNode)
   {
-    Logger::Log(LEVEL_DEBUG, "Could not find <e2movie> element, no movies at location: %s", directory.c_str());
+    Logger::Log(LEVEL_DEBUG, "%s Could not find <e2movie> element, no movies at location: %s", directory.c_str(), __FUNCTION__);
   }  
   else
   {  

--- a/src/enigma2/Settings.cpp
+++ b/src/enigma2/Settings.cpp
@@ -183,6 +183,9 @@ void Settings::ReadFromAddon()
   if (!XBMC->GetSetting("streamreadchunksize", &m_streamReadChunkSize))
     m_streamReadChunkSize = 0;
 
+  if (!XBMC->GetSetting("tracedebug", &m_traceDebug))
+    m_traceDebug = false;
+
   // Now that we've read all the settings construct the connection URL
   
   m_connectionURL.clear();
@@ -288,6 +291,8 @@ ADDON_STATUS Settings::SetValue(const std::string &settingName, const void *sett
     return SetSetting<int, ADDON_STATUS>(settingName, settingValue, m_readTimeout, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "streamreadchunksize")
     return SetSetting<int, ADDON_STATUS>(settingName, settingValue, m_streamReadChunkSize, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  else if (settingName == "tracedebug")
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_traceDebug, ADDON_STATUS_OK, ADDON_STATUS_OK);
   //Backend
   else if (settingName == "globalstartpaddingstb")
   {

--- a/src/enigma2/Settings.cpp
+++ b/src/enigma2/Settings.cpp
@@ -135,6 +135,9 @@ void Settings::ReadFromAddon()
   if (!XBMC->GetSetting("logmissinggenremapping", &m_logMissingGenreMappings))
     m_logMissingGenreMappings = false;
 
+  if (!XBMC->GetSetting("epgdelayperchannel", &m_epgDelayPerChannel))
+    m_epgDelayPerChannel = 0;
+
   //Recording and Timers
   if (XBMC->GetSetting("recordingpath", buffer))
     m_recordingPath = buffer;
@@ -262,6 +265,8 @@ ADDON_STATUS Settings::SetValue(const std::string &settingName, const void *sett
     return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_mapRytecTextGenresFile, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "logmissinggenremapping")
     return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_logMissingGenreMappings, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  else if (settingName == "epgdelayperchannel")
+    return SetSetting<int, ADDON_STATUS>(settingName, settingValue, m_epgDelayPerChannel, ADDON_STATUS_OK, ADDON_STATUS_OK);
   //Recordings and Timers
   else if (settingName == "recordingpath")
     return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_recordingPath, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);

--- a/src/enigma2/Settings.h
+++ b/src/enigma2/Settings.h
@@ -144,6 +144,7 @@ namespace enigma2
     PowerstateMode GetPowerstateModeOnAddonExit() const { return m_powerstateMode; }
     int GetReadTimeoutSecs() const { return m_readTimeout; }
     int GetStreamReadChunkSizeKb() const { return m_streamReadChunkSize; }
+    bool GetTraceDebug() const { return m_traceDebug; };
 
     const std::string& GetConnectionURL() const { return m_connectionURL; }
 
@@ -258,6 +259,7 @@ namespace enigma2
     PowerstateMode m_powerstateMode = PowerstateMode::DISABLED;
     int m_readTimeout = 0;
     int m_streamReadChunkSize = 0;
+    bool m_traceDebug = false;
 
     //Backend
     int m_globalStartPaddingStb = 0;

--- a/src/enigma2/Settings.h
+++ b/src/enigma2/Settings.h
@@ -124,6 +124,7 @@ namespace enigma2
     bool GetMapRytecTextGenres() const { return m_mapRytecTextGenres; }
     const std::string& GetMapRytecTextGenresFile() const { return m_mapRytecTextGenresFile; }
     bool GetLogMissingGenreMappings() const { return m_logMissingGenreMappings; }
+    int GetEPGDelayPerChannelDelay() const { return m_epgDelayPerChannel; }
 
     //Recordings and Timers
     const std::string& GetRecordingPath() const { return m_recordingPath; }
@@ -240,6 +241,7 @@ namespace enigma2
     bool m_mapRytecTextGenres = true;
     std::string m_mapRytecTextGenresFile;
     bool m_logMissingGenreMappings = true;
+    int m_epgDelayPerChannel;
 
     //Recordings and Timers
     std::string m_recordingPath = "";

--- a/src/enigma2/StreamReader.cpp
+++ b/src/enigma2/StreamReader.cpp
@@ -15,14 +15,14 @@ StreamReader::StreamReader(const std::string &streamURL,
     XBMC->CURLAddOption(m_streamHandle, XFILE::CURL_OPTION_PROTOCOL,
       "connection-timeout", std::to_string(0).c_str());
 
-  Logger::Log(LEVEL_DEBUG, "StreamReader: Started; url=%s", streamURL.c_str());
+  Logger::Log(LEVEL_DEBUG, "%s StreamReader: Started; url=%s", __FUNCTION__, streamURL.c_str());
 }
 
 StreamReader::~StreamReader(void)
 {
   if (m_streamHandle)
     XBMC->CloseFile(m_streamHandle);
-  Logger::Log(LEVEL_DEBUG, "StreamReader: Stopped");
+  Logger::Log(LEVEL_DEBUG, "%s StreamReader: Stopped", __FUNCTION__);
 }
 
 bool StreamReader::Start()

--- a/src/enigma2/Timers.cpp
+++ b/src/enigma2/Timers.cpp
@@ -42,7 +42,7 @@ std::vector<Timer> Timers::LoadTimers() const
   TiXmlDocument xmlDoc;
   if (!xmlDoc.Parse(strXML.c_str()))
   {
-    Logger::Log(LEVEL_DEBUG, "Unable to parse XML: %s at line %d", xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
+    Logger::Log(LEVEL_ERROR, "%s Unable to parse XML: %s at line %d", __FUNCTION__, xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
     return timers;
   }
 
@@ -52,7 +52,7 @@ std::vector<Timer> Timers::LoadTimers() const
 
   if (!pElem)
   {
-    Logger::Log(LEVEL_DEBUG, "%s Could not find <e2timerlist> element!", __FUNCTION__);
+    Logger::Log(LEVEL_ERROR, "%s Could not find <e2timerlist> element!", __FUNCTION__);
     return timers;
   }
 
@@ -62,7 +62,7 @@ std::vector<Timer> Timers::LoadTimers() const
 
   if (!pNode)
   {
-    Logger::Log(LEVEL_DEBUG, "Could not find <e2timer> element");
+    Logger::Log(LEVEL_ERROR, "%s Could not find <e2timer> element", __FUNCTION__);
     return timers;
   }
   
@@ -172,7 +172,7 @@ std::vector<AutoTimer> Timers::LoadAutoTimers() const
   TiXmlDocument xmlDoc;
   if (!xmlDoc.Parse(strXML.c_str()))
   {
-    Logger::Log(LEVEL_DEBUG, "Unable to parse XML: %s at line %d", xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
+    Logger::Log(LEVEL_ERROR, "%s Unable to parse XML: %s at line %d", __FUNCTION__, xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
     return autoTimers;
   }
 
@@ -182,7 +182,7 @@ std::vector<AutoTimer> Timers::LoadAutoTimers() const
 
   if (!pElem)
   {
-    Logger::Log(LEVEL_DEBUG, "%s Could not find <autotimer> element!", __FUNCTION__);
+    Logger::Log(LEVEL_ERROR, "%s Could not find <autotimer> element!", __FUNCTION__);
     return autoTimers;
   }
 
@@ -192,7 +192,7 @@ std::vector<AutoTimer> Timers::LoadAutoTimers() const
 
   if (!pNode)
   {
-    Logger::Log(LEVEL_DEBUG, "Could not find <timer> element");
+    Logger::Log(LEVEL_ERROR, "%s Could not find <timer> element", __FUNCTION__);
     return autoTimers;
   }
 

--- a/src/enigma2/TimeshiftBuffer.cpp
+++ b/src/enigma2/TimeshiftBuffer.cpp
@@ -44,7 +44,7 @@ TimeshiftBuffer::~TimeshiftBuffer(void)
     Logger::Log(LEVEL_ERROR, "%s Unable to delete file when timeshift buffer is deleted: %s", __FUNCTION__, m_bufferPath.c_str());
   
   SAFE_DELETE(m_streamReader);
-  Logger::Log(LEVEL_DEBUG, "Timeshift: Stopped");
+  Logger::Log(LEVEL_DEBUG, "%s Timeshift: Stopped", __FUNCTION__);
 }
 
 bool TimeshiftBuffer::Start()
@@ -56,7 +56,7 @@ bool TimeshiftBuffer::Start()
   if (m_running)
     return true;
 
-  Logger::Log(LEVEL_INFO, "Timeshift: Started");
+  Logger::Log(LEVEL_INFO, "%s Timeshift: Started", __FUNCTION__);
   m_start = time(nullptr);
   m_running = true;
   m_inputThread = std::thread([&] { DoReadWrite(); });
@@ -66,7 +66,7 @@ bool TimeshiftBuffer::Start()
 
 void TimeshiftBuffer::DoReadWrite()
 {
-  Logger::Log(LEVEL_DEBUG, "Timeshift: Thread started");
+  Logger::Log(LEVEL_DEBUG, "%s Timeshift: Thread started", __FUNCTION__);
   uint8_t buffer[BUFFER_SIZE];
 
   m_streamReader->Start();
@@ -82,7 +82,7 @@ void TimeshiftBuffer::DoReadWrite()
 
     m_condition.notify_one();
   }
-  Logger::Log(LEVEL_DEBUG, "Timeshift: Thread stopped");
+  Logger::Log(LEVEL_DEBUG, "%s Timeshift: Thread stopped", __FUNCTION__);
   return;
 }
 
@@ -112,7 +112,7 @@ ssize_t TimeshiftBuffer::ReadData(unsigned char *buffer, unsigned int size)
 
   if (!available)
   {
-    Logger::Log(LEVEL_DEBUG, "Timeshift: Read timed out; waited %d", m_readTimeout);
+    Logger::Log(LEVEL_DEBUG, "%s Timeshift: Read timed out; waited %d", __FUNCTION__, m_readTimeout);
     return -1;
   }
 

--- a/src/enigma2/data/Channel.cpp
+++ b/src/enigma2/data/Channel.cpp
@@ -14,7 +14,7 @@ using namespace enigma2;
 using namespace enigma2::data;
 using namespace enigma2::utilities;
 
-bool Channel::UpdateFrom(TiXmlElement* channelNode, const std::string &enigmaURL)
+bool Channel::UpdateFrom(TiXmlElement* channelNode)
 {
   if (!XMLUtils::GetString(channelNode, "e2servicereference", m_serviceReference))
     return false;
@@ -26,47 +26,13 @@ bool Channel::UpdateFrom(TiXmlElement* channelNode, const std::string &enigmaURL
   if (!XMLUtils::GetString(channelNode, "e2servicename", m_channelName)) 
     return false;
 
-  Logger::Log(LEVEL_DEBUG, "%s: Loaded Channel: %s, sRef=%s", __FUNCTION__, m_channelName.c_str(), m_serviceReference.c_str());
+  const std::string commonServiceReference = GetCommonServiceReference(m_serviceReference);
+  m_genericServiceReference = GetGenericServiceReference(commonServiceReference);
+  m_iconPath = CreateIconPath(commonServiceReference);
 
-  std::string iconPath = m_serviceReference;
+  Logger::Log(LEVEL_DEBUG, "%s: Loaded Channel: %s, sRef=%s, picon: %s", __FUNCTION__, m_channelName.c_str(), m_serviceReference.c_str(), m_iconPath.c_str());
 
-  int j = 0;
-  std::string::iterator it = iconPath.begin();
-
-  while (j < 10 && it != iconPath.end())
-  {
-    if (*it == ':')
-      j++;
-
-    it++;
-  }
-  std::string::size_type index = it-iconPath.begin();
-
-  iconPath = iconPath.substr(0, index);
-
-  it = iconPath.end() - 1;
-  if (*it == ':')
-  {
-    iconPath.erase(it);
-  }
-
-  if (Settings::GetInstance().UsePiconsEuFormat())
-  {
-    //Extract the unique part of the icon name and apply the standard pre and post-fix
-    std::regex startPrefixRegex ("^\\d+:\\d+:\\d+:");
-    std::string replaceWith = "";
-    iconPath = regex_replace(iconPath, startPrefixRegex, replaceWith);
-    std::regex endPostfixRegex (":\\d+:\\d+:\\d+$");
-    iconPath = regex_replace(iconPath, endPostfixRegex, replaceWith);
-    iconPath = SERVICE_REF_ICON_PREFIX + iconPath + SERVICE_REF_ICON_POSTFIX;
-  }
-  
-  std::string tempString = StringUtils::Format("%s", iconPath.c_str());
-
-  std::replace(iconPath.begin(), iconPath.end(), ':', '_');
-  iconPath = Settings::GetInstance().GetIconPath().c_str() + iconPath + ".png";
-
-  m_m3uURL = StringUtils::Format("%sweb/stream.m3u?ref=%s", enigmaURL.c_str(), WebUtils::URLEncodeInline(m_serviceReference).c_str());
+  m_m3uURL = StringUtils::Format("%sweb/stream.m3u?ref=%s", Settings::GetInstance().GetConnectionURL().c_str(), WebUtils::URLEncodeInline(m_serviceReference).c_str());
 
   m_streamURL = StringUtils::Format(
     "http%s://%s%s:%d/%s",
@@ -74,17 +40,72 @@ bool Channel::UpdateFrom(TiXmlElement* channelNode, const std::string &enigmaURL
     Settings::GetInstance().UseLoginStream() ? StringUtils::Format("%s:%s@", Settings::GetInstance().GetUsername().c_str(), Settings::GetInstance().GetPassword().c_str()).c_str() : "",
     Settings::GetInstance().GetHostname().c_str(),
     Settings::GetInstance().GetStreamPortNum(),
-    tempString.c_str()
+    commonServiceReference.c_str()
   );
 
-  if (Settings::GetInstance().UseOnlinePicons())
-  {
-    std::replace(tempString.begin(), tempString.end(), ':', '_');
-    iconPath = StringUtils::Format("%spicon/%s.png", enigmaURL.c_str(), tempString.c_str());
-  }
-  m_iconPath = iconPath;
-
   return true;
+}
+
+std::string Channel::GetCommonServiceReference(const std::string &serviceReference)
+{
+  //The common service reference contains only the first 10 groups of digits with colon's in between
+  std::string commonServiceReference = serviceReference;
+
+  int j = 0;
+  std::string::iterator it = commonServiceReference.begin();
+
+  while (j < 10 && it != commonServiceReference.end())
+  {
+    if (*it == ':')
+      j++;
+
+    it++;
+  }
+  std::string::size_type index = it-commonServiceReference.begin();
+
+  commonServiceReference = commonServiceReference.substr(0, index);
+
+  it = commonServiceReference.end() - 1;
+  if (*it == ':')
+  {
+    commonServiceReference.erase(it);
+  }  
+
+  return commonServiceReference;
+}
+
+std::string Channel::GetGenericServiceReference(const std::string &commonServiceReference)
+{
+  //Same as common service reference but starts with SERVICE_REF_GENERIC_PREFIX and ends with SERVICE_REF_GENERIC_POSTFIX
+  std::string genericServiceReference = commonServiceReference;
+
+  std::regex startPrefixRegex ("^\\d+:\\d+:\\d+:");
+  std::string replaceWith = "";
+  genericServiceReference = regex_replace(commonServiceReference, startPrefixRegex, replaceWith);
+  std::regex endPostfixRegex (":\\d+:\\d+:\\d+$");
+  genericServiceReference = regex_replace(genericServiceReference, endPostfixRegex, replaceWith);
+  genericServiceReference = SERVICE_REF_GENERIC_PREFIX + genericServiceReference + SERVICE_REF_GENERIC_POSTFIX;  
+
+  return genericServiceReference;
+}
+
+std::string Channel::CreateIconPath(const std::string &commonServiceReference)
+{
+  std::string iconPath = commonServiceReference;
+
+  if (Settings::GetInstance().UsePiconsEuFormat())
+  {
+    iconPath = m_genericServiceReference;
+  }
+
+  std::replace(iconPath.begin(), iconPath.end(), ':', '_');
+
+  if (Settings::GetInstance().UseOnlinePicons())
+    iconPath = StringUtils::Format("%spicon/%s.png", Settings::GetInstance().GetConnectionURL().c_str(), iconPath.c_str());
+  else
+    iconPath = Settings::GetInstance().GetIconPath().c_str() + iconPath + ".png";
+
+  return iconPath;
 }
 
 void Channel::UpdateTo(PVR_CHANNEL &left) const

--- a/src/enigma2/data/Channel.h
+++ b/src/enigma2/data/Channel.h
@@ -37,8 +37,8 @@ namespace enigma2
     class Channel
     {
     public:
-      const std::string SERVICE_REF_ICON_PREFIX = "1:0:1:";
-      const std::string SERVICE_REF_ICON_POSTFIX = ":0:0:0";
+      const std::string SERVICE_REF_GENERIC_PREFIX = "1:0:1:";
+      const std::string SERVICE_REF_GENERIC_POSTFIX = ":0:0:0";
 
       Channel() = default;
       Channel(Channel &c) : m_radio(c.IsRadio()), m_uniqueId(c.GetUniqueId()), m_channelNumber(c.GetChannelNumber()),
@@ -64,6 +64,9 @@ namespace enigma2
       const std::string& GetServiceReference() const { return m_serviceReference; }
       void SetServiceReference(const std::string& value ) { m_serviceReference = value; }      
 
+      const std::string& GetGenericServiceReference() const { return m_genericServiceReference; }
+      void SetGenericServiceReference(const std::string& value ) { m_genericServiceReference = value; }      
+
       const std::string& GetStreamURL() const { return m_streamURL; }
       void SetStreamURL(const std::string& value ) { m_streamURL = value; }      
 
@@ -76,19 +79,24 @@ namespace enigma2
       const std::string& GetProviderName() const { return m_providerName; }
       void SetProviderlName(const std::string& value ) { m_providerName = value; }      
 
-      bool UpdateFrom(TiXmlElement* channelNode, const std::string &enigmaURL); 
+      bool UpdateFrom(TiXmlElement* channelNode); 
       void UpdateTo(PVR_CHANNEL &left) const;
 
       void AddChannelGroup(std::shared_ptr<enigma2::data::ChannelGroup> &channelGroup);
       std::vector<std::shared_ptr<enigma2::data::ChannelGroup>> GetChannelGroupList() { return m_channelGroupList; };
 
     private:   
+      std::string GetCommonServiceReference(const std::string &serviceReference);
+      std::string GetGenericServiceReference(const std::string &commonServiceReference);
+      std::string CreateIconPath(const std::string &commonServiceReference);
+
       bool m_radio;
       bool m_requiresInitialEPG = true;
       int m_uniqueId;
       int m_channelNumber;
       std::string m_channelName;
       std::string m_serviceReference;
+      std::string m_genericServiceReference;
       std::string m_streamURL;
       std::string m_m3uURL;
       std::string m_iconPath;

--- a/src/enigma2/extract/GenreIdMapper.cpp
+++ b/src/enigma2/extract/GenreIdMapper.cpp
@@ -94,7 +94,7 @@ bool GenreIdMapper::LoadIdToIdGenreFile(const std::string &xmlFile, std::map<int
   TiXmlDocument xmlDoc;
   if (!xmlDoc.Parse(fileContents.c_str()))
   {
-    Logger::Log(LEVEL_ERROR, "Unable to parse XML: %s at line %d", xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
+    Logger::Log(LEVEL_ERROR, "%s Unable to parse XML: %s at line %d", __FUNCTION__, xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
     return false;
   }
 
@@ -141,7 +141,7 @@ bool GenreIdMapper::LoadIdToIdGenreFile(const std::string &xmlFile, std::map<int
 
     map.insert({sourceId, targetId});
 
-    Logger::Log(LEVEL_DEBUG, "%s Read ID Mapping for: %s, sourceId=%#02X, targetId=%#02X", __FUNCTION__, mapperName.c_str(), sourceId, targetId);
+    Logger::Log(LEVEL_TRACE, "%s Read ID Mapping for: %s, sourceId=%#02X, targetId=%#02X", __FUNCTION__, mapperName.c_str(), sourceId, targetId);
   }
 
   return true;  

--- a/src/enigma2/extract/GenreRytecTextMapper.cpp
+++ b/src/enigma2/extract/GenreRytecTextMapper.cpp
@@ -147,7 +147,7 @@ bool GenreRytecTextMapper::LoadTextToIdGenreFile(const std::string &xmlFile, std
   TiXmlDocument xmlDoc;
   if (!xmlDoc.Parse(fileContents.c_str()))
   {
-    Logger::Log(LEVEL_ERROR, "Unable to parse XML: %s at line %d", xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
+    Logger::Log(LEVEL_ERROR, "%s Unable to parse XML: %s at line %d", __FUNCTION__, xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
     return false;
   }
 
@@ -193,7 +193,7 @@ bool GenreRytecTextMapper::LoadTextToIdGenreFile(const std::string &xmlFile, std
 
     map.insert({textMapping, targetId});
 
-    Logger::Log(LEVEL_DEBUG, "%s Read Text Mapping for: %s, text=%s, targetId=%#02X", __FUNCTION__, mapperName.c_str(), textMapping.c_str(), targetId);
+    Logger::Log(LEVEL_TRACE, "%s Read Text Mapping for: %s, text=%s, targetId=%#02X", __FUNCTION__, mapperName.c_str(), textMapping.c_str(), targetId);
   }
 
   return true;  

--- a/src/enigma2/extract/ShowInfoExtractor.cpp
+++ b/src/enigma2/extract/ShowInfoExtractor.cpp
@@ -96,7 +96,7 @@ bool ShowInfoExtractor::LoadShowInfoPatternsFile(const std::string &xmlFile, std
   TiXmlDocument xmlDoc;
   if (!xmlDoc.Parse(fileContents.c_str()))
   {
-    Logger::Log(LEVEL_ERROR, "Unable to parse XML: %s at line %d", xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
+    Logger::Log(LEVEL_ERROR, "%s Unable to parse XML: %s at line %d", __FUNCTION__, xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
     return false;
   }
 

--- a/src/enigma2/utilities/CurlFile.cpp
+++ b/src/enigma2/utilities/CurlFile.cpp
@@ -47,7 +47,7 @@ bool CurlFile::Post(const std::string &strURL, std::string &strResult)
 
   if (!fileHandle)
   {
-    Logger::Log(LEVEL_DEBUG, "%s Unable to create curl handle for %s", __FUNCTION__, strURL.c_str());
+    Logger::Log(LEVEL_ERROR, "%s Unable to create curl handle for %s", __FUNCTION__, strURL.c_str());
     return false;
   }
 
@@ -55,7 +55,7 @@ bool CurlFile::Post(const std::string &strURL, std::string &strResult)
 
   if (!XBMC->CURLOpen(fileHandle, XFILE::READ_NO_CACHE))
   {
-    Logger::Log(LEVEL_DEBUG, "%s Unable to open url: %s", __FUNCTION__, strURL.c_str());
+    Logger::Log(LEVEL_ERROR, "%s Unable to open url: %s", __FUNCTION__, strURL.c_str());
     XBMC->CloseFile(fileHandle);
     return false;
   }

--- a/src/enigma2/utilities/Logger.h
+++ b/src/enigma2/utilities/Logger.h
@@ -34,8 +34,8 @@ namespace enigma2
     enum LogLevel
     {
       LEVEL_ERROR,
-      LEVEL_INFO,
       LEVEL_NOTICE,
+      LEVEL_INFO,
       LEVEL_DEBUG,
       LEVEL_TRACE
     };

--- a/src/enigma2/utilities/StreamStatus.h
+++ b/src/enigma2/utilities/StreamStatus.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <string>
+
+namespace enigma2
+{
+  namespace utilities
+  {
+    enum class StreamType
+      : int // same type as addon settings
+    {
+      DIRECTLY_STREAMED = 0,
+      TRANSCODED
+    };    
+
+    struct StreamStatus
+    {
+      std::string m_ipAddress;
+      std::string m_serviceReference;
+      std::string m_channelName;
+      StreamType m_streamType;
+    };
+  } //namespace utilities
+} //namespace enigma2

--- a/src/enigma2/utilities/WebUtils.cpp
+++ b/src/enigma2/utilities/WebUtils.cpp
@@ -92,7 +92,7 @@ std::string WebUtils::GetHttpXML(const std::string& url)
   CurlFile http;
   if(!http.Get(url, strTmp))
   {
-    Logger::Log(LEVEL_DEBUG, "%s - Could not open webAPI.", __FUNCTION__);
+    Logger::Log(LEVEL_ERROR, "%s - Could not open webAPI.", __FUNCTION__);
     return "";
   }
 
@@ -115,7 +115,7 @@ std::string WebUtils::PostHttpJson(const std::string& url)
   CurlFile http;
   if(!http.Post(url, strTmp))
   {
-    Logger::Log(LEVEL_DEBUG, "%s - Could not open webAPI.", __FUNCTION__);
+    Logger::Log(LEVEL_ERROR, "%s - Could not open webAPI.", __FUNCTION__);
     return "";
   }
 
@@ -141,7 +141,7 @@ bool WebUtils::SendSimpleCommand(const std::string& strCommandURL, std::string& 
     TiXmlDocument xmlDoc;
     if (!xmlDoc.Parse(strXML.c_str()))
     {
-      Logger::Log(LEVEL_DEBUG, "Unable to parse XML: %s at line %d", xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
+      Logger::Log(LEVEL_ERROR, "%s Unable to parse XML: %s at line %d", __FUNCTION__, xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
       return false;
     }
 
@@ -153,7 +153,7 @@ bool WebUtils::SendSimpleCommand(const std::string& strCommandURL, std::string& 
 
     if (!pElem)
     {
-      Logger::Log(LEVEL_DEBUG, "%s Could not find <e2simplexmlresult> element!", __FUNCTION__);
+      Logger::Log(LEVEL_ERROR, "%s Could not find <e2simplexmlresult> element!", __FUNCTION__);
       return false;
     }
 


### PR DESCRIPTION
v3.16.2
- Fixed: Seg fault on shutdown - Timer Updates thread accessing released object, fixes #172
- Fixed: Incorrectly used time_t instead int64 in GetStreamTimes, fixes #171
- Added: Load Addon Version
- Fixed: Clean up/partition addon debug log, fixes #159
- Added: Add user defined delay between EPG Channel Updates, fixes #158
- Added: Enable Trace Logging in debug mode
- Added: Integrate Stream API details with Tuners
- Fixed: JSON API requires version 1.3.5+ of OpenWebIf, fixes #169