### PR TITLE
Point to develop branch of nlohmann-json which uses cmake 3.1

### DIFF
--- a/depends/common/nlohmann-json/nlohmann-json.txt
+++ b/depends/common/nlohmann-json/nlohmann-json.txt
@@ -1,1 +1,1 @@
-nlohmann-json https://github.com/nlohmann/json/archive/v3.5.0.tar.gz
+nlohmann-json https://github.com/nlohmann/json develop


### PR DESCRIPTION
OSMC Leia builds are failing due to nlohmann-json v3.5.0 requiring cmake minimum version 3.8

OSMC uses cmake 3.7.2

nlohmann-json develop version has relaxed the requirements on cmake to v3.1

https://github.com/nlohmann/json/commit/e8b6b7adc138a66f8d47396a2e707366d3771028

With below commit the builds are working again.

@samnazarko 

