### PR TITLE
Custom groups and timer fix matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ Within this tab the connection options need to be configured before it can be su
 * **Streaming port**: This option defines the streaming port the set-top box uses to stream live tv. The default is 8001 which should be fine if the user did not define a custom port within the webinterface.
 * **Use secure HTTP (https) for streams**: Use https to connect to streams.
 * **Use login for streams**: Use the login username and password for streams.
-* **Connection check timeout**: The value in seconds to wait for a connection check to complete before failure. Useful for tuning on older Enigma2 devices.
-* **Connection check interval**: The value in seconds to wait between connection checks. Useful for tuning on older Enigma2 devices.
+* **Connection check timeout**: The value in seconds to wait for a connection check to complete before failure. Useful for tuning on older Enigma2 devices. Note, this setting should rarely need to be changed. It's more likely the `Connection check interval` will have the desired effect. Default is 30 seconds.
+* **Connection check interval**: The value in seconds to wait between connection checks. Useful for tuning on older Enigma2 devices. Default is 10 seconds.
 
 ### General
 Within this tab general options are configured.
@@ -224,7 +224,7 @@ Within this tab more uncommon and advanced options can be configured.
     - `Standby` - Send the standby command on exit
     - `Deep standby` - Send the deep standby command on exit. Note, the set-top box will not respond to Kodi after this command is sent.
     - `Wakeup, then standby` - Similar to standby but first sends a wakeup command. Can be useful if you want to ensure all streams have stopped. Note: if you use CEC this could cause your TV to wake.
-* **Custom live TV timeout (0 to use default)**: The timemout to use when trying to read live streams. Default for live streams is 0. Default for for timeshifting is 10 seconds.
+* **Custom live TV timeout (0 to use default)**: The timemout to use when trying to read live streams. Default for live streams is 0. Default for timeshifting is 10 seconds.
 * **Stream read chunk size**: The chunk size used by Kodi for streams. Default 0 to leave it to Kodi to decide.
 * **Enable debug logging in normal mode**: Debug log statements will display for the addon even though debug logging may not be enabled in Kodi. Note that all debug log statements will display at NOTICE level.
 * **Enable trace logging in debug mode**: Very detailed and verbose log statements will display in addition to standard debug statements. If enabled along with `Enable debug logging in normal mode` both trace and debug will display without debug logging enabled. In this case both debug and trace log statements will display at NOTICE level.

--- a/README.md
+++ b/README.md
@@ -115,9 +115,12 @@ Within this tab options that refer to channel data can be set. When changing bou
 * **Zap before channelswitch (i.e. for Single Tuner boxes)**: When using the addon with a single tuner box it may be necessary that the addon needs to be able to zap to another channel on the set-top box. If this option is enabled each channel switch in Kodi will also result in a channel switch on the set-top box. Please note that "allow channel switching" needs to be enabled in the webinterface on the set-top box.
 * **TV bouquet fetch mode**: Choose from one of the following three modes:
     - `All bouquets` - Fetch all TV bouquets from the set-top box.
-    - `Only one bouquet` - Only fetch the bouquet specified in the next option
-    - `Favourites group` - Only fetch the system bouquet for TV favourites.
-* **TV bouquet**: If the previous option has been has been set to `Only one bouquet` you need to specify the TV bouquet to be fetched from the set-top box. Please not that this is the bouquet-name as shown on the set-top box (i.e. "Favourites (TV)"). This setting is case-sensitive.
+    - `Some bouquets` - Only fetch the bouquet specified in the next option
+    - `Favourites bouquet` - Only fetch the system bouquet for TV favourites.
+    - `Custom bouquets` - Fetch a set of bouquets from the Set-top box whose names are loaded from an XML file.
+* **Number of TV bouquets**: The number of TV bouquets to load when `Some bouquets` is the selected fetch mode. Up to 5 can be chosen. If more than 5 are required the `Custom bouquets` fetch mode should be used instead.
+* **TV bouquet 1-5**: If the previous option has been has been set to `Some bouquets` you need to specify a TV bouquet to be fetched from the set-top box. Please not that this is the bouquet-name as shown on the set-top box (i.e. "Favourites (TV)"). This setting is case-sensitive.
+* **Custom TV Groups file**: The file used to load the custom TV bouquets (groups). If no groups can be matched the channel list will default to 'Last Scanned (TV)'. The default file is `customTVGroups-example.xml`. Details on how to customise can be found in the next section of the README.
 * **Fetch TV favourites bouquet**: If the fetch mode is `All bouquets` or `Only one bouquet` depending on your Enigma2 image you may need to explicitly fetch favourites if you require them. The options are:
     - `Disabled` - Don't explicitly fetch TV favourites.
     - `As first bouquet` - Explicitly fetch them as the first bouquet.
@@ -125,9 +128,12 @@ Within this tab options that refer to channel data can be set. When changing bou
 * **Exclude last scanned bouquet**: Last scanned is a system bouquet containing all the TV and Radio channels found in the last scan. Any TV channels found in the Last Scanned bouquet can be displayed as a group called ```Last Scanned (TV)``` in Kodi. For TV this group is excluded by default. Disable this option to exclude this group. Note that if no TV groups are loaded the Last Scanned group for TV will be loaded by default regardless of this setting.
 * **Radio bouquet fetch mode**: Choose from one of the following three modes:
     - `All bouquets` - Fetch all Radio bouquets from the set-top box.
-    - `Only one bouquet` - Only fetch the bouquet specified in the next option
-    - `Favourites group` - Only fetch the system bouquet for Radio favourites.
-* **Radio bouquet**: If the previous option has been has been set to `Only one bouquet` you need to specify the Radio bouquet to be fetched from the set-top box. Please not that this is the bouquet-name as shown on the set-top box (i.e. "Favourites (Radio)"). This setting is case-sensitive.
+    - `Some bouquets` - Only fetch the bouquet specified in the next option
+    - `Favourites bouquet` - Only fetch the system bouquet for Radio favourites.
+    - `Custom bouquets` - Fetch a set of bouquets from the Set-top box whose names are loaded from an XML file.
+* **Number of radio bouquets**: The number of Radio bouquets to load when `Some bouquets` is the selected fetch mode. Up to 5 can be chosen. If more than 5 are required the `Custom bouquets` fetch mode should be used instead.
+* **Radio bouquet 1-5**: If the previous option has been has been set to `Some bouquets` you need to specify a Radio bouquet to be fetched from the set-top box. Please not that this is the bouquet-name as shown on the set-top box (i.e. "Favourites (Radio)"). This setting is case-sensitive.
+* **Custom Radio Groups file**: The file used to load the custom Radio bouquets (groups). If no groups can be matched the channel list will default to 'Last Scanned (Radio)'. The default file is `customRadioGroups-example.xml`. Details on how to customise can be found in the next section of the README.
 * **Fetch Radio favourites bouquet**: If the fetch mode is `All bouquets` or `Only one bouquet` depending on your Enigma2 image you may need to explicitly fetch favourites if you require them. The options are:
     - `Disabled` - Don't explicitly fetch Radio favourites.
     - `As first bouquet` - Explicitly fetch them as the first bouquet.
@@ -231,17 +237,29 @@ Within this tab more uncommon and advanced options can be configured.
 
 ## Customising Config Files
 
-The various config files allow users to create their own, making it possible to support other languages and formats. Each different type of config file is detailed below. Best way to learn about them is to read the config files themselves. Each contains details of how the config file works.
+The various config files have examples allowing users to create their own, making it possible to support custom config, other languages and formats. Each different type of config file is detailed below. Best way to learn about them is to read the config files themselves. Each contains details of how the config file works.
 
 All of the files listed below are overwritten each time the addon starts. Therefore if you are customising files please create new copies with different file names. Note: that only the files below are overwritten any new files you create will not be touched.
 
-After adding and selecting new config files you will need to clear the EPG cache `Settings->PVR & Live TV->Guide->Clear cache` for it to take effect.
+After adding and selecting new config files you will need to clear the EPG cache `Settings->PVR & Live TV->Guide->Clear cache` for it to take effect in the case of EPG relatd config and for channel related config will need to clear the full cache `Settings->PVR & Live TV->General->Clear cache`.
 
 If you would like to support other formats/languages please raise an issue at the github project https://github.com/kodi-pvr/pvr.vuplus, where you can either create a PR or request your new configs be shipped with the addon.
 
 There is one config file located here: `userdata/addon_data/pvr.vuplus/genres/kodiDvbGenres.xml`. This simply contains the DVB genre IDs that Kodi supports. Can be a useful reference if creating your own configs. This file is also overwritten each time the addon restarts.
 
-### Season, Episode and Year Show Info
+### Custom Channel Groups (Channels)
+
+Config files are located in the `userdata/addon_data/pvr.vuplus/channelGroups` folder.
+
+The following files are currently available with the addon:
+    - `customTVGroups-example.xml`
+    - `customRadioGroups-example.xml`
+
+Note that both these files are provided as examples and are overwritten each time the addon starts. Therefore you should make copies and use those for your custom config.
+
+The format is quite simple, containing a number of channel group/bouquet names.
+
+### Season, Episode and Year Show Info (EPG_)
 
 Config files are located in the `userdata/addon_data/pvr.vuplus/showInfo` folder.
 
@@ -250,7 +268,7 @@ The following files are currently available with the addon:
 
 Note: the config file can contain as many pattern matches as are required. So if you need to support multiple languages in a single file that is possible. However there must be at least one <seasonEpisode> pattern and at least one <year> pattern. Proficiency in regular exressions is required!
 
-### Genre ID Mappings
+### Genre ID Mappings (EPG)
 
 Config files are located in the `userdata/addon_data/pvr.vuplus/genres/genreIdMappings` folder.
 
@@ -262,7 +280,7 @@ The following files are currently available with the addon:
 
 Note: that each source genre ID can be mapped to a DVB ID. However multiple source IDs can be mapped to the same DVB ID. Therefore there are exactly 256 <mapping> elements in each file as a genre ID is 8 bits. All values are in Hex. The first fours bits are the genreType in Kodi PVR and the last four bits are the genreSubType.
 
-### Rytec Genre Text Mappings
+### Rytec Genre Text Mappings (EPG)
 
 Config files are located in the `userdata/addon_data/pvr.vuplus/genres/genreRytecTextMappings` folder.
 

--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="4.1.1"
+  version="4.2.0"
   name="Enigma2 Client"
   provider-name="Joerg Dembski and Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>
@@ -175,6 +175,12 @@
     <disclaimer lang="zh_TW">這是測試版軟體！其原創作者並無法對於以下情況負責，包含：錄影失敗，不正確的定時設定，多餘時數，或任何產生的其它不良影響...</disclaimer>
     <platform>@PLATFORM@</platform>
     <news>
+v4.2.0
+- Added: Custom Channel Groups, closes #209
+- Added: Connection manager improvements
+- Added: Support hidden entries for backend channel numbers
+- Fixed: Timer descprition for providers who only use long descrption
+
 v4.1.1
 - Fixed: Valid XML in addon.xml
 

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,3 +1,9 @@
+v4.2.0
+- Added: Custom Channel Groups, closes #209
+- Added: Connection manager improvements
+- Added: Support hidden entries for backend channel numbers
+- Fixed: Timer descprition for providers who only use long descrption
+
 v4.1.1
 - Fixed: Valid XML in addon.xml
 

--- a/pvr.vuplus/resources/data/channelGroups/customRadioGroups-example.xml
+++ b/pvr.vuplus/resources/data/channelGroups/customRadioGroups-example.xml
@@ -1,0 +1,17 @@
+<!--
+
+Custom Channel Groups:
+ - Allows users to create a bespoke list of groups to load.
+ - For each name that matches a group/bouquet name from the set top box include it in the channels loaded
+ - If no names match the addon will load last scanned by default.
+ - channelGroupName is the only value to be set
+
+If you are creating your own Custom Channel Groups file make a copy of this file in the same directory so it's not overwritten and start from there.
+
+NOTE: IF YOU MODIFY THIS FILE IT WILL BE OVERWRITTEN NEXT TIME THE ADDON IS STARTED
+-->
+
+<customChannelGroups>
+  <channelGroupName>FreeSat UK - Radio Channels</channelGroupName>
+  <channelGroupName>Saorview - Radio Channels</channelGroupName>
+</customChannelGroups>

--- a/pvr.vuplus/resources/data/channelGroups/customTVGroups-example.xml
+++ b/pvr.vuplus/resources/data/channelGroups/customTVGroups-example.xml
@@ -1,0 +1,18 @@
+<!--
+
+Custom Channel Groups:
+ - Allows users to create a bespoke list of groups to load.
+ - For each name that matches a group/bouquet name from the set top box include it in the channels loaded
+ - If no names match the addon will load last scanned by default.
+ - channelGroupName is the only value to be set
+
+If you are creating your own Custom Channel Groups file make a copy of this file in the same directory so it's not overwritten and start from there.
+
+NOTE: IF YOU MODIFY THIS FILE IT WILL BE OVERWRITTEN NEXT TIME THE ADDON IS STARTED
+-->
+
+<customChannelGroups>
+  <channelGroupName>FreeSat UK - All channels</channelGroupName>
+  <channelGroupName>FreeSat UK - Saorview</channelGroupName>
+  <channelGroupName>FreeSat UK - Movies</channelGroupName>
+</customChannelGroups>

--- a/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
@@ -131,7 +131,7 @@ msgstr ""
 
 #label: Channels - onetvgroup
 msgctxt "#30026"
-msgid "TV bouquet"
+msgid "TV bouquet 1"
 msgstr ""
 
 #label: General - onlinepicons
@@ -296,7 +296,7 @@ msgstr ""
 
 #label: Channels - oneradiogroup
 msgctxt "#30059"
-msgid "Radio bouquet"
+msgid "Radio bouquet 1"
 msgstr ""
 
 #label-category: timeshift
@@ -380,7 +380,7 @@ msgstr ""
 #label-option: Channels - tvgroupmode
 #label-option: Channels - radiogroupmode
 msgctxt "#30075"
-msgid "Only one bouquet"
+msgid "Some bouquets"
 msgstr ""
 
 #label-option: Channels - tvfavouritesmode
@@ -398,7 +398,7 @@ msgstr ""
 #label-option: Channels - tvgroupmode
 #label-option: Channels - radiogroupmode
 msgctxt "#30078"
-msgid "Favourites group"
+msgid "Favourites bouquet"
 msgstr ""
 
 #application: ChannelGroups
@@ -655,7 +655,73 @@ msgctxt "#30130"
 msgid "Kodi/E2 instances"
 msgstr ""
 
-#empty strings from id 30131 to 30409
+#label-option: Channels - tvgroupmode
+#label-option: Channels - radiogroupmode
+msgctxt "#30131"
+msgid "Custom bouquets"
+msgstr ""
+
+#label: Channels - customtvgroupsfile
+msgctxt "#30132"
+msgid "Custom TV bouquets file"
+msgstr ""
+
+#label: Channels - customradiogroupsfile
+msgctxt "#30133"
+msgid "Custom Radio bouquets file"
+msgstr ""
+
+#label: Channels - numtvgroups
+msgctxt "#30134"
+msgid "Number of TV bouquets"
+msgstr ""
+
+#label: Channels - twotvgroup
+msgctxt "#30135"
+msgid "TV bouquet 2"
+msgstr ""
+
+#label: Channels - threetvgroup
+msgctxt "#30136"
+msgid "TV bouquet 3"
+msgstr ""
+
+#label: Channels - fourtvgroup
+msgctxt "#30137"
+msgid "TV bouquet 4"
+msgstr ""
+
+#label: Channels - fivetvgroup
+msgctxt "#30138"
+msgid "TV bouquet 5"
+msgstr ""
+
+#label: Channels - numradiogroups
+msgctxt "#30139"
+msgid "Number of radio bouquets"
+msgstr ""
+
+#label: Channels - tworadiogroup
+msgctxt "#30140"
+msgid "Radio bouquet 2"
+msgstr ""
+
+#label: Channels - threeradiogroup
+msgctxt "#30141"
+msgid "Radio bouquet 3"
+msgstr ""
+
+#label: Channels - fourradiogroup
+msgctxt "#30142"
+msgid "Radio bouquet 4"
+msgstr ""
+
+#label: Channels - fiveradiogroup
+msgctxt "#30143"
+msgid "Radio bouquet 5"
+msgstr ""
+
+#empty strings from id 30144 to 30409
 
 ###############
 # application #
@@ -910,17 +976,21 @@ msgstr ""
 
 #help: Channels - tvgroupmode
 msgctxt "#30643"
-msgid "Choose from one of the following three modes: [All bouquets] Fetch all TV bouquets from the set-top box; [Only one bouquet] Only fetch the bouquet specified in the next option; [Favourites group] Only fetch the system bouquet for TV favourites."
+msgid "Choose from one of the following three modes: [All bouquets] Fetch all TV bouquets from the set-top box; [Some bouquets] Only fetch the bouquets specified in the next options; [Favourites group] Only fetch the system bouquet for TV favourites; [Custom groups] Fetch a set of bouquets from the Set-top box whose names are loaded from an XML file."
 msgstr ""
 
 #help: Channels - onetvgroup
+#help: Channels - twotvgroup
+#help: Channels - threetvgroup
+#help: Channels - fourtvgroup
+#help: Channels - fivetvgroup
 msgctxt "#30644"
-msgid "If the previous option has been has been set to 'Only one bouquet' you need to specify the TV bouquet to be fetched from the set-top box. Please not that this is the bouquet-name as shown on the set-top box (i.e. 'Favourites (TV)'). This setting is case-sensitive."
+msgid "If the previous option has been has been set to 'Some bouquets' you need to specify a TV bouquet to be fetched from the set-top box. Please not that this is the bouquet-name as shown on the set-top box (i.e. 'Favourites (TV)'). This setting is case-sensitive."
 msgstr ""
 
 #help: Channels - tvfavouritesmode
 msgctxt "#30645"
-msgid "If the fetch mode is 'All bouquets' or 'Only one bouquet' depending on your Enigma2 image you may need to explicitly fetch favourites if you require them. The options are: [Disabled] Don't explicitly fetch TV favourites; [As first bouquet] Explicitly fetch them as the first bouquet; [As last bouquet] Explicitly fetch them as the last bouquet."
+msgid "If the fetch mode is 'All bouquets' or 'Some bouquets' depending on your Enigma2 image you may need to explicitly fetch favourites if you require them. The options are: [Disabled] Don't explicitly fetch TV favourites; [As first bouquet] Explicitly fetch them as the first bouquet; [As last bouquet] Explicitly fetch them as the last bouquet."
 msgstr ""
 
 #help: Channels - excludelastscannedtv
@@ -930,17 +1000,21 @@ msgstr ""
 
 #help: Channels - radiogroupmode
 msgctxt "#30647"
-msgid "Choose from one of the following three modes: [All bouquets] Fetch all Radio bouquets from the set-top box]; [Only one bouquet] Only fetch the bouquet specified in the next option; [Favourites group] Only fetch the system bouquet for Radio favourites."
+msgid "Choose from one of the following three modes: [All bouquets] Fetch all Radio bouquets from the set-top box]; [Some bouquets] Only fetch the bouquets specified in the next options; [Favourites group] Only fetch the system bouquet for Radio favourites; [Custom groups] Fetch a set of bouquets from the Set-top box whose names are loaded from an XML file."
 msgstr ""
 
 #help: Channels - oneradiogroup
+#help: Channels - tworadiogroup
+#help: Channels - threeradiogroup
+#help: Channels - fourradiogroup
+#help: Channels - fiveradiogroup
 msgctxt "#30648"
-msgid "If the previous option has been has been set to 'Only one bouquet' you need to specify the Radio bouquet to be fetched from the set-top box. Please not that this is the bouquet-name as shown on the set-top box (i.e. 'Favourites (Radio)'). This setting is case-sensitive."
+msgid "If the previous option has been has been set to 'Some bouquets' you need to specify a Radio bouquet to be fetched from the set-top box. Please not that this is the bouquet-name as shown on the set-top box (i.e. 'Favourites (Radio)'). This setting is case-sensitive."
 msgstr ""
 
 #help: Channels - radiofavouritesmode
 msgctxt "#30649"
-msgid "If the fetch mode is 'All bouquets' or 'Only one bouquet' depending on your Enigma2 image you may need to explicitly fetch favourites if you require them. The options are: [Disabled] Don't explicitly fetch Radio favourites; [As first bouquet] Explicitly fetch them as the first bouquet; [As last bouquet] Explicitly fetch them as the last bouquet."
+msgid "If the fetch mode is 'All bouquets' or 'Some bouquets' depending on your Enigma2 image you may need to explicitly fetch favourites if you require them. The options are: [Disabled] Don't explicitly fetch Radio favourites; [As first bouquet] Explicitly fetch them as the first bouquet; [As last bouquet] Explicitly fetch them as the last bouquet."
 msgstr ""
 
 #help: Channels - excludelastscannedradio
@@ -948,7 +1022,27 @@ msgctxt "#30650"
 msgid "Last scanned is a system bouquet containing all the TV and Radio channels found in the last scan. Any Radio channels found in the Last Scanned bouquet can be displayed as a group called 'Last Scanned (Radio)' in Kodi. For Radio this group is excluded by default. Disable this option to show this group."
 msgstr ""
 
-#empty strings from id 30651 to 30659
+#help: Channels - customtvgroupsfile
+msgctxt "#30651"
+msgid "The file used to load the custom TV bouquets (groups). If no groups can be matched the channel list will default to 'Last Scanned (TV)'. The default file is `customTVGroups-example.xml`."
+msgstr ""
+
+#help: Channels - customradiogroupsfile
+msgctxt "#30652"
+msgid "The file used to load the custom Radio bouquets (groups). If no groups can be matched the channel list will default to 'Last Scanned (Radio)'. The default file is `customRadioGroups-example.xml`."
+msgstr ""
+
+#help: Channels - numtvgroups
+msgctxt "#30653"
+msgid "The number of TV bouquets to load when `Some bouquets` is the selected fetch mode. Up to 5 can be chosen. If more than 5 are required the 'Custom bouquets' fetch mode should be used instead."
+msgstr ""
+
+#help: Channels - numradiogroups
+msgctxt "#30654"
+msgid "The number of Radio bouquets to load when `Some bouquets` is the selected fetch mode. Up to 5 can be chosen. If more than 5 are required the 'Custom bouquets' fetch mode should be used instead."
+msgstr ""
+
+#empty strings from id 30655 to 30659
 
 #help info - EPG
 

--- a/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
@@ -832,12 +832,12 @@ msgstr ""
 
 #help: Connection - connectionchecktimeout
 msgctxt "#30610"
-msgid "The value in seconds to wait for a connection check to complete before failure. Useful for tuning on older Enigma2 devices."
+msgid "The value in seconds to wait for a connection check to complete before failure. Useful for tuning on older Enigma2 devices. Note, this setting should rarely need to be changed. It's more likely the `Connection check interval` setting will have the desired effect. Default is 30 seconds."
 msgstr ""
 
 #help: Connection - connectioncheckinterval
 msgctxt "#30611"
-msgid "The value in seconds to wait between connection checks. Useful for tuning on older Enigma2 devices."
+msgid "The value in seconds to wait between connection checks. Useful for tuning on older Enigma2 devices. Default is 10 seconds."
 msgstr ""
 
 #empty strings from id 30612 to 30619

--- a/pvr.vuplus/resources/settings.xml
+++ b/pvr.vuplus/resources/settings.xml
@@ -85,7 +85,7 @@
       <group id="4" label="30020">
         <setting id="connectionchecktimeout" type="integer" label="30121" help="30610">
           <level>3</level>
-          <default>10</default>
+          <default>30</default>
           <constraints>
             <minimum>10</minimum>
             <step>10</step>
@@ -98,7 +98,7 @@
         </setting>
         <setting id="connectioncheckinterval" type="integer" label="30122" help="30611">
           <level>3</level>
-          <default>1</default>
+          <default>10</default>
           <constraints>
             <minimum>1</minimum>
             <step>1</step>

--- a/pvr.vuplus/resources/settings.xml
+++ b/pvr.vuplus/resources/settings.xml
@@ -231,10 +231,25 @@
           <constraints>
             <options>
               <option label="30074">0</option> <!-- ALL_GROUPS -->
-              <option label="30075">1</option> <!-- ONLY_ONE_GROUP -->
+              <option label="30075">1</option> <!-- SOME_GROUPS -->
               <option label="30078">2</option> <!-- FAVOURITES_GROUP -->
+              <option label="30131">3</option> <!-- CUSTOM_GROUPS -->
             </options>
           </constraints>
+          <control type="spinner" format="integer" />
+        </setting>
+
+        <setting id="numtvgroups" type="integer" parent="tvgroupmode" label="30134" help="30653">
+          <level>0</level>
+          <default>1</default>
+          <constraints>
+            <minimum>1</minimum>
+            <step>1</step>
+            <maximum>5</maximum>
+          </constraints>
+          <dependencies>
+            <dependency type="visible" setting="tvgroupmode" operator="is">1</dependency>
+          </dependencies>
           <control type="spinner" format="integer" />
         </setting>
         <setting id="onetvgroup" type="string" parent="tvgroupmode" label="30026" help="30644">
@@ -247,6 +262,85 @@
             <dependency type="visible" setting="tvgroupmode" operator="is">1</dependency>
           </dependencies>
           <control type="edit" format="string" />
+        </setting>
+        <setting id="twotvgroup" type="string" parent="tvgroupmode" label="30135" help="30644">
+          <level>0</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="tvgroupmode" operator="is">1</condition>
+                <condition setting="numtvgroups" operator="gt">1</condition>
+              </and>
+            </dependency>
+          </dependencies>
+          <control type="edit" format="string" />
+        </setting>
+        <setting id="threetvgroup" type="string" parent="tvgroupmode" label="30136" help="30644">
+          <level>0</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="tvgroupmode" operator="is">1</condition>
+                <condition setting="numtvgroups" operator="gt">2</condition>
+              </and>
+            </dependency>
+          </dependencies>
+          <control type="edit" format="string" />
+        </setting>
+        <setting id="fourtvgroup" type="string" parent="tvgroupmode" label="30137" help="30644">
+          <level>0</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="tvgroupmode" operator="is">1</condition>
+                <condition setting="numtvgroups" operator="gt">3</condition>
+              </and>
+            </dependency>
+          </dependencies>
+          <control type="edit" format="string" />
+        </setting>
+        <setting id="fivetvgroup" type="string" parent="tvgroupmode" label="30138" help="30644">
+          <level>0</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="tvgroupmode" operator="is">1</condition>
+                <condition setting="numtvgroups" operator="gt">4</condition>
+              </and>
+            </dependency>
+          </dependencies>
+          <control type="edit" format="string" />
+        </setting>
+
+        <setting id="customtvgroupsfile" type="path" parent="tvgroupmode" label="30132" help="30651">
+          <level>0</level>
+          <default>special://userdata/addon_data/pvr.vuplus/channelGroups/customTVGroups-example.xml</default>
+          <constraints>
+            <allowempty>false</allowempty>
+            <writable>false</writable>
+          </constraints>
+          <dependencies>
+            <dependency type="visible" setting="tvgroupmode" operator="is">3</dependency>
+          </dependencies>
+          <control type="button" format="file">
+            <heading>1033</heading>
+          </control>
         </setting>
         <setting id="tvfavouritesmode" type="integer" label="30068" help="30645">
           <level>2</level>
@@ -284,10 +378,25 @@
           <constraints>
             <options>
               <option label="30074">0</option> <!-- ALL_GROUPS -->
-              <option label="30075">1</option> <!-- ONLY_ONE_GROUP -->
+              <option label="30075">1</option> <!-- SOME_GROUPS -->
               <option label="30078">2</option> <!-- FAVOURITES_GROUP -->
+              <option label="30131">3</option> <!-- CUSTOM_GROUPS -->
             </options>
           </constraints>
+          <control type="spinner" format="integer" />
+        </setting>
+
+        <setting id="numradiogroups" type="integer" parent="tvgroupmode" label="30139" help="30654">
+          <level>0</level>
+          <default>1</default>
+          <constraints>
+            <minimum>1</minimum>
+            <step>1</step>
+            <maximum>5</maximum>
+          </constraints>
+          <dependencies>
+            <dependency type="visible" setting="radiogroupmode" operator="is">1</dependency>
+          </dependencies>
           <control type="spinner" format="integer" />
         </setting>
         <setting id="oneradiogroup" type="string" parent="radiogroupmode" label="30059" help="30648">
@@ -300,6 +409,85 @@
             <dependency type="visible" setting="radiogroupmode" operator="is">1</dependency>
           </dependencies>
           <control type="edit" format="string" />
+        </setting>
+        <setting id="tworadiogroup" type="string" parent="radiogroupmode" label="30140" help="30648">
+          <level>0</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="radiogroupmode" operator="is">1</condition>
+                <condition setting="numradiogroups" operator="gt">1</condition>
+              </and>
+            </dependency>
+          </dependencies>
+          <control type="edit" format="string" />
+        </setting>
+        <setting id="threeradiogroup" type="string" parent="radiogroupmode" label="30141" help="30648">
+          <level>0</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="radiogroupmode" operator="is">1</condition>
+                <condition setting="numradiogroups" operator="gt">2</condition>
+              </and>
+            </dependency>
+          </dependencies>
+          <control type="edit" format="string" />
+        </setting>
+        <setting id="fourradiogroup" type="string" parent="radiogroupmode" label="30142" help="30648">
+          <level>0</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="radiogroupmode" operator="is">1</condition>
+                <condition setting="numradiogroups" operator="gt">3</condition>
+              </and>
+            </dependency>
+          </dependencies>
+          <control type="edit" format="string" />
+        </setting>
+        <setting id="fiveradiogroup" type="string" parent="radiogroupmode" label="30143" help="30648">
+          <level>0</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="radiogroupmode" operator="is">1</condition>
+                <condition setting="numradiogroups" operator="gt">4</condition>
+              </and>
+            </dependency>
+          </dependencies>
+          <control type="edit" format="string" />
+        </setting>
+
+        <setting id="customradiogroupsfile" type="path" parent="radiogroupmode" label="30133" help="30652">
+          <level>0</level>
+          <default>special://userdata/addon_data/pvr.vuplus/channelGroups/customRadioGroups-example.xml</default>
+          <constraints>
+            <allowempty>false</allowempty>
+            <writable>false</writable>
+          </constraints>
+          <dependencies>
+            <dependency type="visible" setting="radiogroupmode" operator="is">3</dependency>
+          </dependencies>
+          <control type="button" format="file">
+            <heading>1033</heading>
+          </control>
         </setting>
         <setting id="radiofavouritesmode" type="integer" label="30069" help="30649">
           <level>2</level>

--- a/src/enigma2/Channels.cpp
+++ b/src/enigma2/Channels.cpp
@@ -213,11 +213,25 @@ bool Channels::LoadChannels(const std::string groupServiceReference, const std::
 
       if (!jsonDoc["services"].empty())
       {
+        int hiddenEntryCount = 0;
+
         for (const auto& it : jsonDoc["services"].items())
         {
           auto jsonChannel = it.value();
 
           std::string serviceReference = jsonChannel["servicereference"].get<std::string>();
+
+          // Check whether the current element is not just a label
+          if (serviceReference.compare(0, 5, "1:64:") == 0)
+            continue;
+
+          // Check whether the current element is a hidden entry
+          if (serviceReference.compare(0, 6, "1:320:") == 0)
+          {
+            hiddenEntryCount++;
+            continue;
+          }
+
           if (Settings::GetInstance().UseStandardServiceReference())
           {
             serviceReference = Channel::CreateStandardServiceReference(serviceReference);
@@ -236,7 +250,7 @@ bool Channels::LoadChannels(const std::string groupServiceReference, const std::
             if (!jsonChannel["pos"].empty() && channel->UsingDefaultChannelNumber())
             {
               Logger::Log(LEVEL_DEBUG, "%s For Channel %s, set backend channel number to %d", __FUNCTION__, jsonChannel["servicename"].get<std::string>().c_str(), jsonChannel["pos"].get<int>());
-              channel->SetChannelNumber(jsonChannel["pos"].get<int>());
+              channel->SetChannelNumber(jsonChannel["pos"].get<int>() + hiddenEntryCount);
               channel->SetUsingDefaultChannelNumber(false);
             }
 

--- a/src/enigma2/ConnectionManager.h
+++ b/src/enigma2/ConnectionManager.h
@@ -30,6 +30,9 @@
 
 namespace enigma2
 {
+  static const int FAST_RECONNECT_ATTEMPTS = 5;
+  static const int SLEEP_INTERVAL_STEP_MS = 500;
+
   class IConnectionListener;
 
   class ConnectionManager : public P8PLATFORM::CThread
@@ -49,6 +52,7 @@ namespace enigma2
   private:
     void* Process() override;
     void SetState(PVR_CONNECTION_STATE state);
+    void SteppedSleep(int intervalMs);
 
     IConnectionListener& m_connectionListener;
     mutable P8PLATFORM::CMutex m_mutex;

--- a/src/enigma2/Settings.cpp
+++ b/src/enigma2/Settings.cpp
@@ -1,8 +1,11 @@
 #include "Settings.h"
 
 #include "../client.h"
+#include "utilities/FileUtils.h"
 #include "utilities/LocalizedString.h"
 
+#include "tinyxml.h"
+#include "util/XMLUtils.h"
 #include "p8-platform/util/StringUtils.h"
 
 using namespace ADDON;
@@ -14,6 +17,8 @@ using namespace enigma2::utilities;
  **************************************************************************/
 void Settings::ReadFromAddon()
 {
+  FileUtils::CopyDirectory(FileUtils::GetResourceDataPath() + CHANNEL_GROUPS_DIR, CHANNEL_GROUPS_ADDON_DATA_BASE_DIR, true);
+
   char buffer[1024];
   buffer[0] = 0;
 
@@ -98,11 +103,62 @@ void Settings::ReadFromAddon()
   if (!XBMC->GetSetting("tvgroupmode", &m_tvChannelGroupMode))
     m_tvChannelGroupMode = ChannelGroupMode::ALL_GROUPS;
 
+  if (!XBMC->GetSetting("numtvgroups", &m_numTVGroups))
+    m_numTVGroups = DEFAULT_NUM_GROUPS;
+
   if (XBMC->GetSetting("onetvgroup", buffer))
     m_oneTVGroup = buffer;
   else
     m_oneTVGroup = "";
   buffer[0] = 0;
+
+  if (XBMC->GetSetting("twotvgroup", buffer))
+    m_twoTVGroup = buffer;
+  else
+    m_twoTVGroup = "";
+  buffer[0] = 0;
+
+  if (XBMC->GetSetting("threetvgroup", buffer))
+    m_threeTVGroup = buffer;
+  else
+    m_threeTVGroup = "";
+  buffer[0] = 0;
+
+  if (XBMC->GetSetting("fourtvgroup", buffer))
+    m_fourTVGroup = buffer;
+  else
+    m_fourTVGroup = "";
+  buffer[0] = 0;
+
+  if (XBMC->GetSetting("fivetvgroup", buffer))
+    m_fiveTVGroup = buffer;
+  else
+    m_fiveTVGroup = "";
+  buffer[0] = 0;
+
+  if (m_tvChannelGroupMode == ChannelGroupMode::SOME_GROUPS)
+  {
+    m_customTVChannelGroupNameList.clear();
+
+    if (!m_oneTVGroup.empty() && m_numTVGroups >= 1)
+      m_customTVChannelGroupNameList.emplace_back(m_oneTVGroup);
+    if (!m_twoTVGroup.empty() && m_numTVGroups >= 2)
+      m_customTVChannelGroupNameList.emplace_back(m_twoTVGroup);
+    if (!m_threeTVGroup.empty() && m_numTVGroups >= 3)
+      m_customTVChannelGroupNameList.emplace_back(m_threeTVGroup);
+    if (!m_fourTVGroup.empty() && m_numTVGroups >= 4)
+      m_customTVChannelGroupNameList.emplace_back(m_fourTVGroup);
+    if (!m_fiveTVGroup.empty() && m_numTVGroups >= 5)
+      m_customTVChannelGroupNameList.emplace_back(m_fiveTVGroup);
+  }
+
+  if (XBMC->GetSetting("customtvgroupsfile", buffer))
+    m_customTVGroupsFile = buffer;
+  else
+    m_customTVGroupsFile = DEFAULT_CUSTOM_TV_GROUPS_FILE;
+  buffer[0] = 0;
+  if (m_tvChannelGroupMode == ChannelGroupMode::CUSTOM_GROUPS)
+    LoadCustomChannelGroupFile(m_customTVGroupsFile, m_customTVChannelGroupNameList);
 
   if (!XBMC->GetSetting("tvfavouritesmode", &m_tvFavouritesMode))
     m_tvFavouritesMode = FavouritesGroupMode::DISABLED;
@@ -113,11 +169,62 @@ void Settings::ReadFromAddon()
   if (!XBMC->GetSetting("radiogroupmode", &m_radioChannelGroupMode))
     m_radioChannelGroupMode = ChannelGroupMode::ALL_GROUPS;
 
+  if (!XBMC->GetSetting("numradiogroups", &m_numRadioGroups))
+    m_numRadioGroups = DEFAULT_NUM_GROUPS;
+
   if (XBMC->GetSetting("oneradiogroup", buffer))
     m_oneRadioGroup = buffer;
   else
     m_oneRadioGroup = "";
   buffer[0] = 0;
+
+  if (XBMC->GetSetting("tworadiogroup", buffer))
+    m_twoRadioGroup = buffer;
+  else
+    m_twoRadioGroup = "";
+  buffer[0] = 0;
+
+  if (XBMC->GetSetting("threeradiogroup", buffer))
+    m_threeRadioGroup = buffer;
+  else
+    m_threeRadioGroup = "";
+  buffer[0] = 0;
+
+  if (XBMC->GetSetting("fourradiogroup", buffer))
+    m_fourRadioGroup = buffer;
+  else
+    m_fourRadioGroup = "";
+  buffer[0] = 0;
+
+  if (XBMC->GetSetting("fiveradiogroup", buffer))
+    m_fiveRadioGroup = buffer;
+  else
+    m_fiveRadioGroup = "";
+  buffer[0] = 0;
+
+  if (m_radioChannelGroupMode == ChannelGroupMode::SOME_GROUPS)
+  {
+    m_customRadioChannelGroupNameList.clear();
+
+    if (!m_oneRadioGroup.empty() && m_numRadioGroups >= 1)
+      m_customRadioChannelGroupNameList.emplace_back(m_oneRadioGroup);
+    if (!m_twoRadioGroup.empty() && m_numRadioGroups >= 2)
+      m_customRadioChannelGroupNameList.emplace_back(m_twoRadioGroup);
+    if (!m_threeRadioGroup.empty() && m_numRadioGroups >= 3)
+      m_customRadioChannelGroupNameList.emplace_back(m_threeRadioGroup);
+    if (!m_fourRadioGroup.empty() && m_numRadioGroups >= 4)
+      m_customRadioChannelGroupNameList.emplace_back(m_fourRadioGroup);
+    if (!m_fiveRadioGroup.empty() && m_numRadioGroups >= 5)
+      m_customRadioChannelGroupNameList.emplace_back(m_fiveRadioGroup);
+  }
+
+  if (XBMC->GetSetting("customradiogroupsfile", buffer))
+    m_customRadioGroupsFile = buffer;
+  else
+    m_customRadioGroupsFile = DEFAULT_CUSTOM_RADIO_GROUPS_FILE;
+  buffer[0] = 0;
+  if (m_radioChannelGroupMode == ChannelGroupMode::CUSTOM_GROUPS)
+    LoadCustomChannelGroupFile(m_customRadioGroupsFile, m_customRadioChannelGroupNameList);
 
   if (!XBMC->GetSetting("radiofavouritesmode", &m_radioFavouritesMode))
     m_radioFavouritesMode = FavouritesGroupMode::DISABLED;
@@ -216,7 +323,7 @@ void Settings::ReadFromAddon()
   if (XBMC->GetSetting("timeshiftbufferpath", buffer) && !std::string(buffer).empty())
     m_timeshiftBufferPath = buffer;
   else
-    m_timeshiftBufferPath = DEFAULT_TSBUFFERPATH;
+    m_timeshiftBufferPath = ADDON_DATA_BASE_DIR;
   buffer[0] = 0;
 
   //Advanced
@@ -299,16 +406,40 @@ ADDON_STATUS Settings::SetValue(const std::string &settingName, const void *sett
     return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_zap, ADDON_STATUS_OK, ADDON_STATUS_OK);
   else if (settingName == "tvgroupmode")
     return SetSetting<ChannelGroupMode, ADDON_STATUS>(settingName, settingValue, m_tvChannelGroupMode, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
+  else if (settingName == "numtvgroups")
+    return SetSetting<unsigned int, ADDON_STATUS>(settingName, settingValue, m_numTVGroups, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "onetvgroup")
     return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_oneTVGroup, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
+  else if (settingName == "twotvgroup")
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_twoTVGroup, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
+  else if (settingName == "threetvgroup")
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_threeTVGroup, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
+  else if (settingName == "twotvgroup")
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_fourTVGroup, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
+  else if (settingName == "fivetvgroup")
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_fiveTVGroup, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
+  else if (settingName == "customtvgroupsfile")
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_customTVGroupsFile, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "tvfavouritesmode")
     return SetSetting<FavouritesGroupMode, ADDON_STATUS>(settingName, settingValue, m_tvFavouritesMode, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "excludelastscannedtv")
     return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_excludeLastScannedTVGroup, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "radiogroupmode")
     return SetSetting<ChannelGroupMode, ADDON_STATUS>(settingName, settingValue, m_radioChannelGroupMode, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
+  else if (settingName == "numradiogroups")
+    return SetSetting<unsigned int, ADDON_STATUS>(settingName, settingValue, m_numRadioGroups, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "oneradiogroup")
     return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_oneRadioGroup, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
+  else if (settingName == "tworadiogroup")
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_twoRadioGroup, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
+  else if (settingName == "threeradiogroup")
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_threeRadioGroup, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
+  else if (settingName == "fourradiogroup")
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_fourRadioGroup, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
+  else if (settingName == "fiveradiogroup")
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_fiveRadioGroup, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
+  else if (settingName == "customradiogroupsfile")
+    return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_customRadioGroupsFile, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "radiofavouritesmode")
     return SetSetting<FavouritesGroupMode, ADDON_STATUS>(settingName, settingValue, m_radioFavouritesMode, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "excludelastscannedradio")
@@ -398,4 +529,63 @@ ADDON_STATUS Settings::SetValue(const std::string &settingName, const void *sett
 bool Settings::IsTimeshiftBufferPathValid() const
 {
   return XBMC->DirectoryExists(m_timeshiftBufferPath.c_str());
+}
+
+bool Settings::LoadCustomChannelGroupFile(std::string &xmlFile, std::vector<std::string> &channelGroupNameList)
+{
+  channelGroupNameList.clear();
+
+  if (!FileUtils::FileExists(xmlFile.c_str()))
+  {
+    Logger::Log(LEVEL_ERROR, "%s No XML file found: %s", __FUNCTION__, xmlFile.c_str());
+    return false;
+  }
+
+  Logger::Log(LEVEL_DEBUG, "%s Loading XML File: %s", __FUNCTION__, xmlFile.c_str());
+
+  const std::string fileContents = FileUtils::ReadXmlFileToString(xmlFile);
+
+  if (fileContents.empty())
+  {
+    Logger::Log(LEVEL_ERROR, "%s No Content in XML file: %s", __FUNCTION__, xmlFile.c_str());
+    return false;
+  }
+
+  TiXmlDocument xmlDoc;
+  if (!xmlDoc.Parse(fileContents.c_str()))
+  {
+    Logger::Log(LEVEL_ERROR, "%s Unable to parse XML: %s at line %d", __FUNCTION__, xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
+    return false;
+  }
+
+  TiXmlHandle hDoc(&xmlDoc);
+
+  TiXmlElement* pElem = hDoc.FirstChildElement("customChannelGroups").Element();
+
+  if (!pElem)
+  {
+    Logger::Log(LEVEL_ERROR, "%s Could not find <customChannelGroups> element!", __FUNCTION__);
+    return false;
+  }
+
+  TiXmlHandle hRoot = TiXmlHandle(pElem);
+
+  TiXmlElement* pNode = hRoot.FirstChildElement("channelGroupName").Element();
+
+  if (!pNode)
+  {
+    Logger::Log(LEVEL_ERROR, "%s Could not find <channelGroupName> element", __FUNCTION__);
+    return false;
+  }
+
+  for (; pNode != nullptr; pNode = pNode->NextSiblingElement("channelGroupName"))
+  {
+    const std::string channelGroupName = pNode->GetText();
+
+    channelGroupNameList.emplace_back(channelGroupName);
+
+    Logger::Log(LEVEL_TRACE, "%s Read Custom ChannelGroup Name: %s, from file: %s", __FUNCTION__, channelGroupName.c_str(), xmlFile.c_str());
+  }
+
+  return true;
 }

--- a/src/enigma2/Settings.h
+++ b/src/enigma2/Settings.h
@@ -22,11 +22,17 @@ namespace enigma2
   static const int DEFAULT_CONNECTION_CHECK_INTERVAL_SECS = 1;
   static const int DEFAULT_UPDATE_INTERVAL = 2;
   static const int DEFAULT_CHANNEL_AND_GROUP_UPDATE_HOUR = 4;
-  static const std::string DEFAULT_TSBUFFERPATH = "special://userdata/addon_data/pvr.vuplus";
-  static const std::string DEFAULT_SHOW_INFO_FILE = "special://userdata/addon_data/pvr.vuplus/showInfo/English-ShowInfo.xml";
-  static const std::string DEFAULT_GENRE_ID_MAP_FILE = "special://userdata/addon_data/pvr.vuplus/genres/genreIdMappings/Sky-UK.xml";
-  static const std::string DEFAULT_GENRE_TEXT_MAP_FILE = "special://userdata/addon_data/pvr.vuplus/genres/genreTextMappings/Rytec-UK-Ireland";
+  static const int DEFAULT_NUM_GROUPS = 1;
+  static const std::string ADDON_DATA_BASE_DIR = "special://userdata/addon_data/pvr.vuplus";
+  static const std::string DEFAULT_SHOW_INFO_FILE = ADDON_DATA_BASE_DIR + "/showInfo/English-ShowInfo.xml";
+  static const std::string DEFAULT_GENRE_ID_MAP_FILE = ADDON_DATA_BASE_DIR + "/genres/genreIdMappings/Sky-UK.xml";
+  static const std::string DEFAULT_GENRE_TEXT_MAP_FILE = ADDON_DATA_BASE_DIR + "/genres/genreTextMappings/Rytec-UK-Ireland.xml";
+  static const std::string DEFAULT_CUSTOM_TV_GROUPS_FILE = ADDON_DATA_BASE_DIR + "/channelGroups/customRadioGroups-example.xml";
+  static const std::string DEFAULT_CUSTOM_RADIO_GROUPS_FILE = ADDON_DATA_BASE_DIR + "/channelGroups/customRadioGroups-example.xml";
   static const int DEFAULT_NUM_GEN_REPEAT_TIMERS = 1;
+
+  static const std::string CHANNEL_GROUPS_DIR = "/channelGroups";
+  static const std::string CHANNEL_GROUPS_ADDON_DATA_BASE_DIR = ADDON_DATA_BASE_DIR + CHANNEL_GROUPS_DIR;
 
   enum class UpdateMode
     : int // same type as addon settings
@@ -47,8 +53,9 @@ namespace enigma2
     : int // same type as addon settings
   {
     ALL_GROUPS = 0,
-    ONLY_ONE_GROUP,
-    FAVOURITES_GROUP
+    SOME_GROUPS,
+    FAVOURITES_GROUP,
+    CUSTOM_GROUPS
   };
 
   enum class FavouritesGroupMode
@@ -134,11 +141,11 @@ namespace enigma2
     bool UseStandardServiceReference() const { return m_useStandardServiceReference; }
     bool GetZapBeforeChannelSwitch() const { return m_zap; }
     const ChannelGroupMode& GetTVChannelGroupMode() const { return m_tvChannelGroupMode; }
-    const std::string& GetOneTVGroupName() const { return m_oneTVGroup; }
+    const std::string& GetCustomTVGroupsFile() const { return m_customTVGroupsFile; }
     const FavouritesGroupMode& GetTVFavouritesMode() const { return m_tvFavouritesMode; }
     bool ExcludeLastScannedTVGroup() const { return m_excludeLastScannedTVGroup; }
     const ChannelGroupMode& GetRadioChannelGroupMode() const { return m_radioChannelGroupMode; }
-    const std::string& GetOneRadioGroupName() const { return m_oneRadioGroup; }
+    const std::string& GetCustomRadioGroupsFile() const { return m_customRadioGroupsFile; }
     const FavouritesGroupMode& GetRadioFavouritesMode() const { return m_radioFavouritesMode; }
     bool ExcludeLastScannedRadioGroup() const { return m_excludeLastScannedRadioGroup; }
 
@@ -222,6 +229,9 @@ namespace enigma2
     bool UsesLastScannedChannelGroup() const { return m_usesLastScannedChannelGroup; }
     void SetUsesLastScannedChannelGroup(bool value) { m_usesLastScannedChannelGroup = value; }
 
+    std::vector<std::string>& GetCustomTVChannelGroupNameList() { return m_customTVChannelGroupNameList; }
+    std::vector<std::string>& GetCustomRadioChannelGroupNameList() { return m_customRadioChannelGroupNameList; }
+
   private:
     Settings() = default;
 
@@ -257,6 +267,8 @@ namespace enigma2
       return defaultReturnValue;
     }
 
+    static bool LoadCustomChannelGroupFile(std::string &file, std::vector<std::string> &channelGroupNameList);
+
     //Connection
     std::string m_hostname = DEFAULT_HOST;
     int m_portWeb = DEFAULT_WEB_PORT;
@@ -284,11 +296,23 @@ namespace enigma2
     bool m_useStandardServiceReference = true;
     bool m_zap = false;
     ChannelGroupMode m_tvChannelGroupMode = ChannelGroupMode::ALL_GROUPS;
+    unsigned int m_numTVGroups = DEFAULT_NUM_GROUPS;
     std::string m_oneTVGroup = "";
+    std::string m_twoTVGroup = "";
+    std::string m_threeTVGroup = "";
+    std::string m_fourTVGroup = "";
+    std::string m_fiveTVGroup = "";
+    std::string m_customTVGroupsFile;
     FavouritesGroupMode m_tvFavouritesMode = FavouritesGroupMode::DISABLED;
     bool m_excludeLastScannedTVGroup = true;
     ChannelGroupMode m_radioChannelGroupMode = ChannelGroupMode::ALL_GROUPS;
+    unsigned int m_numRadioGroups = DEFAULT_NUM_GROUPS;
     std::string m_oneRadioGroup = "";
+    std::string m_twoRadioGroup = "";
+    std::string m_threeRadioGroup = "";
+    std::string m_fourRadioGroup = "";
+    std::string m_fiveRadioGroup = "";
+    std::string m_customRadioGroupsFile;
     FavouritesGroupMode m_radioFavouritesMode = FavouritesGroupMode::DISABLED;
     bool m_excludeLastScannedRadioGroup = true;
 
@@ -323,7 +347,7 @@ namespace enigma2
 
     //Timeshift
     Timeshift m_timeshift = Timeshift::OFF;
-    std::string m_timeshiftBufferPath = DEFAULT_TSBUFFERPATH;
+    std::string m_timeshiftBufferPath = ADDON_DATA_BASE_DIR;
 
     //Advanced
     PrependOutline m_prependOutline = PrependOutline::IN_EPG;
@@ -345,6 +369,9 @@ namespace enigma2
     enigma2::utilities::DeviceSettings* m_deviceSettings;
     enigma2::Admin* m_admin;
     bool m_deviceSettingsSet = false;
+
+    std::vector<std::string> m_customTVChannelGroupNameList;
+    std::vector<std::string> m_customRadioChannelGroupNameList;
 
     //PVR Props
     std::string m_szUserPath = "";

--- a/src/enigma2/Timers.cpp
+++ b/src/enigma2/Timers.cpp
@@ -512,11 +512,18 @@ PVR_ERROR Timers::AddTimer(const PVR_TIMER &timer)
     {
       foundEntry = true;
 
-      /* Note that plot (log desc) is automatically written to a timer entry by the backend
-         therefore we only need to send outline as description to preserve both */
+      /* Note that plot (long desc) is automatically written to a timer entry by the backend
+         therefore we only need to send outline as description to preserve both.
+         Once a timer completes, long description will be cleared so if description
+         is not populated we set it to the value of long description
+         */
       title = partialEntry.GetTitle();
       description = partialEntry.GetPlotOutline();
       epgUid = partialEntry.GetEpgUid();
+
+      // Very important for providers that only use the plot field.
+      if (description.empty())
+        description = partialEntry.GetPlot();
 
       tags.AddTag(TAG_FOR_GENRE_ID, StringUtils::Format("0x%02X", partialEntry.GetGenreType() | partialEntry.GetGenreSubType()));
     }

--- a/src/enigma2/data/Channel.cpp
+++ b/src/enigma2/data/Channel.cpp
@@ -68,7 +68,9 @@ bool Channel::UpdateFrom(TiXmlElement* channelNode)
   if (Settings::GetInstance().UseStandardServiceReference())
     m_serviceReference = m_standardServiceReference;
 
-  Logger::Log(LEVEL_DEBUG, "%s: Loaded Channel: %s, sRef=%s, picon: %s", __FUNCTION__, m_channelName.c_str(), m_serviceReference.c_str(), m_iconPath.c_str());
+  std::sscanf(m_serviceReference.c_str(), "%*X:%*X:%*X:%X:%*s", &m_streamProgramNumber);
+
+  Logger::Log(LEVEL_DEBUG, "%s: Loaded Channel: %s, sRef=%s, picon: %s, program number: %d", __FUNCTION__, m_channelName.c_str(), m_serviceReference.c_str(), m_iconPath.c_str(), m_streamProgramNumber);
 
   m_m3uURL = StringUtils::Format("%sweb/stream.m3u?ref=%s", Settings::GetInstance().GetConnectionURL().c_str(), WebUtils::URLEncodeInline(m_serviceReference).c_str());
 

--- a/src/enigma2/data/Channel.cpp
+++ b/src/enigma2/data/Channel.cpp
@@ -46,8 +46,8 @@ bool Channel::UpdateFrom(TiXmlElement* channelNode)
   if (!XMLUtils::GetString(channelNode, "e2servicereference", m_serviceReference))
     return false;
 
-  // Check whether the current element is not just a label
-  if (m_serviceReference.compare(0,5,"1:64:") == 0)
+  // Check whether the current element is not just a label or that it's not a hidden entry
+  if (m_serviceReference.compare(0, 5, "1:64:") == 0 || m_serviceReference.compare(0, 6, "1:320:") == 0)
     return false;
 
   if (!XMLUtils::GetString(channelNode, "e2servicename", m_channelName))

--- a/src/enigma2/data/Channel.h
+++ b/src/enigma2/data/Channel.h
@@ -47,7 +47,8 @@ namespace enigma2
       Channel(const Channel &c) : BaseChannel(c), m_channelNumber(c.GetChannelNumber()), m_standardServiceReference(c.GetStandardServiceReference()),
         m_extendedServiceReference(c.GetExtendedServiceReference()), m_genericServiceReference(c.GetGenericServiceReference()),
         m_streamURL(c.GetStreamURL()), m_m3uURL(c.GetM3uURL()), m_iconPath(c.GetIconPath()),
-        m_providerName(c.GetProviderName()), m_fuzzyChannelName(c.GetFuzzyChannelName()), m_usingDefaultChannelNumber(c.UsingDefaultChannelNumber()) {};
+        m_providerName(c.GetProviderName()), m_fuzzyChannelName(c.GetFuzzyChannelName()),
+        m_streamProgramNumber(c.GetStreamProgramNumber()), m_usingDefaultChannelNumber(c.UsingDefaultChannelNumber()) {};
       ~Channel() = default;
 
       int GetChannelNumber() const { return m_channelNumber; }
@@ -76,6 +77,9 @@ namespace enigma2
 
       const std::string& GetFuzzyChannelName() const { return m_fuzzyChannelName; }
       void SetFuzzyChannelName(const std::string& value ) { m_fuzzyChannelName = value; }
+
+      int GetStreamProgramNumber() const { return m_streamProgramNumber; }
+      void SetStreamProgramNumber(int value) { m_streamProgramNumber = value; }
 
       bool UsingDefaultChannelNumber() const { return m_usingDefaultChannelNumber; }
       void SetUsingDefaultChannelNumber(bool value) { m_usingDefaultChannelNumber = value; }
@@ -109,6 +113,7 @@ namespace enigma2
       std::string m_iconPath;
       std::string m_providerName;
       std::string m_fuzzyChannelName;
+      int m_streamProgramNumber;
 
       std::vector<std::shared_ptr<enigma2::data::ChannelGroup>> m_channelGroupList;
     };

--- a/src/enigma2/data/ChannelGroup.cpp
+++ b/src/enigma2/data/ChannelGroup.cpp
@@ -58,21 +58,29 @@ bool ChannelGroup::UpdateFrom(TiXmlElement* groupNode, bool radio)
   if (groupName == "<n/a>" || StringUtils::EndsWith(groupName.c_str(), " - Separator"))
     return false;
 
-  if (!radio && Settings::GetInstance().GetTVChannelGroupMode() == ChannelGroupMode::ONLY_ONE_GROUP)
+  if (!radio && (Settings::GetInstance().GetTVChannelGroupMode() == ChannelGroupMode::SOME_GROUPS ||
+                 Settings::GetInstance().GetTVChannelGroupMode() == ChannelGroupMode::CUSTOM_GROUPS))
   {
-    if (Settings::GetInstance().GetOneTVGroupName() != groupName)
-    {
-      Logger::Log(LEVEL_DEBUG, "%s Only one TV group is set, but current e2servicename '%s' does not match requested name '%s'", __FUNCTION__, groupName.c_str(), Settings::GetInstance().GetOneTVGroupName().c_str());
+    auto &customGroupNamelist = Settings::GetInstance().GetCustomTVChannelGroupNameList();
+    auto it = std::find_if(customGroupNamelist.begin(), customGroupNamelist.end(),
+      [&groupName](std::string& customGroupName) { return customGroupName == groupName; });
+
+    if (it == customGroupNamelist.end())
       return false;
-    }
+    else
+      Logger::Log(LEVEL_DEBUG, "%s Custom TV groups are set, current e2servicename '%s' matched", __FUNCTION__, groupName.c_str());
   }
-  else if (radio && Settings::GetInstance().GetRadioChannelGroupMode() == ChannelGroupMode::ONLY_ONE_GROUP)
+  else if (radio && (Settings::GetInstance().GetRadioChannelGroupMode() == ChannelGroupMode::SOME_GROUPS ||
+                     Settings::GetInstance().GetRadioChannelGroupMode() == ChannelGroupMode::CUSTOM_GROUPS))
   {
-    if (Settings::GetInstance().GetOneRadioGroupName() != groupName)
-    {
-      Logger::Log(LEVEL_DEBUG, "%s Only one Radio group is set, but current e2servicename '%s' does not match requested name '%s'", __FUNCTION__, groupName.c_str(), Settings::GetInstance().GetOneRadioGroupName().c_str());
+    auto &customGroupNamelist = Settings::GetInstance().GetCustomRadioChannelGroupNameList();
+    auto it = std::find_if(customGroupNamelist.begin(), customGroupNamelist.end(),
+      [&groupName](std::string& customGroupName) { return customGroupName == groupName; });
+
+    if (it == customGroupNamelist.end())
       return false;
-    }
+    else
+      Logger::Log(LEVEL_DEBUG, "%s Custom Radio groups are set, current e2servicename '%s' matched", __FUNCTION__, groupName.c_str());
   }
   else if (groupName == "Last Scanned")
   {

--- a/src/enigma2/data/Timer.cpp
+++ b/src/enigma2/data/Timer.cpp
@@ -217,7 +217,7 @@ bool Timer::UpdateFrom(TiXmlElement* timerNode, Channels &channels)
     m_plotOutline.clear();
   }
   else if (Settings::GetInstance().GetPrependOutline() == PrependOutline::ALWAYS &&
-          !m_plotOutline.empty() && m_plotOutline != "N/A")
+           m_plot != m_plotOutline && !m_plotOutline.empty() && m_plotOutline != "N/A")
   {
     m_plot.insert(0, m_plotOutline + "\n");
     m_plotOutline.clear();

--- a/src/enigma2/extract/EpgEntryExtractor.h
+++ b/src/enigma2/extract/EpgEntryExtractor.h
@@ -11,7 +11,6 @@ namespace enigma2
   namespace extract
   {
     static const std::string GENRE_DIR = "/genres";
-    static const std::string ADDON_DATA_BASE_DIR = "special://userdata/addon_data/pvr.vuplus";
     static const std::string GENRE_ADDON_DATA_BASE_DIR = ADDON_DATA_BASE_DIR + GENRE_DIR;
     static const std::string SHOW_INFO_DIR = "/showInfo";
     static const std::string SHOW_INFO_ADDON_DATA_BASE_DIR = ADDON_DATA_BASE_DIR + SHOW_INFO_DIR;

--- a/src/enigma2/utilities/CurlFile.cpp
+++ b/src/enigma2/utilities/CurlFile.cpp
@@ -24,6 +24,7 @@
 #include <cstdarg>
 
 #include "Logger.h"
+#include "../Settings.h"
 
 using namespace enigma2::utilities;
 
@@ -82,7 +83,7 @@ bool CurlFile::Check(const std::string &strURL)
   }
 
   XBMC->CURLAddOption(fileHandle, XFILE::CURL_OPTION_PROTOCOL,
-    "connection-timeout", std::to_string(CHECK_TIMEOUT_SECS).c_str());
+    "connection-timeout", std::to_string(Settings::GetInstance().GetConnectioncCheckTimeoutSecs()).c_str());
 
   if (!XBMC->CURLOpen(fileHandle, XFILE::READ_NO_CACHE))
   {

--- a/src/enigma2/utilities/CurlFile.h
+++ b/src/enigma2/utilities/CurlFile.h
@@ -29,8 +29,6 @@ namespace enigma2
 {
   namespace utilities
   {
-    static const int CHECK_TIMEOUT_SECS = 10;
-
     class CurlFile
     {
     public:


### PR DESCRIPTION
v4.2.0
- Added: Custom Channel Groups, closes #209
- Added: Connection manager improvements
- Added: Support hidden entries for backend channel numbers
- Fixed: Timer descprition for providers who only use long descrption