### PR TITLE
Backend channel numbers matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ This addon leverages the OpenWebIf project to interact with the Enigma2 device v
 * Edit recording name, last played position and play count for recordings
 * Bouquet Backend Channel Numbers
 
+Some features are only available with at least certain OpenWebIf versions:
+* 1.3.0
+  * AutoTimers
+* 1.3.5
+  * Embedded EPG Genres
+  * Tuner Details
+  * Provider Name
+  * Backend Channel Numbers
+  * Picon URLs
+* 1.3.6
+  * Editing Recordings
+
 # Enigma2 PVR
 Enigma2 PVR client addon for [Kodi](https://kodi.tv)
 
@@ -98,10 +110,10 @@ Within this tab general options are configured.
 * **Use picons.eu file format**: Assume all picons files fetched from the set-top box start with `1_1_1_` and end with `_0_0_0`.
 * **Use OpenWebIf picon path**: Fetch the picon path from OpenWebIf instead of constructing from ServiceRef. Requires OpenWebIf 1.3.5 or higher. There is no effect if used on a lower version of OpenWebIf.
 * **Icon path**: In order to have Kodi display channel logos you have to copy the picons from your set-top box onto your OpenELEC machine. You then need to specify this path in this property.
-* **Update interval**: As the set-top box can also be used to modify timers, delete recordings etc. and the set-top box does not notify the Kodi installation, the addon needs to regularly check for updates (new channels, new/changed/deletes timers, deleted recordings, etc.) This property defines how often the addon checks for updates.
+* **Update interval**: As the set-top box can also be used to modify timers, delete recordings etc. and the set-top box does not notify the Kodi installation, the addon needs to regularly check for updates (new channels, new/changed/deletes timers, deleted recordings, etc.) This property defines how often the addon checks for updates. Please note that updating the recordings frequently can keep your receiver and it's harddisk from entering standby automatically.
 * **Update mode**: The mode used when the update interval is reached. Note that if there is any timer change detected a recordings update will always occur regardless of the update mode. Choose from one of the following two modes:
     - `Timers and Recordings` - Update all timers and recordings.
-    - `Timers only` - Only update the timers.
+    - `Timers only` - Only update the timers. If it's important to not spin up the HDD on your STB use this option. The HDD should then only spin up when a timer event occurs.
 * **Channel and groups update mode**: The mode used when the hour in the next settings is reached. Choose from one of the following three modes:
     - `Disabled` - Never check for channel and group changes.
     - `Notify on UI and Log` - Display a notice in the UI and log the fact that a change was detectetd.
@@ -110,6 +122,10 @@ Within this tab general options are configured.
 
 ### Channels
 Within this tab options that refer to channel data can be set. When changing bouquets you may need to clear the channel cache to the settings to take effect. You can do this by going to the following in Kodi settings: `Settings->PVR & Live TV->General->Clear cache`.
+
+Note that channel numbers are set in the addon based on their first occurence when loaded, i.e. if a channel appears in multiple bouqets the channel number will be taken from the first bouquet that is loaded, any subsequent channel numbers will be ignored. Therefore if you use a master bouquet it should be the first bouquet loaded assuming it has the channel numbering/order you require.
+
+If Kodi PVR is set to use the channel numbers from the backend the numbers will match those on your STB. If this is not enabled each unique instance of a channel will be given the next free number starting from 1 (i.e. the 17th unique channel will be channel 17). Backend channel numbers will only work for OpenWebIf 1.3.5 and later and they have been tested using ABM (AutoBouquetsMaker).
 
 * **Use standard channel service reference**: Usually service reference's for the channels are in a standard format like `1:0:1:27F6:806:2:11A0000:0:0:0:`. On occasion depending on provider they can be extended with some text e.g. `1:0:1:27F6:806:2:11A0000:0:0:0::UTV` or `1:0:1:27F6:806:2:11A0000:0:0:0::UTV + 1`. If this option is enabled then all read service reference's will be read as standard. This is default behaviour. Functionality like autotimers will always convert to a standard reference.
 * **Zap before channelswitch (i.e. for Single Tuner boxes)**: When using the addon with a single tuner box it may be necessary that the addon needs to be able to zap to another channel on the set-top box. If this option is enabled each channel switch in Kodi will also result in a channel switch on the set-top box. Please note that "allow channel switching" needs to be enabled in the webinterface on the set-top box.

--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="4.2.0"
+  version="4.3.0"
   name="Enigma2 Client"
   provider-name="Joerg Dembski and Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>
@@ -175,6 +175,13 @@
     <disclaimer lang="zh_TW">這是測試版軟體！其原創作者並無法對於以下情況負責，包含：錄影失敗，不正確的定時設定，多餘時數，或任何產生的其它不良影響...</disclaimer>
     <platform>@PLATFORM@</platform>
     <news>
+v4.3.0
+- Added: Support backend channel numbers for all channel groups not just the first
+- Added: Ignore empty channel groups
+- Added: Readme and help info updates
+- Fixed: Revert support hidden entries for backend channel numbers
+- Fixed: Fix hanging on deleting multiple recordings at once
+
 v4.2.0
 - Added: Custom Channel Groups, closes #209
 - Added: Connection manager improvements

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,3 +1,10 @@
+v4.3.0
+- Added: Support backend channel numbers for all channel groups not just the first
+- Added: Ignore empty channel groups
+- Added: Readme and help info updates
+- Fixed: Revert support hidden entries for backend channel numbers
+- Fixed: Fix hanging on deleting multiple recordings at once
+
 v4.2.0
 - Added: Custom Channel Groups, closes #209
 - Added: Connection manager improvements

--- a/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
@@ -937,12 +937,12 @@ msgstr ""
 
 #help: General - updateint
 msgctxt "#30625"
-msgid "As the set-top box can also be used to modify timers, delete recordings etc. and the set-top box does not notify the Kodi installation, the addon needs to regularly check for updates (new channels, new/changed/deletes timers, deleted recordings, etc.) This property defines how often the addon checks for updates."
+msgid "As the set-top box can also be used to modify timers, delete recordings etc. and the set-top box does not notify the Kodi installation, the addon needs to regularly check for updates (new channels, new/changed/deletes timers, deleted recordings, etc.) This property defines how often the addon checks for updates. Please note that updating the recordings frequently can keep your receiver and it's harddisk from entering standby automatically."
 msgstr ""
 
 #help: General - updatemode
 msgctxt "#30626"
-msgid "The mode used when the update interval is reached. Note that if there is any timer change detected a recordings update will always occur regardless of the update mode. Choose from one of the following two modes: [Timers and Recordings] Update all timers and recordings; [Timers only] Only update the timers."
+msgid "The mode used when the update interval is reached. Note that if there is any timer change detected a recordings update will always occur regardless of the update mode. Choose from one of the following two modes: [Timers and Recordings] Update all timers and recordings; [Timers only] Only update the timers. If it's important to not spin up the HDD on your STB use this option. The HDD should then only spin up when a timer event occurs."
 msgstr ""
 
 #help: General - channelandgroupupdatemode

--- a/src/enigma2/ChannelGroups.cpp
+++ b/src/enigma2/ChannelGroups.cpp
@@ -24,7 +24,7 @@ void ChannelGroups::GetChannelGroups(std::vector<PVR_CHANNEL_GROUP> &kodiChannel
   {
     Logger::Log(LEVEL_DEBUG, "%s - Transfer channelGroup '%s', ChannelGroupIndex '%d'", __FUNCTION__, channelGroup->GetGroupName().c_str(), channelGroup->GetUniqueId());
 
-    if (channelGroup->IsRadio() == radio)
+    if (channelGroup->IsRadio() == radio && !channelGroup->IsEmptyGroup())
     {
       PVR_CHANNEL_GROUP kodiChannelGroup = {0};
 

--- a/src/enigma2/ChannelGroups.cpp
+++ b/src/enigma2/ChannelGroups.cpp
@@ -133,6 +133,8 @@ void ChannelGroups::ClearChannelGroups()
   m_channelGroups.clear();
   m_channelGroupsNameMap.clear();
 
+  m_extraDataChannelGroups.clear();
+
   Settings::GetInstance().SetUsesLastScannedChannelGroup(false);
 }
 
@@ -216,7 +218,7 @@ bool ChannelGroups::LoadTVChannelGroups()
     {
       ChannelGroup newChannelGroup;
 
-      if (!newChannelGroup.UpdateFrom(pNode, false))
+      if (!newChannelGroup.UpdateFrom(pNode, false, m_extraDataChannelGroups))
         continue;
 
       AddChannelGroup(newChannelGroup);
@@ -287,7 +289,7 @@ bool ChannelGroups::LoadRadioChannelGroups()
     {
       ChannelGroup newChannelGroup;
 
-      if (!newChannelGroup.UpdateFrom(pNode, true))
+      if (!newChannelGroup.UpdateFrom(pNode, true, m_extraDataChannelGroups))
         continue;
 
       AddChannelGroup(newChannelGroup);

--- a/src/enigma2/ChannelGroups.h
+++ b/src/enigma2/ChannelGroups.h
@@ -49,6 +49,7 @@ namespace enigma2
     void ClearChannelGroups();
     std::vector<std::shared_ptr<enigma2::data::ChannelGroup>>& GetChannelGroupsList();
     bool LoadChannelGroups();
+    const std::vector<std::shared_ptr<enigma2::data::ChannelGroup>>& GetExtraDataChannelGroupsList() const { return m_extraDataChannelGroups; };
 
   private:
     bool LoadTVChannelGroups();
@@ -61,5 +62,9 @@ namespace enigma2
 
     std::vector<std::shared_ptr<enigma2::data::ChannelGroup>> m_channelGroups;
     std::unordered_map<std::string, std::shared_ptr<enigma2::data::ChannelGroup>> m_channelGroupsNameMap;
+
+    // This is a special vector containing all channel groups even ones we don't require
+    // This is needed to calculate the backend channel numbers and they work in an unusual way on enigma2
+    std::vector<std::shared_ptr<enigma2::data::ChannelGroup>> m_extraDataChannelGroups;
   };
 } //namespace enigma2

--- a/src/enigma2/Channels.cpp
+++ b/src/enigma2/Channels.cpp
@@ -213,24 +213,15 @@ bool Channels::LoadChannels(const std::string groupServiceReference, const std::
 
       if (!jsonDoc["services"].empty())
       {
-        int hiddenEntryCount = 0;
-
         for (const auto& it : jsonDoc["services"].items())
         {
           auto jsonChannel = it.value();
 
           std::string serviceReference = jsonChannel["servicereference"].get<std::string>();
 
-          // Check whether the current element is not just a label
-          if (serviceReference.compare(0, 5, "1:64:") == 0)
+          // Check whether the current element is not just a label or that it's not a hidden entry
+          if (serviceReference.compare(0, 5, "1:64:") == 0 || serviceReference.compare(0, 6, "1:320:") == 0)
             continue;
-
-          // Check whether the current element is a hidden entry
-          if (serviceReference.compare(0, 6, "1:320:") == 0)
-          {
-            hiddenEntryCount++;
-            continue;
-          }
 
           if (Settings::GetInstance().UseStandardServiceReference())
           {
@@ -250,7 +241,7 @@ bool Channels::LoadChannels(const std::string groupServiceReference, const std::
             if (!jsonChannel["pos"].empty() && channel->UsingDefaultChannelNumber())
             {
               Logger::Log(LEVEL_DEBUG, "%s For Channel %s, set backend channel number to %d", __FUNCTION__, jsonChannel["servicename"].get<std::string>().c_str(), jsonChannel["pos"].get<int>());
-              channel->SetChannelNumber(jsonChannel["pos"].get<int>() + hiddenEntryCount);
+              channel->SetChannelNumber(jsonChannel["pos"].get<int>());
               channel->SetUsingDefaultChannelNumber(false);
             }
 

--- a/src/enigma2/Channels.cpp
+++ b/src/enigma2/Channels.cpp
@@ -148,6 +148,17 @@ bool Channels::LoadChannels(ChannelGroups &channelGroups)
       bOk = true;
   }
 
+  // Load Channels extra data for groups
+  int tvChannelNumberOffset = 0;
+  int radioChannelNumberOffset = 0;
+  for (const auto& group : channelGroups.GetExtraDataChannelGroupsList())
+  {
+    if (group->IsRadio())
+      radioChannelNumberOffset = LoadChannelsExtraData(group->GetServiceReference(), group->GetGroupName(), channelGroups.IsValid(group->GetGroupName()), radioChannelNumberOffset);
+    else
+      tvChannelNumberOffset = LoadChannelsExtraData(group->GetServiceReference(), group->GetGroupName(), channelGroups.IsValid(group->GetGroupName()), tvChannelNumberOffset);
+  }
+
   return bOk;
 }
 
@@ -200,9 +211,18 @@ bool Channels::LoadChannels(const std::string groupServiceReference, const std::
 
   Logger::Log(LEVEL_INFO, "%s Loaded %d Channels", __FUNCTION__, GetNumChannels());
 
+  return true;
+}
+
+int Channels::LoadChannelsExtraData(const std::string groupServiceReference, const std::string groupName, bool requiredGroup, int channelPositionOffset)
+{
+  int newChannelPositionOffset = channelPositionOffset;
+
   if (Settings::GetInstance().SupportsProviderNumberAndPiconForChannels())
   {
-    //We can use the JSON API so let's supplement the data with provider information
+    Logger::Log(LEVEL_INFO, "%s loading channel group extra data: '%s'", __FUNCTION__, groupName.c_str());
+
+    //We can use the JSON API so let's supplement the data with extra information
 
     const std::string jsonURL = StringUtils::Format("%sapi/getservices?provider=1&picon=1&sRef=%s", Settings::GetInstance().GetConnectionURL().c_str(), WebUtils::URLEncodeInline(groupServiceReference).c_str());
     const std::string strJson = WebUtils::GetHttpXML(jsonURL);
@@ -211,7 +231,7 @@ bool Channels::LoadChannels(const std::string groupServiceReference, const std::
     {
       auto jsonDoc = json::parse(strJson);
 
-      if (!jsonDoc["services"].empty())
+      if (!jsonDoc["services"].empty() && requiredGroup)
       {
         for (const auto& it : jsonDoc["services"].items())
         {
@@ -241,7 +261,7 @@ bool Channels::LoadChannels(const std::string groupServiceReference, const std::
             if (!jsonChannel["pos"].empty() && channel->UsingDefaultChannelNumber())
             {
               Logger::Log(LEVEL_DEBUG, "%s For Channel %s, set backend channel number to %d", __FUNCTION__, jsonChannel["servicename"].get<std::string>().c_str(), jsonChannel["pos"].get<int>());
-              channel->SetChannelNumber(jsonChannel["pos"].get<int>());
+              channel->SetChannelNumber(jsonChannel["pos"].get<int>() + channelPositionOffset);
               channel->SetUsingDefaultChannelNumber(false);
             }
 
@@ -259,6 +279,13 @@ bool Channels::LoadChannels(const std::string groupServiceReference, const std::
           }
         }
       }
+
+      if (!jsonDoc["pos"].empty())
+      {
+        newChannelPositionOffset += jsonDoc["pos"].get<int>();
+
+        Logger::Log(LEVEL_DEBUG, "%s For groupName %s, highest  backend channel number offset is %d", __FUNCTION__, groupName.c_str(), newChannelPositionOffset);
+      }
     }
     catch (nlohmann::detail::parse_error& e)
     {
@@ -270,7 +297,7 @@ bool Channels::LoadChannels(const std::string groupServiceReference, const std::
     }
   }
 
-  return true;
+  return newChannelPositionOffset;
 }
 
 ChannelsChangeState Channels::CheckForChannelAndGroupChanges(enigma2::ChannelGroups &latestChannelGroups, enigma2::Channels &latestChannels)

--- a/src/enigma2/Channels.cpp
+++ b/src/enigma2/Channels.cpp
@@ -197,6 +197,8 @@ bool Channels::LoadChannels(const std::string groupServiceReference, const std::
     return false;
   }
 
+  bool emptyGroup = true;
+
   for (; pNode != nullptr; pNode = pNode->NextSiblingElement("e2service"))
   {
     Channel newChannel;
@@ -204,10 +206,14 @@ bool Channels::LoadChannels(const std::string groupServiceReference, const std::
 
     if (!newChannel.UpdateFrom(pNode))
       continue;
+    else
+      emptyGroup = false;
 
     AddChannel(newChannel, channelGroup);
     Logger::Log(LEVEL_DEBUG, "%s Loaded channel: %s, Group: %s, Icon: %s, ID: %d", __FUNCTION__, newChannel.GetChannelName().c_str(), groupName.c_str(), newChannel.GetIconPath().c_str(), newChannel.GetUniqueId());
   }
+
+  channelGroup->SetEmptyGroup(emptyGroup);
 
   Logger::Log(LEVEL_INFO, "%s Loaded %d Channels", __FUNCTION__, GetNumChannels());
 

--- a/src/enigma2/Channels.h
+++ b/src/enigma2/Channels.h
@@ -70,6 +70,7 @@ namespace enigma2
   private:
     void AddChannel(enigma2::data::Channel &channel, std::shared_ptr<enigma2::data::ChannelGroup> &channelGroup);
     bool LoadChannels(const std::string groupServiceReference, const std::string groupName, std::shared_ptr<enigma2::data::ChannelGroup> &channelGroup);
+    int LoadChannelsExtraData(const std::string groupServiceReference, const std::string groupName, bool requiredGroup, int channelPositionOffset);
 
     std::vector<std::shared_ptr<enigma2::data::Channel>> m_channels;
     std::unordered_map<std::string, std::shared_ptr<enigma2::data::Channel>> m_channelsServiceReferenceMap;

--- a/src/enigma2/Recordings.cpp
+++ b/src/enigma2/Recordings.cpp
@@ -418,7 +418,8 @@ PVR_ERROR Recordings::DeleteRecording(const PVR_RECORDING &recinfo)
   if(!WebUtils::SendSimpleCommand(strTmp, strResult))
     return PVR_ERROR_FAILED;
 
-  PVR->TriggerRecordingUpdate();
+  // No need to call PVR->TriggerRecordingUpdate() as it is handled by kodi PVR.
+  // In fact when multiple recordings are removed at once, calling it here can cause hanging issues
 
   return PVR_ERROR_NO_ERROR;
 }

--- a/src/enigma2/data/ChannelGroup.cpp
+++ b/src/enigma2/data/ChannelGroup.cpp
@@ -39,7 +39,7 @@ bool ChannelGroup::operator!=(const ChannelGroup &right) const
   return !(*this == right);
 }
 
-bool ChannelGroup::UpdateFrom(TiXmlElement* groupNode, bool radio)
+bool ChannelGroup::UpdateFrom(TiXmlElement* groupNode, bool radio, std::vector<std::shared_ptr<ChannelGroup>> &extraDataChannelGroups)
 {
   std::string serviceReference;
   std::string groupName;
@@ -57,6 +57,13 @@ bool ChannelGroup::UpdateFrom(TiXmlElement* groupNode, bool radio)
   // Check if the current element is hidden or a separator
   if (groupName == "<n/a>" || StringUtils::EndsWith(groupName.c_str(), " - Separator"))
     return false;
+
+  m_serviceReference = serviceReference;
+  m_groupName = groupName;
+  m_radio = radio;
+
+  // we keep this group even if it get's discarded so we can calculate backend channel numbers later on
+  extraDataChannelGroups.emplace_back(new ChannelGroup(*this));
 
   if (!radio && (Settings::GetInstance().GetTVChannelGroupMode() == ChannelGroupMode::SOME_GROUPS ||
                  Settings::GetInstance().GetTVChannelGroupMode() == ChannelGroupMode::CUSTOM_GROUPS))
@@ -90,10 +97,6 @@ bool ChannelGroup::UpdateFrom(TiXmlElement* groupNode, bool radio)
     // as it is never supplied as a radio group from Enigma2
     return false;
   }
-
-  m_serviceReference = serviceReference;
-  m_groupName = groupName;
-  m_radio = radio;
 
   return true;
 }

--- a/src/enigma2/data/ChannelGroup.h
+++ b/src/enigma2/data/ChannelGroup.h
@@ -60,7 +60,7 @@ namespace enigma2
 
       void AddChannel(std::shared_ptr<enigma2::data::Channel> channel);
 
-      bool UpdateFrom(TiXmlElement* groupNode, bool radio);
+      bool UpdateFrom(TiXmlElement* groupNode, bool radio, std::vector<std::shared_ptr<ChannelGroup>> &extraDataChannelGroups);
       void UpdateTo(PVR_CHANNEL_GROUP &left) const;
 
       std::vector<std::shared_ptr<enigma2::data::Channel>> GetChannelList() { return m_channelList; };

--- a/src/enigma2/data/ChannelGroup.h
+++ b/src/enigma2/data/ChannelGroup.h
@@ -40,7 +40,7 @@ namespace enigma2
     public:
       ChannelGroup() = default;
       ChannelGroup(ChannelGroup &c) : m_radio(c.IsRadio()), m_uniqueId(c.GetUniqueId()),
-        m_groupName(c.GetGroupName()), m_serviceReference(c.GetServiceReference()), m_lastScannedGroup(c.IsLastScannedGroup()) {};
+        m_groupName(c.GetGroupName()), m_serviceReference(c.GetServiceReference()), m_lastScannedGroup(c.IsLastScannedGroup()), m_emptyGroup(c.IsEmptyGroup()) {};
       ~ChannelGroup() = default;
 
       bool IsRadio() const { return m_radio; }
@@ -57,6 +57,9 @@ namespace enigma2
 
       bool IsLastScannedGroup() const { return m_lastScannedGroup; }
       void SetLastScannedGroup(bool value) { m_lastScannedGroup = value; }
+
+      bool IsEmptyGroup() const { return m_emptyGroup; }
+      void SetEmptyGroup(bool value) { m_emptyGroup = value; }
 
       void AddChannel(std::shared_ptr<enigma2::data::Channel> channel);
 
@@ -75,6 +78,7 @@ namespace enigma2
       std::string m_serviceReference;
       std::string m_groupName;
       bool m_lastScannedGroup;
+      bool m_emptyGroup;
 
       std::vector<std::shared_ptr<enigma2::data::Channel>> m_channelList;
     };


### PR DESCRIPTION
v4.3.0
- Added: Support backend channel numbers for all channel groups not just the first
- Added: Ignore empty channel groups
- Added: Readme updates
- Fixed: Revert support hidden entries for backend channel numbers
- Fixed: Fix hanging on deleting multiple recordings at once