### PR TITLE
Settings help info

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,15 +76,14 @@ For more detailed info on logging please see the appendix [here](#logging-detail
 Within this tab the connection options need to be configured before it can be successfully enabled.
 
 * **Enigma2 hostname or IP address**: The IP address or hostname of your enigma2 based set-top box.
-* **Web interface port**: The port used to connect to the web interface
-* **Use secure HTTP (https)**: Use https to connect to the web interface
-* **Username**: If the webinterface of the set-top box is protected with a username / password combination this needs to be set in this option.
-* **Password**: If the webinterface of the set-top box is protected with a username / password combination this needs to be set in this option.
+* **Web interface port**: The port used to connect to the web interface.
+* **Use secure HTTP (https)**: Use https to connect to the web interface.
+* **Username**: If the webinterface of the set-top box is protected with a username/password combination this needs to be set in this option.
+* **Password**: If the webinterface of the set-top box is protected with a username/password combination this needs to be set in this option.
 * **Enable automatic configuration for live streams**: When enabled the stream URL will be read from an M3U file. When disabled it is constructed based on the filename.
 * **Streaming port**: This option defines the streaming port the set-top box uses to stream live tv. The default is 8001 which should be fine if the user did not define a custom port within the webinterface.
-Webinterface Port: This option defines the port that should be used to access the webinterface of the set-top box.
-* **Use secure HTTP (https) for streams**: Use https to connect to streams
-* **Use login for streams**: Use the login username and password for streams
+* **Use secure HTTP (https) for streams**: Use https to connect to streams.
+* **Use login for streams**: Use the login username and password for streams.
 * **Connection check timeout**: The value in seconds to wait for a connection check to complete before failure. Useful for tuning on older Enigma2 devices.
 * **Connection check interval**: The value in seconds to wait between connection checks. Useful for tuning on older Enigma2 devices.
 
@@ -92,7 +91,7 @@ Webinterface Port: This option defines the port that should be used to access th
 Within this tab general options are configured.
 
 * **Fetch picons from web interface**: Fetch the picons straight from the Enigma 2 set-top box.
-* **Use picons.eu file format**: Assume all picons files fetched from the set-top box start with `1_1_1_` and end with `_0_0_0`
+* **Use picons.eu file format**: Assume all picons files fetched from the set-top box start with `1_1_1_` and end with `_0_0_0`.
 * **Use OpenWebIf picon path**: Fetch the picon path from OpenWebIf instead of constructing from ServiceRef. Requires OpenWebIf 1.3.5 or higher. There is no effect if used on a lower version of OpenWebIf.
 * **Icon path**: In order to have Kodi display channel logos you have to copy the picons from your set-top box onto your OpenELEC machine. You then need to specify this path in this property.
 * **Update interval**: As the set-top box can also be used to modify timers, delete recordings etc. and the set-top box does not notify the Kodi installation, the addon needs to regularly check for updates (new channels, new/changed/deletes timers, deleted recordings, etc.) This property defines how often the addon checks for updates.
@@ -108,9 +107,8 @@ Within this tab general options are configured.
 ### Channels
 Within this tab options that refer to channel data can be set. When changing bouquets you may need to clear the channel cache to the settings to take effect. You can do this by going to the following in Kodi settings: `Settings->PVR & Live TV->General->Clear cache`.
 
-* **Use standard channel service reference**: Usually service reference's for the channels are in a standard format like `1:0:1:27F6:806:2:11A0000:0:0:0:`. On occasion depending on provider they can be extended with some text e.g. `1:0:1:27F6:806:2:11A0000:0:0:0::UTV` or `1:0:1:27F6:806:2:11A0000:0:0:0::UTV + 1`. If this option is enabled the all read service reference's will be read as standard. This is default behaviour. Functionality like autotimers will always convert to a standard reference.
+* **Use standard channel service reference**: Usually service reference's for the channels are in a standard format like `1:0:1:27F6:806:2:11A0000:0:0:0:`. On occasion depending on provider they can be extended with some text e.g. `1:0:1:27F6:806:2:11A0000:0:0:0::UTV` or `1:0:1:27F6:806:2:11A0000:0:0:0::UTV + 1`. If this option is enabled then all read service reference's will be read as standard. This is default behaviour. Functionality like autotimers will always convert to a standard reference.
 * **Zap before channelswitch (i.e. for Single Tuner boxes)**: When using the addon with a single tuner box it may be necessary that the addon needs to be able to zap to another channel on the set-top box. If this option is enabled each channel switch in Kodi will also result in a channel switch on the set-top box. Please note that "allow channel switching" needs to be enabled in the webinterface on the set-top box.
-* **Exclude last scanned bouquet**: By default the `Last Scanned` bouquet will be included with all bouquets. Enable this option to exclude it from the retrieved list. Note that last scanned applies to both TV and Radio channels.
 * **TV bouquet fetch mode**: Choose from one of the following three modes:
     - `All bouquets` - Fetch all TV bouquets from the set-top box.
     - `Only one bouquet` - Only fetch the bouquet specified in the next option
@@ -145,7 +143,7 @@ Information on customising the extraction and mapper configs can be found in the
 * **Rytec genre text mappings file**: The config used to map Rytec Genre Text to DVB IDs. The default file is `Rytec-UK-Ireland.xml`.
 * **Log missing genre text mappings**: If you would like missing genre mappings to be logged so you can report them enable this option. Note: any genres found that don't have a mapping will still be extracted and sent to Kodi as strings. Currently genres are extracted by looking for text between square brackets, e.g. [TV Drama], or for major, minor genres using a dot (.) to separate [TV Drama. Soap Opera]
 * **EPG update delay per channel**: For older Enigma2 devices EPG updates can effect streaming quality (such as buffer timeouts). A delay of between 250ms and 5000ms can be introduced to improve quality. Only recommended for older devices. Choose the lowest value that avoids buffer timeouts.
-* **Skip intial EPG load**: Ignore the intial EPG load (now and next). Enabled by default as can cause issues on LibreElec/CoreElec
+* **Skip intial EPG load**: Ignore the intial EPG load (now and next). Enabled by default to prevent crash issues on LibreElec/CoreElec.
 
 ### Recordings
 The following configuration is available on the Recordings tab of the addon settings.
@@ -156,7 +154,7 @@ The following configuration is available on the Recordings tab of the addon sett
     - `Kodi/E2 instances` - Use the value across kodi and the E2 device so they stay in sync. Last played will be synced with the E2 device once every 5-10 minutes per recording if the PVR menus are in use. Note that only a single kodi instance is required to have this option enabled.
 * **Recording folder on receiver**: Per default the addon does not specify the recording folder in newly created timers, so the default set in the set-top box will be used. If you want to specify a different folder (i.e. because you want all recordings scheduled via Kodi to be stored in a separate folder), then you need to set this option.
 * **Use only the DVB boxes' current recording path**: If this option is not set the addon will fetch all available recordings from all configured paths from the set-top box. If this option is set then it will only list recordings that are stored within the "current recording path" on the set-top box.
-* **Keep folder structure for records**: If enabled do not specify a recording folder, when disabled (defaut), check if the recording is in it's own folder or in the root of the recording path
+* **Keep folder structure for records**: If enabled do not specify a recording folder, when disabled (defaut), check if the recording is in it's own folder or in the root of the recording path.
 * **Enable EDLs support**: EDLs are used to define commericals etc. in recordings. If a tool like [Comskip]() is used to generate EDL files enabling this will allow Kodi PVR to use them. E.g. if there is a file called ```my recording.ts``` the EDL file should be call ```my recording.edl```. Note: enabling this setting has no effect if the files are not present.
 * **EDL start time padding**: Padding to use at an EDL stop. I.e. use a negative number to start the cut earlier and positive to start the cut later. Default 0.
 * **EDL stop time padding**: Padding to use at an EDL stop. I.e. use a negative number to stop the cut earlier and positive to stop the cut later. Default 0.
@@ -216,8 +214,7 @@ Timeshifting allows you to pause live TV as well as move back and forward from y
 ### Advanced
 Within this tab more uncommon and advanced options can be configured.
 
-* **Put outline (e.g. sub-title) before plot**: By default plot outline (short description on Enigma2) is not displayed in the UI. Can be
- displayed in EPG, Recordings or both. After changing this option you will need to clear the EPG cache `Settings->PVR & Live TV->Guide->Clear cache` for it to take effect.
+* **Put outline (e.g. sub-title) before plot**: By default plot outline (short description on Enigma2) is not displayed in the UI. Can be displayed in EPG, Recordings or both. After changing this option you will need to clear the EPG cache `Settings->PVR & Live TV->Guide->Clear cache` for it to take effect.
 * **Send powerstate mode on addon exit**: If this option is set to a value other than `DISABLED` then the addon will send a Powerstate command to the set-top box when Kodi will be closed (or the addon will be deactivated).
     - `Disabled` - No command sent when the addon exits
     - `Standby` - Send the standby command on exit

--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="3.21.0"
+  version="3.22.0"
   name="Enigma2 Client"
   provider-name="Joerg Dembski and Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>
@@ -175,6 +175,14 @@
     <disclaimer lang="zh_TW">這是測試版軟體！其原創作者並無法對於以下情況負責，包含：錄影失敗，不正確的定時設定，多餘時數，或任何產生的其它不良影響...</disclaimer>
     <platform>@PLATFORM@</platform>
     <news>
+v3.22.0
+- Added: Help info for addon settings
+- Added: Delete child timers when deleting autotimers
+- Added: Set max connection check interval to 60 seconds
+- Fixed: Incorrect localisation IDs
+- Fixed: Timers in error state cause crash on delete
+- Added: Support show info fields for Timers
+
 v3.21.0
 - Added: Support Edit Recording name, last played and play count
 - Fixed: Use v3.6.1 of nlohmann/json to relax cmake version dependency for OSMC, fixes #194

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,3 +1,11 @@
+v3.22.0
+- Added: Help info for addon settings
+- Added: Delete child timers when deleting autotimers
+- Added: Set max connection check interval to 60 seconds
+- Fixed: Incorrect localisation IDs
+- Fixed: Timers in error state cause crash on delete
+- Added: Support show info fields for Timers
+
 v3.21.0
 - Added: Support Edit Recording name, last played and play count
 - Fixed: Use v3.6.1 of nlohmann/json to relax cmake version dependency for OSMC, fixes #194

--- a/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
@@ -16,621 +16,1168 @@ msgstr ""
 "Language: en_GB\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#settings labels
+###################
+# settings labels #
+###################
 
+#label: Connection - host
 msgctxt "#30000"
 msgid "Enigma2 hostname or IP address"
 msgstr ""
 
 #empty string with id 30001
 
+#label: Connection - streamport
 msgctxt "#30002"
 msgid "Streaming port"
 msgstr ""
 
+#label: Connection - user
 msgctxt "#30003"
 msgid "Username"
 msgstr ""
 
+#label: Connection - pass
 msgctxt "#30004"
 msgid "Password"
 msgstr ""
 
+#label-category: connection
 msgctxt "#30005"
 msgid "Connection"
 msgstr ""
 
+#label-group: General - Icons
 msgctxt "#30006"
 msgid "Icons"
 msgstr ""
 
-msgctxt "#30007"
-msgid "Response timeout in seconds"
-msgstr ""
+#empty string with id 30007
 
+#label: General - iconpath
 msgctxt "#30008"
 msgid "Icon path"
 msgstr ""
 
+#label-group: General - Update Interval
 msgctxt "#30009"
 msgid "Update Interval"
 msgstr ""
 
-msgctxt "#30010"
-msgid "Update Interval in minutes"
-msgstr ""
+#empty string with id 30010
 
+#label: Timers - timerlistcleanup
 msgctxt "#30011"
 msgid "Automatic timerlist cleanup"
 msgstr ""
 
+#label: Connection - webport
 msgctxt "#30012"
 msgid "Web interface port"
 msgstr ""
 
+#label: Channels - zap
 msgctxt "#30013"
 msgid "Zap before channelswitch (i.e. for single tuner boxes)"
 msgstr ""
 
-msgctxt "#30014"
-msgid "Folder for channeldata"
-msgstr ""
+#empty string with id 30014
 
+#label: General - updateint
 msgctxt "#30015"
 msgid "Update interval"
 msgstr ""
 
-msgctxt "#30016"
-msgid "Check for channel updates"
-msgstr ""
+#empty string with id 30016
 
+#label: Recordings - onlycurrent
 msgctxt "#30017"
 msgid "Use only the DVB boxes' current recording path"
 msgstr ""
 
+#label-category: general
+#label-group: Channels
 msgctxt "#30018"
 msgid "General"
 msgstr ""
 
+#label-category: channels
 msgctxt "#30019"
 msgid "Channels"
 msgstr ""
 
+#label-category: advanced
+#label-group: Connection - Advanced
 msgctxt "#30020"
 msgid "Advanced"
 msgstr ""
 
-msgctxt "#30021"
-msgid "HTTP"
-msgstr ""
+#empty strings from id 30021 to 30022
 
-msgctxt "#30022"
-msgid "Recordings / Timer"
-msgstr ""
-
+#label: Recordings - recordingpath
 msgctxt "#30023"
 msgid "Recording folder on the receiver"
 msgstr ""
 
+#label: Advanced - powerstatemode
 msgctxt "#30024"
 msgid "Send powerstate mode on addon exit"
 msgstr ""
 
+#label: Channels - tvgroupmode
 msgctxt "#30025"
 msgid "TV bouquet fetch mode"
 msgstr ""
 
+#label: Channels - onetvgroup
 msgctxt "#30026"
 msgid "TV bouquet"
 msgstr ""
 
+#label: General - onlinepicons
 msgctxt "#30027"
 msgid "Fetch picons from web interface"
 msgstr ""
 
+label: Connection - use_secure
 msgctxt "#30028"
 msgid "Use secure HTTP (https)"
 msgstr ""
 
+#label: Connection - autoconfig
 msgctxt "#30029"
 msgid "Enable automatic configuration for live streams"
 msgstr ""
 
+#label: Reordings - keepfolders
 msgctxt "#30030"
 msgid "Keep folder structure for records"
 msgstr ""
 
+#label-group: EPG - Seasons and Episodes
 msgctxt "#30031"
 msgid "Seasons and Episodes"
 msgstr ""
 
+#label-category: epg
 msgctxt "#30032"
 msgid "EPG"
 msgstr ""
 
+#label: EPG - extractshowinfoenabled
 msgctxt "#30033"
 msgid "Extract season, episode and year info where possible"
 msgstr ""
 
+#label: Timers - enableautotimers
 msgctxt "#30034"
 msgid "Enable autotimers"
 msgstr ""
 
+#label: General - usepiconseuformat
 msgctxt "#30035"
 msgid "Use picons.eu file format"
 msgstr ""
 
+#label: Timers - enablegenrepeattimers
 msgctxt "#30036"
 msgid "Enable generate repeat timers"
 msgstr ""
 
+#label: EPG - logmissinggenremapping
 msgctxt "#30037"
 msgid "Log missing genre text mappings"
 msgstr ""
 
+#label-group: Connection - Web Interface
 msgctxt "#30038"
 msgid "Web Interface"
 msgstr ""
 
+#label-group: Connection - Streaming
 msgctxt "#30039"
 msgid "Streaming"
 msgstr ""
 
+#label: Advanced - prependoutline
 msgctxt "#30040"
 msgid "Put outline (e.g. sub-title) before plot"
 msgstr ""
 
+#label: Advanced - streamreadchunksize
 msgctxt "#30041"
 msgid "Stream read chunk size"
 msgstr ""
 
+#label - Advanced - prependoutline
 msgctxt "#30042"
 msgid "Never"
 msgstr ""
 
+#label - Advanced - prependoutline
 msgctxt "#30043"
 msgid "In EPG only"
 msgstr ""
 
+#label - Advanced - prependoutline
 msgctxt "#30044"
 msgid "In recordings only"
 msgstr ""
 
+#label - Advanced - prependoutline
 msgctxt "#30045"
 msgid "Always"
 msgstr ""
 
+#label: EPG - extractshowinfofile
 msgctxt "#30046"
 msgid "Extract show info file"
 msgstr ""
 
+#label-group: EPG - Rytec genre text Mappings
 msgctxt "#30047"
 msgid "Rytec genre text Mappings"
 msgstr ""
 
+#label: EPG - rytecgenretextmapenabled
 msgctxt "#30048"
 msgid "Enable Rytec genre text mappings"
 msgstr ""
 
+#label: EPG - rytecgenretextmapfile
 msgctxt "#30049"
 msgid "Rytec genre text mappings file"
 msgstr ""
 
+#label: Advanced - readtimeout
 msgctxt "#30050"
 msgid "Custom live TV timeout (0 to use default)"
 msgstr ""
 
+#label-group: Connection - Login
 msgctxt "#30051"
 msgid "Login"
 msgstr ""
 
+#label-group: Advanced - Misc
 msgctxt "#30052"
 msgid "Misc"
 msgstr ""
 
+#label-group: EPG - Genre ID Mappings
 msgctxt "#30053"
 msgid "Genre ID Mappings"
 msgstr ""
 
+#label: EPG - genreidmapenabled
 msgctxt "#30054"
 msgid "Enable genre ID Mappings"
 msgstr ""
 
+#label: EPG - genreidmapfile
 msgctxt "#30055"
 msgid "Genre ID mappings file"
 msgstr ""
 
+#label-group: Channels - TV
 msgctxt "#30056"
 msgid "TV"
 msgstr ""
 
+#label-group: Channels - Radio
 msgctxt "#30057"
 msgid "Radio"
 msgstr ""
 
+#label: Channels - radiogroupmode
 msgctxt "#30058"
 msgid "Radio bouquet fetch mode"
 msgstr ""
 
+#label: Channels - oneradiogroup
 msgctxt "#30059"
 msgid "Radio bouquet"
 msgstr ""
 
+#label-category: timeshift
+#label-group: Timeshift - Timeshift
 msgctxt "#30060"
 msgid "Timeshift"
 msgstr ""
 
+#label: Timeshift - enabletimeshift
 msgctxt "#30061"
 msgid "Enable timeshift"
 msgstr ""
 
+#label: Timeshift - timeshiftbufferpath
 msgctxt "#30062"
 msgid "Timeshift buffer path"
 msgstr ""
 
+#label-option: Timeshift - enabletimeshift
 msgctxt "#30063"
 msgid "Off"
 msgstr ""
 
+#label-option: Timeshift - enabletimeshift
 msgctxt "#30064"
 msgid "On playback"
 msgstr ""
 
+#label-option: Timeshift - enabletimeshift
 msgctxt "#30065"
 msgid "On pause"
 msgstr ""
 
+#label: Connection - use_secure_stream
 msgctxt "#30066"
 msgid "Use secure HTTP (https) for streams"
 msgstr ""
 
+#label: Connection - use_login_stream
 msgctxt "#30067"
 msgid "Use login for streams"
 msgstr ""
 
+#label: Channels - tvfavouritesmode
 msgctxt "#30068"
 msgid "Fetch TV favourites bouquet"
 msgstr ""
 
+#label: Channels - radiofavouritesmode
 msgctxt "#30069"
 msgid "Fetch radio favourites bouquet"
 msgstr ""
 
+#label-category: recordings
 msgctxt "#30070"
 msgid "Recordings"
 msgstr ""
 
+#label-group: Recordings - Recordings
 msgctxt "#30071"
 msgid "Recordings"
 msgstr ""
 
+#label-category: timers
+#label-group: Timers - timers
 msgctxt "#30072"
 msgid "Timers"
 msgstr ""
 
+#label: Timers - numgenrepeattimers
 msgctxt "#30073"
 msgid "Number of repeat timers to generate"
 msgstr ""
 
+#label-option: Channels - tvgroupmode
+#label-option: Channels - radiogroupmode
 msgctxt "#30074"
 msgid "All bouquets"
 msgstr ""
 
+#label-option: Channels - tvgroupmode
+#label-option: Channels - radiogroupmode
 msgctxt "#30075"
 msgid "Only one bouquet"
 msgstr ""
 
+#label-option: Channels - tvfavouritesmode
+#label-option: Channels - radiofavouritesmode
 msgctxt "#30076"
 msgid "As first bouquet"
 msgstr ""
 
+#label-option: Channels - tvfavouritesmode
+#label-option: Channels - radiofavouritesmode
 msgctxt "#30077"
 msgid "As last bouquet"
 msgstr ""
 
+#label-option: Channels - tvgroupmode
+#label-option: Channels - radiogroupmode
 msgctxt "#30078"
 msgid "Favourites group"
 msgstr ""
 
+#application: ChannelGroups
 msgctxt "#30079"
 msgid "Favourites (TV)"
 msgstr ""
 
+#application: ChannelGroups
 msgctxt "#30080"
 msgid "Favourites (Radio)"
 msgstr ""
 
+#application: Client
+#application: Admin
 msgctxt "#30081"
 msgid "unknown"
 msgstr ""
 
+#application: Client
 msgctxt "#30082"
 msgid " (Not connected!)"
 msgstr ""
 
+#application: Client
 msgctxt "#30083"
 msgid "addon error"
 msgstr ""
 
-msgctxt "#30084"
-msgid "Enigma2 Media Server"
-msgstr ""
+#empty strings from id 30084 to 30085
 
-msgctxt "#30085"
-msgid "OK"
-msgstr ""
-
+#label-category: backend
 msgctxt "#30086"
 msgid "Backend"
 msgstr ""
 
+#label-group: Backend - Recording Padding
 msgctxt "#30087"
 msgid "Recording Padding"
 msgstr ""
 
+#label: Backend - globalstartpaddingstb
 msgctxt "#30088"
 msgid "Global start padding"
 msgstr ""
 
+#label: Backend - globalendpaddingstb
 msgctxt "#30089"
 msgid "Global end padding"
 msgstr ""
 
+#label-group: Backend - Device Info
 msgctxt "#30090"
 msgid "Device Info"
 msgstr ""
 
+#label: Backend - webifversion
 msgctxt "#30091"
 msgid "WebIf version"
 msgstr ""
 
+#label: Backend - autotimertagintags
 msgctxt "#30092"
 msgid "AutoTimer tag in timer tags"
 msgstr ""
 
+#label: Backend - autotimernameintags
 msgctxt "#30093"
 msgid "AutoTimer name in timer tags"
 msgstr ""
 
+#application: Admin
 msgctxt "#30094"
 msgid "N/A"
 msgstr ""
 
+#application: Admin
 msgctxt "#30095"
 msgid "True"
 msgstr ""
 
+#application: Admin
 msgctxt "#30096"
 msgid "False"
 msgstr ""
 
+#label-option: Advanced - powerstatemode
 msgctxt "#30097"
 msgid "Standby"
 msgstr ""
 
+#label-option: Advanced - powerstatemode
 msgctxt "#30098"
 msgid "Deep standby"
 msgstr ""
 
+#label-option: Advanced - powerstatemode
 msgctxt "#30099"
 msgid "Wakeup, then standby"
 msgstr ""
 
+#label: General - updatemode
 msgctxt "#30100"
 msgid "Update mode"
 msgstr ""
 
+#label-option: General - updatemode
 msgctxt "#30101"
 msgid "Timers and recordings"
 msgstr ""
 
+#label-option: General - updatemode
 msgctxt "#30102"
 msgid "Timers only"
 msgstr ""
 
+#label: General - useopenwebifpiconpath
 msgctxt "#30103"
 msgid "Use OpenWebIf picon path"
 msgstr ""
 
+#label: Advanced - tracedebug
 msgctxt "#30104"
 msgid "Enable trace logging in debug mode"
 msgstr ""
 
+#label-group - EPG - Other
 msgctxt "#30105"
 msgid "Other"
 msgstr ""
 
+#label: EPG - epgdelayperchannel
 msgctxt "#30106"
 msgid "EPG update delay per channel"
 msgstr ""
 
+#label-group: Recordings - Recording EDLs (Edit Decision Lists)
 msgctxt "#30107"
 msgid "Recording EDLs (Edit Decision Lists)"
 msgstr ""
 
+#label: Recordings - enablerecordingedls
 msgctxt "#30108"
 msgid "Enable EDLs support"
 msgstr ""
 
+#label: Recordings - edlpaddingstart
 msgctxt "#30109"
 msgid "EDL start time padding"
 msgstr ""
 
+#label: Recordings - edlpaddingstop
 msgctxt "#30110"
 msgid "EDL stop time padding"
 msgstr ""
 
+#label: Advanced - debugnormal
 msgctxt "#30111"
 msgid "Enable debug logging in normal mode"
 msgstr ""
 
+#application: ChannelGroups
 msgctxt "#30112"
 msgid "Last Scanned (TV)"
 msgstr ""
 
+#application: ChannelGroups
 msgctxt "#30113"
 msgid "Last Scanned (Radio)"
 msgstr ""
 
+#label: Channels - excludelastscannedtv
+#label: Channels - excludelastscannedradio
 msgctxt "#30114"
 msgid "Exclude last scanned bouquet"
 msgstr ""
 
+#label: EPG - skipinitialepg
 msgctxt "#30115"
 msgid "Skip Initial EPG Load"
 msgstr ""
 
+#label: General - channelandgroupupdatemode
 msgctxt "#30116"
 msgid "Channels and groups update mode"
 msgstr ""
 
+#label-option: General - channelandgroupupdatemode
 msgctxt "#30117"
 msgid "Disabled"
 msgstr ""
 
+#label-option: General - channelandgroupupdatemode
 msgctxt "#30118"
 msgid "Notify on UI and Log"
 msgstr ""
 
+#label-option: General - channelandgroupupdatemode
 msgctxt "#30119"
 msgid "Reload Channels and Groups"
 msgstr ""
 
+#label: General - channelandgroupupdatehour
 msgctxt "#30120"
 msgid "Channels and groups update hour (24h)"
 msgstr ""
 
+#label: Connection - connectionchecktimeout
 msgctxt "#30121"
 msgid "Connection check timeout"
 msgstr ""
 
+#label: Connection - connectioncheckinterval
 msgctxt "#30122"
 msgid "Connection check interval"
 msgstr ""
 
+#label: Timers - Autotimers
 msgctxt "#30123"
 msgid "Autotimers"
 msgstr ""
 
+#label: Timers - limitanychannelautotimers
 msgctxt "#30124"
 msgid "Limit 'Any Channel' autotimers to TV or Radio"
 msgstr ""
 
+#label: Timers - limitanychannelautotimerstogroups
 msgctxt "#30125"
 msgid "Limit to groups of original EPG channel"
 msgstr ""
 
+#label: Channels - usestandardserviceref
 msgctxt "#30126"
 msgid "Use standard channel service reference"
 msgstr ""
 
+#label: Recordings - storeextrarecordinginfo
 msgctxt "#30127"
 msgid "Store last played/play count on the backend"
 msgstr ""
 
+#label: Recordings - sharerecordinglastplayed
 msgctxt "#30128"
 msgid "Share last played across:"
 msgstr ""
 
+#label-option: Recordings - sharerecordinglastplayed
 msgctxt "#30129"
 msgid "Kodi instances"
 msgstr ""
 
+#label-option: Recordings - sharerecordinglastplayed
 msgctxt "#30130"
 msgid "Kodi/E2 instances"
 msgstr ""
 
 #empty strings from id 30131 to 30409
 
+###############
+# application #
+###############
+
+#application: Timers
 msgctxt "#30410"
 msgid "Automatic"
 msgstr ""
 
 #empty strings from id 30411 to 30419
 
+#application: Timers
 msgctxt "#30420"
 msgid "Once off timer (set by auto guide-based rule)"
 msgstr ""
 
+#application: Timers
 msgctxt "#30421"
 msgid "Once off timer (set by repeating time/channel based rule)"
 msgstr ""
 
+#application: Timers
 msgctxt "#30422"
 msgid "Once off time/channel based"
 msgstr ""
 
+#application: Timers
 msgctxt "#30423"
 msgid "Repeating time/channel based"
 msgstr ""
 
+#application: Timers
 msgctxt "#30424"
 msgid "One time guide-based"
 msgstr ""
 
+#application: Timers
 msgctxt "#30425"
 msgid "Repeating guide-based"
 msgstr ""
 
+#application: Timers
 msgctxt "#30426"
 msgid "Auto guide-based"
 msgstr ""
 
 #empty strings from id 30427 to 30429
 
+#label-option: Channels - tvfavouritesmode
+#label-option: Channels - radiofavouritesmode
+#label-option: Advanced - powerstatemode
+#application: Timers
 msgctxt "#30430"
 msgid "Disabled"
 msgstr ""
 
+#application: Timers
 msgctxt "#30431"
 msgid "Record if EPG title differs"
 msgstr ""
 
+#application: Timers
 msgctxt "#30432"
 msgid "Record if EPG title and short description differs"
 msgstr ""
 
+#application: Timers
 msgctxt "#30433"
 msgid "Record if EPG title and all descriptions differ"
 msgstr ""
 
 #empty strings from id 30434 to 30499
-#notifications
 
-msgctxt "#30500"
-msgid "Disconnected from '%s'"
-msgstr ""
+#################
+# notifications #
+#################
 
-msgctxt "#30501"
-msgid "Reconnected to '%s'"
-msgstr ""
+#empty strings from id 300500 to 30513
 
-#empty strings from id 30502 to 30513
-
+#notification: Client
 msgctxt "#30514"
 msgid "Timeshift buffer path does not exist"
 msgstr ""
 
+#notification: Enigma2
 msgctxt "#30515"
 msgid "Enigma2: Could not reach web interface"
 msgstr ""
 
+#notification: Enigma2
 msgctxt "#30516"
 msgid "Enigma2: No channel groups found"
 msgstr ""
 
+#notification: Enigma2
 msgctxt "#30517"
 msgid "Enigma2: No channels found"
 msgstr ""
 
+#notification: Enigma2
 msgctxt "#30518"
 msgid "Enigma2: Channel group changes detected, please restart to load changes"
 msgstr ""
 
+#notification: Enigma2
 msgctxt "#30519"
 msgid "Enigma2: Channel changes detected, please restart to load changes"
 msgstr ""
 
+#application: AutoTimer
+#application: Timer
 msgctxt "#30520"
 msgid "Invalid Channel"
+msgstr ""
+
+#empty strings from id 30521 to 30599
+
+#############
+# help info #
+#############
+
+#help info - Connection
+
+#help-category: connection
+msgctxt "#30600"
+msgid "This category cotains the settings for connecting to the Enigma2 device"
+msgstr ""
+
+#help: Connection - host
+msgctxt "#30601"
+msgid "The IP address or hostname of your enigma2 based set-top box."
+msgstr ""
+
+#help: Connection - webport
+msgctxt "#30602"
+msgid "The port used to connect to the web interface."
+msgstr ""
+
+#help: Connection - use_secure
+msgctxt "#30603"
+msgid "Use https to connect to the web interface."
+msgstr ""
+
+#help: Connection - user
+msgctxt "#30604"
+msgid "If the webinterface of the set-top box is protected with a username/password combination this needs to be set in this option."
+msgstr ""
+
+#help: Connection - pass
+msgctxt "#30605"
+msgid "If the webinterface of the set-top box is protected with a username/password combination this needs to be set in this option."
+msgstr ""
+
+#help: Connection - autoconfig
+msgctxt "#30606"
+msgid "When enabled the stream URL will be read from an M3U file. When disabled it is constructed based on the filename."
+msgstr ""
+
+#help: Connection - streamport
+msgctxt "#30607"
+msgid "This option defines the streaming port the set-top box uses to stream live tv. The default is 8001 which should be fine if the user did not define a custom port within the webinterface."
+msgstr ""
+
+#help: Connection - use_secure_stream
+msgctxt "#30608"
+msgid "Use https to connect to streams."
+msgstr ""
+
+#help: Connection - use_login_stream
+msgctxt "#30609"
+msgid "Use the login username and password for streams."
+msgstr ""
+
+#help: Connection - connectionchecktimeout
+msgctxt "#30610"
+msgid "The value in seconds to wait for a connection check to complete before failure. Useful for tuning on older Enigma2 devices."
+msgstr ""
+
+#help: Connection - connectioncheckinterval
+msgctxt "#30611"
+msgid "The value in seconds to wait between connection checks. Useful for tuning on older Enigma2 devices."
+msgstr ""
+
+#empty strings from id 30612 to 30619
+
+#help info - General
+
+#help-category: general
+msgctxt "#30620"
+msgid "This category cotains the settings whivh generally need to be set by the user"
+msgstr ""
+
+#help: General - onlinepicons
+msgctxt "#30621"
+msgid "Fetch the picons straight from the Enigma 2 set-top box."
+msgstr ""
+
+#help: General - useopenwebifpiconpath
+msgctxt "#30622"
+msgid "Fetch the picon path from OpenWebIf instead of constructing from ServiceRef. Requires OpenWebIf 1.3.5 or higher. There is no effect if used on a lower version of OpenWebIf."
+msgstr ""
+
+#help: General - usepiconseuformat
+msgctxt "#30623"
+msgid "Assume all picons files fetched from the set-top box start with '1_1_1_' and end with '_0_0_0'."
+msgstr ""
+
+#help: General - iconpath
+msgctxt "#30624"
+msgid "In order to have Kodi display channel logos you have to copy the picons from your set-top box onto your OpenELEC machine. You then need to specify this path in this property."
+msgstr ""
+
+#help: General - updateint
+msgctxt "#30625"
+msgid "As the set-top box can also be used to modify timers, delete recordings etc. and the set-top box does not notify the Kodi installation, the addon needs to regularly check for updates (new channels, new/changed/deletes timers, deleted recordings, etc.) This property defines how often the addon checks for updates."
+msgstr ""
+
+#help: General - updatemode
+msgctxt "#30626"
+msgid "The mode used when the update interval is reached. Note that if there is any timer change detected a recordings update will always occur regardless of the update mode. Choose from one of the following two modes: [Timers and Recordings] Update all timers and recordings; [Timers only] Only update the timers."
+msgstr ""
+
+#help: General - channelandgroupupdatemode
+msgctxt "#30627"
+msgid "The mode used when the hour in the next settings is reached. Choose from one of the following three modes: [Disabled] Never check for channel and group changes; [Notify on UI and Log] Display a notice in the UI and log the fact that a change was detectetd]; [Reload Channels and Groups] Disconnect and reconnect with E2 device to reload channels only if a change is detected."
+msgstr ""
+
+#help: General - channelandgroupupdatehour
+msgctxt "#30628"
+msgid "The hour of the day when the check for new channels should occur. Default is 4h as the Auto Bouquet Maker (ABM) on the E2 device defaults to 3AM."
+msgstr ""
+
+#empty strings from id 30629 to 30639
+
+#help info - Channels
+
+#help-category: channels
+msgctxt "#30640"
+msgid "This category cotains the settings for channels. When changing bouquets you may need to clear the channel cache to the settings to take effect. You can do this by going to the following in Kodi settings: 'Settings->PVR & Live TV->General->Clear cache'."
+msgstr ""
+
+#help: Channels - usestandardserviceref
+msgctxt "#30641"
+msgid "Usually service reference's for the channels are in a standard format like '1:0:1:27F6:806:2:11A0000:0:0:0:'. On occasion depending on provider they can be extended with some text e.g. '1:0:1:27F6:806:2:11A0000:0:0:0::UTV' or '1:0:1:27F6:806:2:11A0000:0:0:0::UTV + 1'. If this option is enabled then all read service reference's will be read as standard. This is default behaviour. Functionality like autotimers will always convert to a standard reference."
+msgstr ""
+
+#help: Channels - zap
+msgctxt "#30642"
+msgid "When using the addon with a single tuner box it may be necessary that the addon needs to be able to zap to another channel on the set-top box. If this option is enabled each channel switch in Kodi will also result in a channel switch on the set-top box. Please note that "allow channel switching" needs to be enabled in the webinterface on the set-top box."
+msgstr ""
+
+#help: Channels - tvgroupmode
+msgctxt "#30643"
+msgid "Choose from one of the following three modes: [All bouquets] Fetch all TV bouquets from the set-top box; [Only one bouquet] Only fetch the bouquet specified in the next option; [Favourites group] Only fetch the system bouquet for TV favourites."
+msgstr ""
+
+#help: Channels - onetvgroup
+msgctxt "#30644"
+msgid "If the previous option has been has been set to 'Only one bouquet' you need to specify the TV bouquet to be fetched from the set-top box. Please not that this is the bouquet-name as shown on the set-top box (i.e. 'Favourites (TV)'). This setting is case-sensitive."
+msgstr ""
+
+#help: Channels - tvfavouritesmode
+msgctxt "#30645"
+msgid "If the fetch mode is 'All bouquets' or 'Only one bouquet' depending on your Enigma2 image you may need to explicitly fetch favourites if you require them. The options are: [Disabled] Don't explicitly fetch TV favourites; [As first bouquet] Explicitly fetch them as the first bouquet; [As last bouquet] Explicitly fetch them as the last bouquet."
+msgstr ""
+
+#help: Channels - excludelastscannedtv
+msgctxt "#30646"
+msgid "Last scanned is a system bouquet containing all the TV and Radio channels found in the last scan. Any TV channels found in the Last Scanned bouquet can be displayed as a group called 'Last Scanned (TV)' in Kodi. For TV this group is excluded by default. Disable this option to exclude this group. Note that if no TV groups are loaded the Last Scanned group for TV will be loaded by default regardless of this setting."
+msgstr ""
+
+#help: Channels - radiogroupmode
+msgctxt "#30647"
+msgid "Choose from one of the following three modes: [All bouquets] Fetch all Radio bouquets from the set-top box]; [Only one bouquet] Only fetch the bouquet specified in the next option; [Favourites group] Only fetch the system bouquet for Radio favourites."
+msgstr ""
+
+#help: Channels - oneradiogroup
+msgctxt "#30648"
+msgid "If the previous option has been has been set to 'Only one bouquet' you need to specify the Radio bouquet to be fetched from the set-top box. Please not that this is the bouquet-name as shown on the set-top box (i.e. 'Favourites (Radio)'). This setting is case-sensitive."
+msgstr ""
+
+#help: Channels - radiofavouritesmode
+msgctxt "#30649"
+msgid "If the fetch mode is 'All bouquets' or 'Only one bouquet' depending on your Enigma2 image you may need to explicitly fetch favourites if you require them. The options are: [Disabled] Don't explicitly fetch Radio favourites; [As first bouquet] Explicitly fetch them as the first bouquet; [As last bouquet] Explicitly fetch them as the last bouquet."
+msgstr ""
+
+#help: Channels - excludelastscannedradio
+msgctxt "#30650"
+msgid "Last scanned is a system bouquet containing all the TV and Radio channels found in the last scan. Any Radio channels found in the Last Scanned bouquet can be displayed as a group called 'Last Scanned (Radio)' in Kodi. For Radio this group is excluded by default. Disable this option to show this group."
+msgstr ""
+
+#empty strings from id 30651 to 30659
+
+#help info - EPG
+
+#help-category: epg
+msgctxt "#30660"
+msgid "This category cotains the settings for EPG (Electronic Programme Guide). Excluding logging missing genre text mappings all other options will require clearing the EPG cache to take effect. This can be done by going to 'Settings->PVR & Live TV->Guide->Clear cache' in Kodi after the addon restarts."
+msgstr ""
+
+#help: EPG - extractshowinfoenabled
+msgctxt "#30661"
+msgid "Check the description fields in the EPG data and attempt to extract season, episode and year info where possible."
+msgstr ""
+
+#help: EPG - extractshowinfofile
+msgctxt "#30662"
+msgid "The config used to extract season, episode and year information. The default file is `English-ShowInfo.xml`."
+msgstr ""
+
+#help: EPG - genreidmapenabled
+msgctxt "#30663"
+msgid "If the genre IDs sent with EPG data from your set-top box are not using the DVB standard, map from these to the DVB standard IDs. Sky UK for instance uses OpenTV, in that case without this option set the genre colouring and text would be incorrect in Kodi."
+msgstr ""
+
+#help: EPG - genreidmapfile
+msgctxt "#30664"
+msgid "The config used to map set-top box EPG genre IDs to DVB standard IDs. The default file is `Sky-UK.xml`."
+msgstr ""
+
+#help: EPG - rytecgenretextmapenabled
+msgctxt "#30665"
+msgid "If you use Rytec XMLTV EPG data this option can be used to map the text genres to DVB standard IDs."
+msgstr ""
+
+#help: EPG - rytecgenretextmapfile
+msgctxt "#30666"
+msgid "The config used to map Rytec Genre Text to DVB IDs. The default file is `Rytec-UK-Ireland.xml`."
+msgstr ""
+
+#help: EPG - logmissinggenremapping
+msgctxt "#30667"
+msgid "If you would like missing genre mappings to be logged so you can report them enable this option. Note: any genres found that don't have a mapping will still be extracted and sent to Kodi as strings. Currently genres are extracted by looking for text between square brackets, e.g. [TV Drama], or for major, minor genres using a dot (.) to separate [TV Drama. Soap Opera]"
+msgstr ""
+
+#help: EPG - epgdelayperchannel
+msgctxt "#30668"
+msgid "For older Enigma2 devices EPG updates can effect streaming quality (such as buffer timeouts). A delay of between 250ms and 5000ms can be introduced to improve quality. Only recommended for older devices. Choose the lowest value that avoids buffer timeouts."
+msgstr ""
+
+#help: EPG - skipinitialepg
+msgctxt "#30669"
+msgid "Ignore the intial EPG load (now and next). Enabled by default to prevent crash issues on LibreElec/CoreElec."
+msgstr ""
+
+#empty strings from id 30670 to 30679
+
+#help info - Recordings
+
+#help-category: recordings
+msgctxt "#30680"
+msgid "This category cotains the settings for recordings"
+msgstr ""
+
+#help: Recordings - storeextrarecordinginfo
+msgctxt "#30681"
+msgid "Store last played position and count on the backend so they can be shared across kodi instances. Only supported on OpenWebIf version 1.3.6+."
+msgstr ""
+
+#help: Recordings - sharerecordinglastplayed
+msgctxt "#30682"
+msgid "The options are: [Kodi instances] Only use the value in kodi and will not affect last played on the E2 device; [Kodi/E2 instances] Use the value across kodi and the E2 device so they stay in sync. Last played will be synced with the E2 device once every 5-10 minutes per recording if the PVR menus are in use. Note that only a single kodi instance is required to have this option enabled."
+msgstr ""
+
+#help: Recordings - recordingpath
+msgctxt "#30683"
+msgid "Per default the addon does not specify the recording folder in newly created timers, so the default set in the set-top box will be used. If you want to specify a different folder (i.e. because you want all recordings scheduled via Kodi to be stored in a separate folder), then you need to set this option."
+msgstr ""
+
+#help: Recordings - onlycurrent
+msgctxt "#30684"
+msgid "If this option is not set the addon will fetch all available recordings from all configured paths from the set-top box. If this option is set then it will only list recordings that are stored within the 'current recording path' on the set-top box."
+msgstr ""
+
+#help: Reordings - keepfolders
+msgctxt "#30685"
+msgid "If enabled do not specify a recording folder, when disabled (defaut), check if the recording is in it's own folder or in the root of the recording path."
+msgstr ""
+
+#help: Recordings - enablerecordingedls
+msgctxt "#30686"
+msgid "EDLs are used to define commericals etc. in recordings. If a tool like Comskip is used to generate EDL files enabling this will allow Kodi PVR to use them. E.g. if there is a file called 'my recording.ts' the EDL file should be call 'my recording.edl'. Note: enabling this setting has no effect if the files are not present."
+msgstr ""
+
+#help: Recordings - edlpaddingstart
+msgctxt "#30687"
+msgid "Padding to use at an EDL stop. I.e. use a negative number to start the cut earlier and positive to start the cut later. Default 0."
+msgstr ""
+
+#help: Recordings - edlpaddingstop
+msgctxt "#30688"
+msgid "Padding to use at an EDL stop. I.e. use a negative number to stop the cut earlier and positive to stop the cut later. Default 0."
+msgstr ""
+
+#empty strings from id 30689 to 30699
+
+#help info - Timers
+
+#help-category: timers
+msgctxt "#30700"
+msgid "This category cotains the settings for timers (regular and auto)"
+msgstr ""
+
+#help: Timers - enablegenrepeattimers
+msgctxt "#30701"
+msgid "Repeat timers will display as timer rules. Enabling this will make Kodi generate regular timers to match the repeat timer rules so the UI can show what's scheduled and currently recording for each repeat timer."
+msgstr ""
+
+#help: Timers - numgenrepeattimers
+msgctxt "#30702"
+msgid "The number of Kodi PVR timers to generate."
+msgstr ""
+
+#help: Timers - timerlistcleanup
+msgctxt "#30703"
+msgid "If this option is set then the addon will send the command to delete completed timers from the set-top box after each update interval."
+msgstr ""
+
+#help: Timers - enableautotimers
+msgctxt "#30704"
+msgid "When this is enabled there are some settings required on the set-top box to enable linking of AutoTimers (Timer Rules) to Timers in the Kodi UI. The addon attempts to set these automatically on boot."
+msgstr ""
+
+#help: Timers - limitanychannelautotimers
+msgctxt "#30705"
+msgid "If last scanned groups are excluded attempt to limit new autotimers to either TV or Radio (dependent on channel used to create the autotimer). Note that if last scanned groups are enabled this is not possible and the setting will be ignored."
+msgstr ""
+
+#help: Timers - limitanychannelautotimerstogroups
+msgctxt "#30706"
+msgid "For the channel used to create the autotimer limit to channel groups that this channel is a member of."
+msgstr ""
+
+#empty strings from id 30707 to 30719
+
+#help info - Timeshift
+
+#help-category: timeshift
+msgctxt "#30720"
+msgid "This category cotains the settings for timeshift. Timeshifting allows you to pause live TV as well as move back and forward from your current position similar to playing back a recording. The buffer is deleted each time a channel is changed or stopped."
+msgstr ""
+
+#help: Timeshift - enabletimeshift
+msgctxt "#30721"
+msgid "What timeshift option do you want: [Disabled] No timeshifting; [On Pause] Timeshifting starts when a live stream is paused. E.g. you want to continue from where you were at after pausing; [On Playback] Timeshifting starts when a live stream is opened. E.g. You can go to any point in the stream since it was opened."
+msgstr ""
+
+#help: Timeshift - timeshiftbufferpath
+msgctxt "#30722"
+msgid "The path used to store the timeshift buffer. The default is the `addon_data/pvr.vuplus` folder in userdata."
+msgstr ""
+
+#empty strings from id 30723 to 30739
+
+#help info - Advanced
+
+#help-category: advanced
+msgctxt "#30740"
+msgid "This category cotains advanced/expert settings"
+msgstr ""
+
+#help: Advanced - prependoutline
+msgctxt "#30741"
+msgid "By default plot outline (short description on Enigma2) is not displayed in the UI. Can be displayed in EPG, Recordings or both. After changing this option you will need to clear the EPG cache `Settings->PVR & Live TV->Guide->Clear cache` for it to take effect."
+msgstr ""
+
+#help: Advanced - powerstatemode
+msgctxt "#30742"
+msgid "If this option is set to a value other than `Disabled` then the addon will send a Powerstate command to the set-top box when Kodi will be closed (or the addon will be deactivated): [Disabled] No command sent when the addon exits; [Standby] Send the standby command on exit; [Deep standby] Send the deep standby command on exit. Note, the set-top box will not respond to Kodi after this command is sent; [Wakeup, then standby] Similar to standby but first sends a wakeup command. Can be useful if you want to ensure all streams have stopped. Note: if you use CEC this could cause your TV to wake."
+msgstr ""
+
+#help: Advanced - readtimeout
+msgctxt "#30743"
+msgid "The timemout to use when trying to read live streams. Default for live streams is 0. Default for for timeshifting is 10 seconds."
+msgstr ""
+
+#help: Advanced - streamreadchunksize
+msgctxt "#30744"
+msgid "The chunk size used by Kodi for streams. Default 0 to leave it to Kodi to decide."
+msgstr ""
+
+#help: Advanced - debugnormal
+msgctxt "#30745"
+msgid "Debug log statements will display for the addon even though debug logging may not be enabled in Kodi. Note that all debug log statements will display at NOTICE level."
+msgstr ""
+
+#help: Advanced - tracedebug
+msgctxt "#30746"
+msgid "Very detailed and verbose log statements will display in addition to standard debug statements. If enabled along with `Enable debug logging in normal mode` both trace and debug will display without debug logging enabled. In this case both debug and trace log statements will display at NOTICE level."
+msgstr ""
+
+#empty strings from id 30747 to 30759
+
+#help info - Backend
+
+#help-category: backend
+msgctxt "#30760"
+msgid "This category cotains advanced/expert settings"
+msgstr ""
+
+#help: Backend - webifversion
+msgctxt "#30761"
+msgid "webifversion"
+msgstr ""
+
+#help: Backend - autotimertagintags
+msgctxt "#30762"
+msgid "autotimertagintags"
+msgstr ""
+
+#help: Backend - autotimernameintags
+msgctxt "#30763"
+msgid "autotimernameintags"
+msgstr ""
+
+#help: Backend - globalstartpaddingstb
+msgctxt "#30764"
+msgid "globalstartpaddingstb"
+msgstr ""
+
+#help: Backend - globalendpaddingstb
+msgctxt "#30765"
+msgid "globalendpaddingstb"
 msgstr ""

--- a/pvr.vuplus/resources/settings.xml
+++ b/pvr.vuplus/resources/settings.xml
@@ -3,14 +3,14 @@
   <section id="pvr.vuplus">
 
     <!-- Connection -->
-    <category id="connection" label="30005">
+    <category id="connection" label="30005" help="30600">
       <group id="1" label="30038">
-        <setting id="host" type="string" label="30000">
+        <setting id="host" type="string" label="30000" help="30601">
           <level>0</level>
           <default>127.0.0.1</default>
           <control type="edit" format="string" />
         </setting>
-        <setting id="webport" type="integer" label="30012">
+        <setting id="webport" type="integer" label="30012" help="30602">
           <level>0</level>
           <default>80</default>
           <constraints>
@@ -20,14 +20,14 @@
           </constraints>
           <control type="edit" format="integer" />
         </setting>
-        <setting id="use_secure" type="boolean" label="30028">
+        <setting id="use_secure" type="boolean" label="30028" help="30603">
           <level>0</level>
           <default>false</default>
           <control type="toggle" />
         </setting>
       </group>
       <group id="2" label="30051">
-        <setting id="user" type="string" label="30003">
+        <setting id="user" type="string" label="30003" help="30604">
           <level>0</level>
           <default></default>
           <constraints>
@@ -35,7 +35,7 @@
           </constraints>
           <control type="edit" format="string" />
         </setting>
-        <setting id="pass" type="string" label="30004">
+        <setting id="pass" type="string" label="30004" help="30605">
           <level>0</level>
           <default></default>
           <constraints>
@@ -47,12 +47,12 @@
         </setting>
       </group>
       <group id="3" label="30039">
-        <setting id="autoconfig" type="boolean" label="30029">
+        <setting id="autoconfig" type="boolean" label="30029" help="30606">
           <level>0</level>
           <default>false</default>
           <control type="toggle" />
         </setting>
-        <setting id="streamport" type="integer" label="30002">
+        <setting id="streamport" type="integer" label="30002" help="30607">
           <level>0</level>
           <default>8001</default>
           <constraints>
@@ -65,7 +65,7 @@
           </dependencies>
           <control type="edit" format="integer" />
         </setting>
-        <setting id="use_secure_stream" type="boolean" label="30066">
+        <setting id="use_secure_stream" type="boolean" label="30066" help="30608">
           <level>0</level>
           <default>false</default>
           <dependencies>
@@ -73,7 +73,7 @@
           </dependencies>
           <control type="toggle" />
         </setting>
-        <setting id="use_login_stream" type="boolean" label="30067">
+        <setting id="use_login_stream" type="boolean" label="30067" help="30609">
           <level>0</level>
           <default>false</default>
           <dependencies>
@@ -83,7 +83,7 @@
         </setting>
       </group>
       <group id="4" label="30020">
-        <setting id="connectionchecktimeout" type="integer" label="30121">
+        <setting id="connectionchecktimeout" type="integer" label="30121" help="30610">
           <level>0</level>
           <default>10</default>
           <constraints>
@@ -96,7 +96,7 @@
             <formatlabel>14045</formatlabel>
           </control>
         </setting>
-        <setting id="connectioncheckinterval" type="integer" label="30122">
+        <setting id="connectioncheckinterval" type="integer" label="30122" help="30611">
           <level>0</level>
           <default>1</default>
           <constraints>
@@ -113,14 +113,14 @@
     </category>
 
     <!-- General -->
-    <category id="general" label="30018">
+    <category id="general" label="30018" help="30620">
       <group id="1" label="30006">
-        <setting id="onlinepicons" type="boolean" label="30027">
+        <setting id="onlinepicons" type="boolean" label="30027" help="30621">
           <level>0</level>
           <default>true</default>
           <control type="toggle" />
         </setting>
-        <setting id="useopenwebifpiconpath" type="boolean" parent="onlinepicons" label="30103">
+        <setting id="useopenwebifpiconpath" type="boolean" parent="onlinepicons" label="30103" help="30622">
           <level>0</level>
           <default>false</default>
           <dependencies>
@@ -128,12 +128,12 @@
           </dependencies>
           <control type="toggle" />
         </setting>
-        <setting id="usepiconseuformat" type="boolean" label="30035">
+        <setting id="usepiconseuformat" type="boolean" label="30035" help="30623">
           <level>0</level>
           <default>false</default>
           <control type="toggle" />
         </setting>
-        <setting id="iconpath" type="path" label="30008">
+        <setting id="iconpath" type="path" label="30008" help="30624">
           <level>0</level>
           <default></default>
           <constraints>
@@ -150,7 +150,7 @@
       </group>
 
       <group id="2" label="30009">
-        <setting id="updateint" type="integer" label="30015">
+        <setting id="updateint" type="integer" label="30015" help="30625">
           <level>0</level>
           <default>2</default>
           <constraints>
@@ -163,7 +163,7 @@
             <formatlabel>14044</formatlabel>
           </control>
         </setting>
-        <setting id="updatemode" type="integer" label="30100">
+        <setting id="updatemode" type="integer" label="30100" help="30626">
           <level>0</level>
           <default>0</default>
           <constraints>
@@ -174,7 +174,7 @@
           </constraints>
           <control type="list" format="integer" />
         </setting>
-        <setting id="channelandgroupupdatemode" type="integer" label="30116">
+        <setting id="channelandgroupupdatemode" type="integer" label="30116" help="30627">
           <level>0</level>
           <default>2</default>
           <constraints>
@@ -186,7 +186,7 @@
           </constraints>
           <control type="list" format="integer" />
         </setting>
-        <setting id="channelandgroupupdatehour" type="integer" label="30120">
+        <setting id="channelandgroupupdatehour" type="integer" label="30120" help="30628">
           <level>0</level>
           <default>4</default>
           <constraints>
@@ -211,21 +211,21 @@
     </category>
 
     <!-- Channels -->
-    <category id="channels" label="30019">
+    <category id="channels" label="30019" help="30640">
       <group id="1" label="30018">
-        <setting id="usestandardserviceref" type="boolean" label="30126">
+        <setting id="usestandardserviceref" type="boolean" label="30126" help="30641">
           <level>0</level>
           <default>true</default>
           <control type="toggle" />
         </setting>
-        <setting id="zap" type="boolean" label="30013">
+        <setting id="zap" type="boolean" label="30013" help="30642">
           <level>0</level>
           <default>false</default>
           <control type="toggle" />
         </setting>
       </group>
       <group id="2" label="30056">
-        <setting id="tvgroupmode" type="integer" label="30025">
+        <setting id="tvgroupmode" type="integer" label="30025" help="30643">
           <level>0</level>
           <default>0</default>
           <constraints>
@@ -237,7 +237,7 @@
           </constraints>
           <control type="spinner" format="integer" />
         </setting>
-        <setting id="onetvgroup" type="string" parent="tvgroupmode" label="30026">
+        <setting id="onetvgroup" type="string" parent="tvgroupmode" label="30026" help="30644">
           <level>0</level>
           <default></default>
           <constraints>
@@ -248,7 +248,7 @@
           </dependencies>
           <control type="edit" format="string" />
         </setting>
-        <setting id="tvfavouritesmode" type="integer" label="30068">
+        <setting id="tvfavouritesmode" type="integer" label="30068" help="30645">
           <level>0</level>
           <default>0</default>
           <constraints>
@@ -268,7 +268,7 @@
           </dependencies>
           <control type="spinner" format="integer" />
         </setting>
-        <setting id="excludelastscannedtv" type="boolean" label="30114">
+        <setting id="excludelastscannedtv" type="boolean" label="30114" help="30646">
           <level>0</level>
           <default>true</default>
           <dependencies>
@@ -278,7 +278,7 @@
         </setting>
       </group>
       <group id="3" label="30057">
-        <setting id="radiogroupmode" type="integer" label="30058">
+        <setting id="radiogroupmode" type="integer" label="30058" help="30647">
           <level>0</level>
           <default>0</default>
           <constraints>
@@ -290,7 +290,7 @@
           </constraints>
           <control type="spinner" format="integer" />
         </setting>
-        <setting id="oneradiogroup" type="string" parent="radiogroupmode" label="30059">
+        <setting id="oneradiogroup" type="string" parent="radiogroupmode" label="30059" help="30648">
           <level>0</level>
           <default></default>
           <constraints>
@@ -301,7 +301,7 @@
           </dependencies>
           <control type="edit" format="string" />
         </setting>
-        <setting id="radiofavouritesmode" type="integer" label="30069">
+        <setting id="radiofavouritesmode" type="integer" label="30069" help="30649">
           <level>0</level>
           <default>0</default>
           <constraints>
@@ -321,7 +321,7 @@
           </dependencies>
           <control type="spinner" format="integer" />
         </setting>
-        <setting id="excludelastscannedradio" type="boolean" label="30114">
+        <setting id="excludelastscannedradio" type="boolean" label="30114" help="30650">
           <level>0</level>
           <default>true</default>
           <dependencies>
@@ -333,14 +333,14 @@
     </category>
 
     <!-- EPG -->
-    <category id="epg" label="30032">
+    <category id="epg" label="30032" help="30660">
       <group id="1" label="30031">
-        <setting id="extractshowinfoenabled" type="boolean" label="30033">
+        <setting id="extractshowinfoenabled" type="boolean" label="30033" help="30661">
           <level>0</level>
           <default>false</default>
           <control type="toggle" />
         </setting>
-        <setting id="extractshowinfofile" type="path" parent="extractshowinfoenabled" label="30046">
+        <setting id="extractshowinfofile" type="path" parent="extractshowinfoenabled" label="30046" help="30662">
           <level>0</level>
           <default>special://userdata/addon_data/pvr.vuplus/showInfo/English-ShowInfo.xml</default>
           <constraints>
@@ -356,12 +356,12 @@
         </setting>
       </group>
       <group id="2" label="30053">
-        <setting id="genreidmapenabled" type="boolean" label="30054">
+        <setting id="genreidmapenabled" type="boolean" label="30054" help="30663">
           <level>0</level>
           <default>false</default>
           <control type="toggle" />
         </setting>
-        <setting id="genreidmapfile" type="path" parent="genreidmapenabled" label="30055">
+        <setting id="genreidmapfile" type="path" parent="genreidmapenabled" label="30055" help="30664">
           <level>0</level>
           <default>special://userdata/addon_data/pvr.vuplus/genres/genreIdMappings/Sky-UK.xml</default>
           <constraints>
@@ -377,12 +377,12 @@
         </setting>
       </group>
       <group id="3" label="30047">
-        <setting id="rytecgenretextmapenabled" type="boolean" label="30048">
+        <setting id="rytecgenretextmapenabled" type="boolean" label="30048" help="30665">
           <level>0</level>
           <default>false</default>
           <control type="toggle" />
         </setting>
-        <setting id="rytecgenretextmapfile" type="path" parent="rytecgenretextmapenabled" label="30049">
+        <setting id="rytecgenretextmapfile" type="path" parent="rytecgenretextmapenabled" label="30049" help="30666">
           <level>0</level>
           <default>special://userdata/addon_data/pvr.vuplus/genres/genreRytecTextMappings/Rytec-UK-Ireland.xml</default>
           <constraints>
@@ -396,7 +396,7 @@
             <heading>1033</heading>
           </control>
         </setting>
-        <setting id="logmissinggenremapping" type="boolean" parent="rytecgenretextmapenabled" label="30037">
+        <setting id="logmissinggenremapping" type="boolean" parent="rytecgenretextmapenabled" label="30037" help="30667">
           <level>0</level>
           <default>false</default>
           <dependencies>
@@ -406,7 +406,7 @@
         </setting>
       </group>
       <group id="4" label="30105">
-        <setting id="epgdelayperchannel" type="integer" label="30106">
+        <setting id="epgdelayperchannel" type="integer" label="30106" help="30668">
           <level>0</level>
           <default>0</default>
           <constraints>
@@ -419,7 +419,7 @@
             <formatlabel>14046</formatlabel>
           </control>
         </setting>
-        <setting id="skipinitialepg" type="boolean" label="30115">
+        <setting id="skipinitialepg" type="boolean" label="30115" help="30669">
           <level>0</level>
           <default>true</default>
           <control type="toggle" />
@@ -428,14 +428,14 @@
     </category>
 
     <!-- Recordings -->
-    <category id="recordings" label="30070">
+    <category id="recordings" label="30070" help="30680">
       <group id="1" label="30071">
-        <setting id="storeextrarecordinginfo" type="boolean" label="30127">
+        <setting id="storeextrarecordinginfo" type="boolean" label="30127" help="30681">
           <level>0</level>
           <default>true</default>
           <control type="toggle" />
         </setting>
-        <setting id="sharerecordinglastplayed" type="integer" parent="storeextrarecordinginfo" label="30128">
+        <setting id="sharerecordinglastplayed" type="integer" parent="storeextrarecordinginfo" label="30128" help="30682">
           <level>0</level>
           <default>0</default>
           <dependencies>
@@ -449,7 +449,7 @@
           </constraints>
           <control type="spinner" format="integer" />
         </setting>
-        <setting id="recordingpath" type="string" label="30023">
+        <setting id="recordingpath" type="string" label="30023" help="30683">
           <level>0</level>
           <default></default>
           <constraints>
@@ -457,12 +457,12 @@
           </constraints>
           <control type="edit" format="string" />
         </setting>
-        <setting id="onlycurrent" type="boolean" label="30017">
+        <setting id="onlycurrent" type="boolean" label="30017" help="30684">
           <level>0</level>
           <default>false</default>
           <control type="toggle" />
         </setting>
-        <setting id="keepfolders" type="boolean" label="30030">
+        <setting id="keepfolders" type="boolean" label="30030" help="30685">
           <level>0</level>
           <default>false</default>
           <control type="toggle" />
@@ -470,12 +470,12 @@
       </group>
 
       <group id="2" label="30107">
-        <setting id="enablerecordingedls" type="boolean" label="30108">
+        <setting id="enablerecordingedls" type="boolean" label="30108" help="30686">
           <level>0</level>
           <default>false</default>
           <control type="toggle" />
         </setting>
-        <setting id="edlpaddingstart" type="integer" parent="enablerecordingedls" label="30109">
+        <setting id="edlpaddingstart" type="integer" parent="enablerecordingedls" label="30109" help="30687">
           <level>0</level>
           <default>0</default>
           <constraints>
@@ -491,7 +491,7 @@
             <formatlabel>14046</formatlabel>
           </control>
         </setting>
-        <setting id="edlpaddingstop" type="integer" parent="enablerecordingedls" label="30110">
+        <setting id="edlpaddingstop" type="integer" parent="enablerecordingedls" label="30110" help="30688">
           <level>0</level>
           <default>0</default>
           <constraints>
@@ -511,14 +511,14 @@
     </category>
 
     <!-- Timers-->
-    <category id="timers" label="30072">
+    <category id="timers" label="30072" help="30700">
       <group id="1" label="30072">
-        <setting id="enablegenrepeattimers" type="boolean" label="30036">
+        <setting id="enablegenrepeattimers" type="boolean" label="30036" help="30701">
           <level>0</level>
           <default>true</default>
           <control type="toggle" />
         </setting>
-        <setting id="numgenrepeattimers" type="integer" parent="enablegenrepeattimers" label="30073">
+        <setting id="numgenrepeattimers" type="integer" parent="enablegenrepeattimers" label="30073" help="30702">
           <level>0</level>
           <default>1</default>
           <constraints>
@@ -531,19 +531,19 @@
           </dependencies>
           <control type="edit" format="integer" />
         </setting>
-        <setting id="timerlistcleanup" type="boolean" label="30011">
+        <setting id="timerlistcleanup" type="boolean" label="30011" help="30703">
           <level>0</level>
           <default>false</default>
           <control type="toggle" />
         </setting>
       </group>
       <group id="2" label="30123">
-        <setting id="enableautotimers" type="boolean" label="30034">
+        <setting id="enableautotimers" type="boolean" label="30034" help="30704">
           <level>0</level>
           <default>true</default>
           <control type="toggle" />
         </setting>
-        <setting id="limitanychannelautotimers" type="boolean" label="30124">
+        <setting id="limitanychannelautotimers" type="boolean" label="30124" help="30705">
           <level>0</level>
           <default>true</default>
           <dependencies>
@@ -551,7 +551,7 @@
           </dependencies>
           <control type="toggle" />
         </setting>
-        <setting id="limitanychannelautotimerstogroups" type="boolean" parent="limitanychannelautotimers" label="30125">
+        <setting id="limitanychannelautotimerstogroups" type="boolean" parent="limitanychannelautotimers" label="30125" help="30706">
           <level>0</level>
           <default>true</default>
           <dependencies>
@@ -564,9 +564,9 @@
     </category>
 
     <!-- Timeshift -->
-    <category id="timeshift" label="30060">
+    <category id="timeshift" label="30060" help="30720">
       <group id="1" label="30060">
-        <setting id="enabletimeshift" type="integer" label="30061">
+        <setting id="enabletimeshift" type="integer" label="30061" help="30721">
           <level>0</level>
           <default>0</default>
           <constraints>
@@ -578,7 +578,7 @@
           </constraints>
           <control type="spinner" format="integer" />
         </setting>
-        <setting id="timeshiftbufferpath" type="path" parent="enabletimeshift" label="30062">
+        <setting id="timeshiftbufferpath" type="path" parent="enabletimeshift" label="30062" help="30722">
           <level>0</level>
           <default>special://userdata/addon_data/pvr.vuplus</default>
           <constraints>
@@ -596,9 +596,9 @@
     </category>
 
     <!-- Advanced -->
-    <category id="advanced" label="30020">
+    <category id="advanced" label="30020" help="30740">
       <group id="1" label="30052">
-        <setting id="prependoutline" type="integer" label="30040">
+        <setting id="prependoutline" type="integer" label="30040" help="30741">
           <level>0</level>
           <default>0</default>
           <constraints>
@@ -611,7 +611,7 @@
           </constraints>
           <control type="list" format="integer" />
         </setting>
-        <setting id="powerstatemode" type="integer" label="30024">
+        <setting id="powerstatemode" type="integer" label="30024" help="30742">
           <level>0</level>
           <default>0</default>
           <constraints>
@@ -624,7 +624,7 @@
           </constraints>
           <control type="list" format="integer" />
         </setting>
-        <setting id="readtimeout" type="integer" label="30050">
+        <setting id="readtimeout" type="integer" label="30050" help="30743">
           <level>0</level>
           <default>0</default>
           <constraints>
@@ -637,7 +637,7 @@
             <formatlabel>14045</formatlabel>
           </control>
         </setting>
-        <setting id="streamreadchunksize" type="integer" label="30041">
+        <setting id="streamreadchunksize" type="integer" label="30041" help="30744">
           <level>0</level>
           <default>0</default>
           <constraints>
@@ -650,12 +650,12 @@
             <formatlabel>14049</formatlabel>
           </control>
         </setting>
-        <setting id="debugnormal" type="boolean" label="30111">
+        <setting id="debugnormal" type="boolean" label="30111" help="30745">
           <level>0</level>
           <default>false</default>
           <control type="toggle" />
         </setting>
-        <setting id="tracedebug" type="boolean" label="30104">
+        <setting id="tracedebug" type="boolean" label="30104" help="30746">
           <level>0</level>
           <default>false</default>
           <control type="toggle" />
@@ -666,9 +666,9 @@
     <!-- Backend -->
     <!-- Add again one new addon API is supported -->
     <!--
-    <category id="backend" label="30086">
+    <category id="backend" label="30086" help="30760">
       <group id="1" label="30090">
-        <setting id="webifversion" type="string" label="30091">
+        <setting id="webifversion" type="string" label="30091" help="30761">
           <level>0</level>
           <default>N/A</default>
           <dependencies>
@@ -676,7 +676,7 @@
           </dependencies>
           <control type="edit" format="string" />
         </setting>
-        <setting id="autotimertagintags" type="string" label="30092">
+        <setting id="autotimertagintags" type="string" label="30092" help="30762">
           <level>0</level>
           <default>N/A</default>
           <dependencies>
@@ -684,7 +684,7 @@
           </dependencies>
           <control type="edit" format="string" />
         </setting>
-        <setting id="autotimernameintags" type="string" label="30093">
+        <setting id="autotimernameintags" type="string" label="30093" help="30763">
           <level>0</level>
           <default>N/A</default>
           <dependencies>
@@ -695,7 +695,7 @@
       </group>
 
       <group id="2" label="30087">
-        <setting id="globalstartpaddingstb" type="integer" label="30088">
+        <setting id="globalstartpaddingstb" type="integer" label="30088" help="30764">
           <level>0</level>
           <default>0</default>
           <constraints>
@@ -708,7 +708,7 @@
             <formatlabel>14044</formatlabel>
           </control>
         </setting>
-        <setting id="globalendpaddingstb" type="integer" label="30089">
+        <setting id="globalendpaddingstb" type="integer" label="30089" help="30765">
           <level>0</level>
           <default>0</default>
           <constraints>

--- a/pvr.vuplus/resources/settings.xml
+++ b/pvr.vuplus/resources/settings.xml
@@ -102,7 +102,7 @@
           <constraints>
             <minimum>1</minimum>
             <step>1</step>
-            <maximum>10</maximum>
+            <maximum>60</maximum>
           </constraints>
           <control type="slider" format="integer">
             <popup>true</popup>

--- a/src/Enigma2.h
+++ b/src/Enigma2.h
@@ -127,7 +127,7 @@ private:
   enigma2::Recordings m_recordings = enigma2::Recordings(m_channels, m_entryExtractor);
   std::vector<std::string>& m_locations = m_recordings.GetLocations();
   enigma2::Epg m_epg = enigma2::Epg(m_entryExtractor);
-  enigma2::Timers m_timers = enigma2::Timers(m_channels, m_channelGroups, m_locations, m_epg);
+  enigma2::Timers m_timers = enigma2::Timers(m_channels, m_channelGroups, m_locations, m_epg, m_entryExtractor);
   enigma2::Settings &m_settings = enigma2::Settings::GetInstance();
   enigma2::Admin m_admin;
   enigma2::extract::EpgEntryExtractor m_entryExtractor;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -220,13 +220,13 @@ PVR_ERROR GetAddonCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities)
 
 const char *GetBackendName(void)
 {
-  static const char *backendName = enigma ? enigma->GetServerName() : LocalizedString(60081).c_str(); //unknown
+  static const char *backendName = enigma ? enigma->GetServerName() : LocalizedString(30081).c_str(); //unknown
   return backendName;
 }
 
 const char *GetBackendVersion(void)
 {
-  static const char *backendVersion = enigma ? enigma->GetServerVersion() : LocalizedString(60081).c_str(); //unknown
+  static const char *backendVersion = enigma ? enigma->GetServerVersion() : LocalizedString(30081).c_str(); //unknown
   return backendVersion;
 }
 
@@ -235,9 +235,9 @@ static std::string connectionString;
 const char *GetConnectionString(void)
 {
   if (enigma)
-    connectionString = StringUtils::Format("%s%s", settings.GetHostname().c_str(), enigma->IsConnected() ? "" : LocalizedString(60082).c_str()); // (Not connected!)
+    connectionString = StringUtils::Format("%s%s", settings.GetHostname().c_str(), enigma->IsConnected() ? "" : LocalizedString(30082).c_str()); // (Not connected!)
   else
-    connectionString = StringUtils::Format("%s (%s!)", settings.GetHostname().c_str(), LocalizedString(60083).c_str()); //addon error
+    connectionString = StringUtils::Format("%s (%s!)", settings.GetHostname().c_str(), LocalizedString(30083).c_str()); //addon error
   return connectionString.c_str();
 }
 

--- a/src/enigma2/Admin.cpp
+++ b/src/enigma2/Admin.cpp
@@ -58,7 +58,7 @@ void Admin::SendPowerstate()
 
 bool Admin::Initialise()
 {
-  std::string unknown = LocalizedString(60081).c_str();
+  std::string unknown = LocalizedString(30081).c_str();
   SetCharString(m_serverName, unknown);
   SetCharString(m_serverVersion, unknown);
 
@@ -142,7 +142,7 @@ bool Admin::LoadDeviceInfo()
   if (!XMLUtils::GetString(pElem, "e2distroversion", strTmp))
   {
     Logger::Log(LEVEL_NOTICE, "%s Could not parse e2distroversion from result, continuing as not available in all images!", __FUNCTION__);
-    strTmp = LocalizedString(60081); //unknown
+    strTmp = LocalizedString(30081); //unknown
   }
   else
   {

--- a/src/enigma2/Timers.cpp
+++ b/src/enigma2/Timers.cpp
@@ -247,7 +247,7 @@ void Timers::GetTimerTypes(std::vector<PVR_TIMER_TYPE> &types) const
       if ((iRecordingGroupSize = groupValues.size()))
         iRecordingGroupDefault = groupValues[0].first;
       i = 0;
-      for (auto &group : groupValues)
+      for (const auto &group : groupValues)
       {
         recordingGroup[i].iValue = group.first;
         strncpy(recordingGroup[i].strDescription, group.second.c_str(), sizeof(recordingGroup[i].strDescription) - 1);
@@ -257,7 +257,7 @@ void Timers::GetTimerTypes(std::vector<PVR_TIMER_TYPE> &types) const
       if ((iPreventDuplicateEpisodesSize = deDupValues.size()))
         iPreventDuplicateEpisodesDefault = preventDuplicateEpisodesDefault;
       i = 0;
-      for (auto &deDup : deDupValues)
+      for (const auto &deDup : deDupValues)
       {
         preventDuplicateEpisodes[i].iValue = deDup.first;
         strncpy(preventDuplicateEpisodes[i].strDescription, deDup.second.c_str(), sizeof(preventDuplicateEpisodes[i].strDescription) - 1);
@@ -270,7 +270,7 @@ void Timers::GetTimerTypes(std::vector<PVR_TIMER_TYPE> &types) const
   std::vector<std::pair<int, std::string>> groupValues = {
     { 0, LocalizedString(30410) }, //automatic
   };
-  for (auto &recf : m_locations)
+  for (const auto &recf : m_locations)
     groupValues.emplace_back(groupValues.size(), recf);
 
   /* One-shot manual (time and channel based) */
@@ -676,7 +676,7 @@ PVR_ERROR Timers::UpdateTimer(const PVR_TIMER &timer)
 
   const std::string strServiceReference = m_channels.GetChannel(timer.iClientChannelUid)->GetServiceReference().c_str();
 
-  const auto it = std::find_if(m_timers.cbegin(), m_timers.cend(), [timer](const Timer& myTimer)
+  const auto it = std::find_if(m_timers.cbegin(), m_timers.cend(), [&timer](const Timer& myTimer)
   {
     return myTimer.GetClientIndex() == timer.iClientIndex;
   });
@@ -752,7 +752,7 @@ std::string Timers::RemovePaddingTag(std::string tag)
 
 PVR_ERROR Timers::UpdateAutoTimer(const PVR_TIMER &timer)
 {
-  const auto it = std::find_if(m_autotimers.cbegin(), m_autotimers.cend(), [timer](const AutoTimer& autoTimer)
+  const auto it = std::find_if(m_autotimers.cbegin(), m_autotimers.cend(), [&timer](const AutoTimer& autoTimer)
   {
     return autoTimer.GetClientIndex() == timer.iClientIndex;
   });
@@ -944,7 +944,7 @@ PVR_ERROR Timers::DeleteTimer(const PVR_TIMER &timer)
   if (IsAutoTimer(timer))
     return DeleteAutoTimer(timer);
 
-  const auto it = std::find_if(m_timers.cbegin(), m_timers.cend(), [timer](const Timer& myTimer)
+  const auto it = std::find_if(m_timers.cbegin(), m_timers.cend(), [&timer](const Timer& myTimer)
   {
     return myTimer.GetClientIndex() == timer.iClientIndex;
   });
@@ -972,7 +972,7 @@ PVR_ERROR Timers::DeleteTimer(const PVR_TIMER &timer)
 
 PVR_ERROR Timers::DeleteAutoTimer(const PVR_TIMER &timer)
 {
-  const auto it = std::find_if(m_autotimers.cbegin(), m_autotimers.cend(), [timer](const AutoTimer& autoTimer)
+  const auto it = std::find_if(m_autotimers.cbegin(), m_autotimers.cend(), [&timer](const AutoTimer& autoTimer)
   {
     return autoTimer.GetClientIndex() == timer.iClientIndex;
   });
@@ -983,7 +983,7 @@ PVR_ERROR Timers::DeleteAutoTimer(const PVR_TIMER &timer)
 
     //remove any child timers
     bool childTimerIsRecording = false;
-    for (auto &childTimer : m_timers)
+    for (const auto &childTimer : m_timers)
     {
       if (childTimer.GetParentClientIndex() == timerToDelete.GetClientIndex())
       {

--- a/src/enigma2/Timers.cpp
+++ b/src/enigma2/Timers.cpp
@@ -74,6 +74,9 @@ std::vector<Timer> Timers::LoadTimers() const
     if (!newTimer.UpdateFrom(pNode, m_channels))
       continue;
 
+    if (m_entryExtractor.IsEnabled())
+      m_entryExtractor.ExtractFromEntry(newTimer);
+
     timers.emplace_back(newTimer);
 
     if ((newTimer.GetType() == Timer::MANUAL_REPEATING || newTimer.GetType() == Timer::EPG_REPEATING)

--- a/src/enigma2/Timers.h
+++ b/src/enigma2/Timers.h
@@ -10,6 +10,7 @@
 #include "Epg.h"
 #include "data/AutoTimer.h"
 #include "data/Timer.h"
+#include "extract/EpgEntryExtractor.h"
 
 #include "libXBMC_pvr.h"
 #include "tinyxml.h"
@@ -19,8 +20,8 @@ namespace enigma2
   class Timers
   {
   public:
-    Timers(Channels &channels, ChannelGroups &channelGroups, std::vector<std::string> &locations, Epg &epg)
-      : m_channels(channels), m_channelGroups(channelGroups), m_locations(locations), m_epg(epg)
+    Timers(Channels &channels, ChannelGroups &channelGroups, std::vector<std::string> &locations, Epg &epg, enigma2::extract::EpgEntryExtractor &entryExtractor)
+      : m_channels(channels), m_channelGroups(channelGroups), m_locations(locations), m_epg(epg), m_entryExtractor(entryExtractor)
     {
       m_clientIndexCounter = 1;
     };
@@ -71,6 +72,8 @@ namespace enigma2
     // members
     unsigned int m_clientIndexCounter;
     std::vector<std::atomic_bool*> m_timerChangeWatchers;
+
+    enigma2::extract::EpgEntryExtractor &m_entryExtractor;
 
     enigma2::Settings &m_settings = enigma2::Settings::GetInstance();
     std::vector<enigma2::data::Timer> m_timers;

--- a/src/enigma2/data/AutoTimer.cpp
+++ b/src/enigma2/data/AutoTimer.cpp
@@ -159,12 +159,15 @@ bool AutoTimer::UpdateFrom(TiXmlElement* autoTimerNode, Channels &channels)
       {
         m_channelId = channels.GetChannelUniqueId(Channel::NormaliseServiceReference(strTmp.c_str()));
 
-        // Skip autotimers for channels we don't know about, such as when the addon only uses one bouquet or an old channel referene that doesn't exist
+        // For autotimers for channels we don't know about, such as when the addon only uses one bouquet or an old channel referene that doesn't exist
+        // we'll default to any channel (as that is what kodi PVR does) and leave in ERROR state
         if (m_channelId == PVR_CHANNEL_INVALID_UID)
         {
           m_state = PVR_TIMER_STATE_ERROR;
           Logger::Log(LEVEL_DEBUG, "%s Overriding AutoTimer state as channel not found, state is: ERROR", __FUNCTION__);
           m_channelName = LocalizedString(30520); // Invalid Channel
+          m_channelId = PVR_TIMER_ANY_CHANNEL;
+          m_anyChannel = true;
         }
         else
         {

--- a/src/enigma2/data/EpgEntry.cpp
+++ b/src/enigma2/data/EpgEntry.cpp
@@ -110,7 +110,7 @@ bool EpgEntry::UpdateFrom(TiXmlElement* eventNode, const std::shared_ptr<EpgChan
     m_plot = strTmp;
 
   if (XMLUtils::GetString(eventNode, "e2eventdescription", strTmp))
-      m_plotOutline = strTmp;
+    m_plotOutline = strTmp;
 
   ProcessPrependMode(PrependOutline::IN_EPG);
 

--- a/src/enigma2/data/Timer.cpp
+++ b/src/enigma2/data/Timer.cpp
@@ -157,7 +157,10 @@ bool Timer::UpdateFrom(TiXmlElement* timerNode, Channels &channels)
   m_title = strTmp;
 
   if (XMLUtils::GetString(timerNode, "e2servicereference", strTmp))
+  {
+    m_serviceReference = strTmp;
     m_channelId = channels.GetChannelUniqueId(Channel::NormaliseServiceReference(strTmp.c_str()));
+  }
 
   // Skip timers for channels we don't know about, such as when the addon only uses one bouquet or an old channel referene that doesn't exist
   if (m_channelId == PVR_CHANNEL_INVALID_UID)

--- a/src/enigma2/data/Timer.cpp
+++ b/src/enigma2/data/Timer.cpp
@@ -36,6 +36,15 @@ bool Timer::operator==(const Timer &right) const
   isEqual &= (m_title == right.m_title);
   isEqual &= (m_plot == right.m_plot);
   isEqual &= (m_tags == right.m_tags);
+  isEqual &= (m_plotOutline == right.m_plotOutline);
+  isEqual &= (m_plot == right.m_plot);
+  isEqual &= (m_genreType == right.m_genreType);
+  isEqual &= (m_genreSubType == right.m_genreSubType);
+  isEqual &= (m_genreDescription == right.m_genreDescription);
+  isEqual &= (m_episodeNumber == right.m_episodeNumber);
+  isEqual &= (m_episodePartNumber == right.m_episodePartNumber);
+  isEqual &= (m_seasonNumber == right.m_seasonNumber);
+  isEqual &= (m_year == right.m_year);
 
   return isEqual;
 }
@@ -54,6 +63,15 @@ void Timer::UpdateFrom(const Timer &right)
   m_state = right.m_state;
   m_paddingStartMins = right.m_paddingStartMins;
   m_paddingEndMins = right.m_paddingEndMins;
+  m_plotOutline = right.m_plotOutline;
+  m_plot = right.m_plot;
+  m_genreType = right.m_genreType;
+  m_genreSubType = right.m_genreSubType;
+  m_genreDescription = right.m_genreDescription;
+  m_episodeNumber = right.m_episodeNumber;
+  m_episodePartNumber = right.m_episodePartNumber;
+  m_seasonNumber = right.m_seasonNumber;
+  m_year = right.m_year;
 }
 
 void Timer::UpdateTo(PVR_TIMER &left) const
@@ -183,10 +201,10 @@ bool Timer::UpdateFrom(TiXmlElement* timerNode, Channels &channels)
 
   m_endTime = iTmp;
 
-  if (XMLUtils::GetString(timerNode, "e2description", strTmp))
+  if (XMLUtils::GetString(timerNode, "e2descriptionextended", strTmp))
     m_plot = strTmp;
 
-  if (XMLUtils::GetString(timerNode, "e2descriptionextended", strTmp))
+  if (XMLUtils::GetString(timerNode, "e2description", strTmp))
     m_plotOutline = strTmp;
 
   // Some providers only use PlotOutline (e.g. freesat) and Kodi does not display it, if this is the case swap them

--- a/src/enigma2/data/Timer.h
+++ b/src/enigma2/data/Timer.h
@@ -25,6 +25,7 @@
 #include <ctime>
 #include <type_traits>
 
+#include "BaseEntry.h"
 #include "Tags.h"
 #include "../Channels.h"
 #include "../utilities/UpdateState.h"
@@ -41,7 +42,7 @@ namespace enigma2
     static const std::string TAG_FOR_EPG_TIMER = "EPG";
     static const std::string TAG_FOR_PADDING = "Padding";
 
-    class Timer : public Tags
+    class Timer : public BaseEntry, public Tags
     {
     public:
 
@@ -66,14 +67,8 @@ namespace enigma2
       Type GetType() const { return m_type; }
       void SetType(const Type value ) { m_type = value; }
 
-      const std::string& GetTitle() const { return m_title; }
-      void SetTitle(const std::string& value ) { m_title = value; }
-
       const std::string& GetServiceReference() const { return m_serviceReference; }
       void SetServiceReference(const std::string& value ) { m_serviceReference = value; }
-
-      const std::string& GetPlot() const { return m_plot; }
-      void SetPlot(const std::string& value ) { m_plot = value; }
 
       int GetChannelId() const { return m_channelId; }
       void SetChannelId(int value) { m_channelId = value; }
@@ -126,10 +121,7 @@ namespace enigma2
 
     protected:
       Type m_type = Type::MANUAL_ONCE;
-      std::string m_title;
       std::string m_serviceReference;
-      std::string m_plot;
-      std::string m_plotOutline;
       int m_channelId;
       std::string m_channelName;
       time_t m_startTime;
@@ -142,8 +134,6 @@ namespace enigma2
       unsigned int m_parentClientIndex;
       unsigned int m_paddingStartMins = 0;
       unsigned int m_paddingEndMins = 0;
-      int m_genreType = 0;
-      int m_genreSubType = 0;
     };
   } //namespace data
 } //namespace enigma2

--- a/src/enigma2/data/Timer.h
+++ b/src/enigma2/data/Timer.h
@@ -69,6 +69,9 @@ namespace enigma2
       const std::string& GetTitle() const { return m_title; }
       void SetTitle(const std::string& value ) { m_title = value; }
 
+      const std::string& GetServiceReference() const { return m_serviceReference; }
+      void SetServiceReference(const std::string& value ) { m_serviceReference = value; }
+
       const std::string& GetPlot() const { return m_plot; }
       void SetPlot(const std::string& value ) { m_plot = value; }
 
@@ -124,6 +127,7 @@ namespace enigma2
     protected:
       Type m_type = Type::MANUAL_ONCE;
       std::string m_title;
+      std::string m_serviceReference;
       std::string m_plot;
       std::string m_plotOutline;
       int m_channelId;


### PR DESCRIPTION
v3.22.0
- Added: Help info for addon settings
- Added: Delete child timers when deleting autotimers
- Added: Set max connection check interval to 60 seconds
- Fixed: Incorrect localisation IDs
- Fixed: Timers in error state cause crash on delete
- Added: Support show info fields for Timers