### PR TITLE
Backend channel numbers api matrix & undelete/trashcan

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ Within this tab more uncommon and advanced options can be configured.
     - `Wakeup, then standby` - Similar to standby but first sends a wakeup command. Can be useful if you want to ensure all streams have stopped. Note: if you use CEC this could cause your TV to wake.
 * **Custom live TV timeout (0 to use default)**: The timemout to use when trying to read live streams. Default for live streams is 0. Default for timeshifting is 10 seconds.
 * **Stream read chunk size**: The chunk size used by Kodi for streams. Default 0 to leave it to Kodi to decide.
+* **Ignore debug logging in debug mode**: Debug log statements will not be displayed for the addon even though debug logging is enabled in Kodi. This can be useful when trying to debug an issue in Kodi which is not addon related.
 * **Enable debug logging in normal mode**: Debug log statements will display for the addon even though debug logging may not be enabled in Kodi. Note that all debug log statements will display at NOTICE level.
 * **Enable trace logging in debug mode**: Very detailed and verbose log statements will display in addition to standard debug statements. If enabled along with `Enable debug logging in normal mode` both trace and debug will display without debug logging enabled. In this case both debug and trace log statements will display at NOTICE level.
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ Some features are only available with at least certain OpenWebIf versions:
   * Embedded EPG Genres
   * Tuner Details
   * Provider Name
-  * Backend Channel Numbers
   * Picon URLs
 * 1.3.6
   * Editing Recordings
+* 1.3.7
+  * Backend Channel Numbers
 
 # Enigma2 PVR
 Enigma2 PVR client addon for [Kodi](https://kodi.tv)
@@ -123,7 +124,9 @@ Within this tab general options are configured.
 ### Channels
 Within this tab options that refer to channel data can be set. When changing bouquets you may need to clear the channel cache to the settings to take effect. You can do this by going to the following in Kodi settings: `Settings->PVR & Live TV->General->Clear cache`.
 
-Note that channel numbers are set in the addon based on their first occurence when loaded, i.e. if a channel appears in multiple bouqets the channel number will be taken from the first bouquet that is loaded, any subsequent channel numbers will be ignored. Therefore if you use a master bouquet it should be the first bouquet loaded assuming it has the channel numbering/order you require.
+Note that channel numbers are set in the addon based on their first occurence when loaded, i.e. if a channel appears in multiple bouqets the channel number will be taken from the first bouquet in which it is loaded, any subsequent channel numbers will be ignored. Therefore if it's desired to keep the same channel numbers across the Enigma2 device and the addon the following guidelines should be adhered to:
+  * If a master bouquet is used it should be the first bouquet loaded assuming it has the channel numbering/order you require.
+  * If not using a master bouquet each channel should only appear in a single bouquet (i.e. do not use channels in multiple bouquets unless they have different service references).
 
 If Kodi PVR is set to use the channel numbers from the backend the numbers will match those on your STB. If this is not enabled each unique instance of a channel will be given the next free number starting from 1 (i.e. the 17th unique channel will be channel 17). Backend channel numbers will only work for OpenWebIf 1.3.5 and later and they have been tested using ABM (AutoBouquetsMaker).
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Within this tab the connection options need to be configured before it can be su
 ### General
 Within this tab general options are configured.
 
+* **Set program id for live channel streams**: Some TV Providers (e.g. Nos - Portugal) using MPTS send extra program stream information. Setting the program id allows kodi to select the correct stream and therefore makes the channel/recording playable. Note that it takes approx 33% longer to open any stream with this option enabled.
 * **Fetch picons from web interface**: Fetch the picons straight from the Enigma 2 set-top box.
 * **Use picons.eu file format**: Assume all picons files fetched from the set-top box start with `1_1_1_` and end with `_0_0_0`.
 * **Use OpenWebIf picon path**: Fetch the picon path from OpenWebIf instead of constructing from ServiceRef. Requires OpenWebIf 1.3.5 or higher. There is no effect if used on a lower version of OpenWebIf.
@@ -130,8 +131,8 @@ Note that channel numbers are set in the addon based on their first occurence wh
 
 If Kodi PVR is set to use the channel numbers from the backend the numbers will match those on your STB. If this is not enabled each unique instance of a channel will be given the next free number starting from 1 (i.e. the 17th unique channel will be channel 17). Backend channel numbers will only work for OpenWebIf 1.3.5 and later and they have been tested using ABM (AutoBouquetsMaker).
 
-* **Use standard channel service reference**: Usually service reference's for the channels are in a standard format like `1:0:1:27F6:806:2:11A0000:0:0:0:`. On occasion depending on provider they can be extended with some text e.g. `1:0:1:27F6:806:2:11A0000:0:0:0::UTV` or `1:0:1:27F6:806:2:11A0000:0:0:0::UTV + 1`. If this option is enabled then all read service reference's will be read as standard. This is default behaviour. Functionality like autotimers will always convert to a standard reference.
 * **Zap before channelswitch (i.e. for Single Tuner boxes)**: When using the addon with a single tuner box it may be necessary that the addon needs to be able to zap to another channel on the set-top box. If this option is enabled each channel switch in Kodi will also result in a channel switch on the set-top box. Please note that "allow channel switching" needs to be enabled in the webinterface on the set-top box.
+* **Use standard channel service reference**: Usually service reference's for the channels are in a standard format like `1:0:1:27F6:806:2:11A0000:0:0:0:`. On occasion depending on provider they can be extended with some text e.g. `1:0:1:27F6:806:2:11A0000:0:0:0::UTV` or `1:0:1:27F6:806:2:11A0000:0:0:0::UTV + 1`. If this option is enabled then all read service reference's will be read as standard. This is default behaviour. Functionality like autotimers will always convert to a standard reference.
 * **TV bouquet fetch mode**: Choose from one of the following three modes:
     - `All bouquets` - Fetch all TV bouquets from the set-top box.
     - `Some bouquets` - Only fetch the bouquet specified in the next option

--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="4.3.0"
+  version="4.4.0"
   name="Enigma2 Client"
   provider-name="Joerg Dembski and Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>
@@ -175,6 +175,13 @@
     <disclaimer lang="zh_TW">這是測試版軟體！其原創作者並無法對於以下情況負責，包含：錄影失敗，不正確的定時設定，多餘時數，或任何產生的其它不良影響...</disclaimer>
     <platform>@PLATFORM@</platform>
     <news>
+v4.4.0
+- Added: Set program id option for streams with superfluous program data
+- Added: Undelete and trashcan (when configured on backend) for recordings
+- Added: Use new API for backend channel numbers - openwebif 1.3.7
+- Fixed: Radio groups parsed from wrong api
+- Added: Support disabling addon debug logging in debug mode
+
 v4.3.0
 - Added: Support backend channel numbers for all channel groups not just the first
 - Added: Ignore empty channel groups

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,3 +1,10 @@
+v4.4.0
+- Added: Set program id option for streams with superfluous program data
+- Added: Undelete and trashcan (when configured on backend) for recordings
+- Added: Use new API for backend channel numbers - openwebif 1.3.7
+- Fixed: Radio groups parsed from wrong api
+- Added: Support disabling addon debug logging in debug mode
+
 v4.3.0
 - Added: Support backend channel numbers for all channel groups not just the first
 - Added: Ignore empty channel groups

--- a/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
@@ -52,7 +52,10 @@ msgctxt "#30006"
 msgid "Icons"
 msgstr ""
 
-#empty string with id 30007
+#label-group: General - Program Streams
+msgctxt "#30007"
+msgid "Program Streams"
+msgstr ""
 
 #label: General - iconpath
 msgctxt "#30008"
@@ -81,7 +84,10 @@ msgctxt "#30013"
 msgid "Zap before channelswitch (i.e. for single tuner boxes)"
 msgstr ""
 
-#empty string with id 30014
+#label: Channels - setprogramid
+msgctxt "#30014"
+msgid "Set program id for live channel or recorded streams"
+msgstr ""
 
 #label: General - updateint
 msgctxt "#30015"
@@ -960,7 +966,12 @@ msgctxt "#30628"
 msgid "The hour of the day when the check for new channels should occur. Default is 4h as the Auto Bouquet Maker (ABM) on the E2 device defaults to 3AM."
 msgstr ""
 
-#empty strings from id 30629 to 30639
+#help: Channels - setprogramid
+msgctxt "#30629"
+msgid "Some TV Providers (e.g. Nos - Portugal) using MPTS send extra program stream information. Setting the program id allows kodi to select the correct stream and therefore makes the channel/recording playable. Note that it takes approx 33% longer to open any stream with this option enabled."
+msgstr ""
+
+#empty strings from id 30630 to 30639
 
 #help info - Channels
 

--- a/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
@@ -721,7 +721,12 @@ msgctxt "#30143"
 msgid "Radio bouquet 5"
 msgstr ""
 
-#empty strings from id 30144 to 30409
+#label: Advanced - ignoredebug
+msgctxt "#30144"
+msgid "No addon debug logging in Kodi debug mode"
+msgstr ""
+
+#empty strings from id 30145 to 30409
 
 ###############
 # application #
@@ -1242,7 +1247,12 @@ msgctxt "#30746"
 msgid "Very detailed and verbose log statements will display in addition to standard debug statements. If enabled along with `Enable debug logging in normal mode` both trace and debug will display without debug logging enabled. In this case both debug and trace log statements will display at NOTICE level."
 msgstr ""
 
-#empty strings from id 30747 to 30759
+#help: Advanced - ignoredebug
+msgctxt "#30747"
+msgid "Debug log statements will not be displayed for the addon even though debug logging is enabled in Kodi. This can be useful when trying to debug an issue in Kodi which is not addon related."
+msgstr ""
+
+#empty strings from id 30748 to 30759
 
 #help info - Backend
 

--- a/pvr.vuplus/resources/settings.xml
+++ b/pvr.vuplus/resources/settings.xml
@@ -838,14 +838,25 @@
             <formatlabel>14049</formatlabel>
           </control>
         </setting>
-        <setting id="debugnormal" type="boolean" label="30111" help="30745">
+        <setting id="nodebug" type="boolean" label="30144" help="30747">
           <level>1</level>
           <default>false</default>
           <control type="toggle" />
         </setting>
-        <setting id="tracedebug" type="boolean" label="30104" help="30746">
+        <setting id="debugnormal" type="boolean" parent="nodebug" label="30111" help="30745">
           <level>1</level>
           <default>false</default>
+          <dependencies>
+            <dependency type="enable" setting="nodebug">false</dependency>
+          </dependencies>
+          <control type="toggle" />
+        </setting>
+        <setting id="tracedebug" type="boolean" parent="nodebug" label="30104" help="30746">
+          <level>1</level>
+          <default>false</default>
+          <dependencies>
+            <dependency type="enable" setting="nodebug">false</dependency>
+          </dependencies>
           <control type="toggle" />
         </setting>
       </group>

--- a/pvr.vuplus/resources/settings.xml
+++ b/pvr.vuplus/resources/settings.xml
@@ -114,7 +114,15 @@
 
     <!-- General -->
     <category id="general" label="30018" help="30620">
-      <group id="1" label="30006">
+      <group id="1" label="30007">
+        <setting id="setprogramid" type="boolean" label="30014" help="30629">
+          <level>0</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+      </group>
+
+      <group id="2" label="30006">
         <setting id="onlinepicons" type="boolean" label="30027" help="30621">
           <level>0</level>
           <default>true</default>
@@ -149,7 +157,7 @@
         </setting>
       </group>
 
-      <group id="2" label="30009">
+      <group id="3" label="30009">
         <setting id="updateint" type="integer" label="30015" help="30625">
           <level>1</level>
           <default>2</default>
@@ -213,14 +221,14 @@
     <!-- Channels -->
     <category id="channels" label="30019" help="30640">
       <group id="1" label="30018">
-        <setting id="usestandardserviceref" type="boolean" label="30126" help="30641">
-          <level>3</level>
-          <default>true</default>
-          <control type="toggle" />
-        </setting>
         <setting id="zap" type="boolean" label="30013" help="30642">
           <level>0</level>
           <default>false</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="usestandardserviceref" type="boolean" label="30126" help="30641">
+          <level>3</level>
+          <default>true</default>
           <control type="toggle" />
         </setting>
       </group>

--- a/src/Enigma2.cpp
+++ b/src/Enigma2.cpp
@@ -85,7 +85,8 @@ void Enigma2::Reset()
   m_timers.ClearTimers();
 
   Logger::Log(LEVEL_DEBUG, "%s Removing internal recordings list...", __FUNCTION__);
-  m_recordings.ClearRecordings();
+  m_recordings.ClearRecordings(false);
+  m_recordings.ClearRecordings(true);
 
   Logger::Log(LEVEL_DEBUG, "%s Removing internal group list...", __FUNCTION__);
   m_channelGroups.ClearChannelGroups();
@@ -508,19 +509,19 @@ std::string Enigma2::GetStreamURL(const std::string& strM3uURL)
  * Recordings
  **************************************************************************/
 
-unsigned int Enigma2::GetRecordingsAmount()
+unsigned int Enigma2::GetRecordingsAmount(bool deleted)
 {
-  return m_recordings.GetNumRecordings();
+  return m_recordings.GetNumRecordings(deleted);
 }
 
-PVR_ERROR Enigma2::GetRecordings(ADDON_HANDLE handle)
+PVR_ERROR Enigma2::GetRecordings(ADDON_HANDLE handle, bool deleted)
 {
-  m_recordings.LoadRecordings();
+  m_recordings.LoadRecordings(deleted);
 
   std::vector<PVR_RECORDING> recordings;
   {
     CLockObject lock(m_mutex);
-    m_recordings.GetRecordings(recordings);
+    m_recordings.GetRecordings(recordings, deleted);
   }
 
   Logger::Log(LEVEL_DEBUG, "%s - recordings available '%d'", __FUNCTION__, recordings.size());
@@ -534,6 +535,16 @@ PVR_ERROR Enigma2::GetRecordings(ADDON_HANDLE handle)
 PVR_ERROR Enigma2::DeleteRecording(const PVR_RECORDING &recinfo)
 {
   return m_recordings.DeleteRecording(recinfo);
+}
+
+PVR_ERROR Enigma2::UndeleteRecording(const PVR_RECORDING& recording)
+{
+  return m_recordings.UndeleteRecording(recording);
+}
+
+PVR_ERROR Enigma2::DeleteAllRecordingsFromTrash()
+{
+  return m_recordings.DeleteAllRecordingsFromTrash();
 }
 
 PVR_ERROR Enigma2::GetRecordingEdl(const PVR_RECORDING &recinfo, PVR_EDL_ENTRY edl[], int *size)

--- a/src/Enigma2.cpp
+++ b/src/Enigma2.cpp
@@ -484,6 +484,10 @@ const std::string Enigma2::GetLiveStreamURL(const PVR_CHANNEL &channelinfo)
   return m_channels.GetChannel(channelinfo.iUniqueId)->GetStreamURL();
 }
 
+int Enigma2::GetChannelStreamProgramNumber(const PVR_CHANNEL &channelinfo)
+{
+  return m_channels.GetChannel(channelinfo.iUniqueId)->GetStreamProgramNumber();
+}
 
 /**
   * GetStreamURL() reads out a stream-URL from a M3U-file.
@@ -591,6 +595,16 @@ RecordingReader *Enigma2::OpenRecordedStream(const PVR_RECORDING &recinfo)
   }
 
   return new RecordingReader(m_recordings.GetRecordingURL(recinfo).c_str(), start, end, recinfo.iDuration);
+}
+
+bool Enigma2::HasRecordingStreamProgramNumber(const PVR_RECORDING& recording)
+{
+  return m_recordings.HasRecordingStreamProgramNumber(recording);
+}
+
+int Enigma2::GetRecordingStreamProgramNumber(const PVR_RECORDING& recording)
+{
+  return m_recordings.GetRecordingStreamProgramNumber(recording);
 }
 
 PVR_ERROR Enigma2::RenameRecording(const PVR_RECORDING &recording)

--- a/src/Enigma2.h
+++ b/src/Enigma2.h
@@ -83,9 +83,11 @@ public:
   bool OpenLiveStream(const PVR_CHANNEL &channelinfo);
   void CloseLiveStream();
   const std::string GetLiveStreamURL(const PVR_CHANNEL &channelinfo);
-  unsigned int GetRecordingsAmount();
-  PVR_ERROR GetRecordings(ADDON_HANDLE handle);
+  unsigned int GetRecordingsAmount(bool deleted);
+  PVR_ERROR GetRecordings(ADDON_HANDLE handle, bool deleted);
   PVR_ERROR DeleteRecording(const PVR_RECORDING &recinfo);
+  PVR_ERROR UndeleteRecording(const PVR_RECORDING& recording);
+  PVR_ERROR DeleteAllRecordingsFromTrash();
   bool GetRecordingsFromLocation(std::string strRecordingFolder);
   PVR_ERROR GetRecordingEdl(const PVR_RECORDING &recinfo, PVR_EDL_ENTRY edl[], int *size);
   PVR_ERROR RenameRecording(const PVR_RECORDING &recording);

--- a/src/Enigma2.h
+++ b/src/Enigma2.h
@@ -83,6 +83,7 @@ public:
   bool OpenLiveStream(const PVR_CHANNEL &channelinfo);
   void CloseLiveStream();
   const std::string GetLiveStreamURL(const PVR_CHANNEL &channelinfo);
+  int GetChannelStreamProgramNumber(const PVR_CHANNEL &channelinfo);
   unsigned int GetRecordingsAmount(bool deleted);
   PVR_ERROR GetRecordings(ADDON_HANDLE handle, bool deleted);
   PVR_ERROR DeleteRecording(const PVR_RECORDING &recinfo);
@@ -94,6 +95,8 @@ public:
   PVR_ERROR SetRecordingPlayCount(const PVR_RECORDING &recording, int count);
   PVR_ERROR SetRecordingLastPlayedPosition(const PVR_RECORDING &recording, int lastplayedposition);
   int GetRecordingLastPlayedPosition(const PVR_RECORDING &recording);
+  bool HasRecordingStreamProgramNumber(const PVR_RECORDING& recording);
+  int GetRecordingStreamProgramNumber(const PVR_RECORDING& recording);
   enigma2::RecordingReader *OpenRecordedStream(const PVR_RECORDING &recinfo);
   void GetTimerTypes(PVR_TIMER_TYPE types[], int *size);
   int GetTimersAmount(void);

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -203,7 +203,7 @@ PVR_ERROR GetAddonCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities)
   pCapabilities->bSupportsTV                 = true;
   pCapabilities->bSupportsRadio              = true;
   pCapabilities->bSupportsRecordings         = true;
-  pCapabilities->bSupportsRecordingsUndelete = false;
+  pCapabilities->bSupportsRecordingsUndelete = true;
   pCapabilities->bSupportsTimers             = true;
   pCapabilities->bSupportsChannelGroups      = true;
   pCapabilities->bSupportsChannelScan        = false;
@@ -469,7 +469,7 @@ int GetRecordingsAmount(bool deleted)
   if (!enigma || !enigma->IsConnected())
     return 0;
 
-  return enigma->GetRecordingsAmount();
+  return enigma->GetRecordingsAmount(deleted);
 }
 
 PVR_ERROR GetRecordings(ADDON_HANDLE handle, bool deleted)
@@ -477,7 +477,7 @@ PVR_ERROR GetRecordings(ADDON_HANDLE handle, bool deleted)
   if (!enigma || !enigma->IsConnected())
     return PVR_ERROR_SERVER_ERROR;
 
-  return enigma->GetRecordings(handle);
+  return enigma->GetRecordings(handle, deleted);
 }
 
 PVR_ERROR DeleteRecording(const PVR_RECORDING &recording)
@@ -486,6 +486,22 @@ PVR_ERROR DeleteRecording(const PVR_RECORDING &recording)
     return PVR_ERROR_SERVER_ERROR;
 
   return enigma->DeleteRecording(recording);
+}
+
+PVR_ERROR UndeleteRecording(const PVR_RECORDING& recording)
+{
+  if (!enigma || !enigma->IsConnected())
+    return PVR_ERROR_SERVER_ERROR;
+
+  return enigma->UndeleteRecording(recording);
+}
+
+PVR_ERROR DeleteAllRecordingsFromTrash()
+{
+  if (!enigma || !enigma->IsConnected())
+    return PVR_ERROR_SERVER_ERROR;
+
+  return enigma->DeleteAllRecordingsFromTrash();
 }
 
 PVR_ERROR GetRecordingEdl(const PVR_RECORDING &recinfo, PVR_EDL_ENTRY edl[], int *size)
@@ -649,8 +665,6 @@ void DemuxReset(void) {}
 void DemuxFlush(void) {}
 bool SeekTime(double,bool,double*) { return false; }
 void SetSpeed(int) {};
-PVR_ERROR UndeleteRecording(const PVR_RECORDING& recording) { return PVR_ERROR_NOT_IMPLEMENTED; }
-PVR_ERROR DeleteAllRecordingsFromTrash() { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR SetEPGTimeFrame(int) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR GetDescrambleInfo(PVR_DESCRAMBLE_INFO*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR SetRecordingLifetime(const PVR_RECORDING*) { return PVR_ERROR_NOT_IMPLEMENTED; }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -89,6 +89,10 @@ ADDON_STATUS ADDON_Create(void* hdl, void* props)
   /* Configure the logger */
   Logger::GetInstance().SetImplementation([](LogLevel level, const char *message)
   {
+    /* Don't log trace messages unless told so */
+    if (level == LogLevel::LEVEL_TRACE && !Settings::GetInstance().GetTraceDebug())
+      return;
+
     /* Convert the log level */
     addon_log_t addonLevel;
 
@@ -107,11 +111,10 @@ ADDON_STATUS ADDON_Create(void* hdl, void* props)
         addonLevel = addon_log_t::LOG_DEBUG;
     }
 
-    /* Don't log trace messages unless told so */
-    if (level == LogLevel::LEVEL_TRACE && !Settings::GetInstance().GetTraceDebug())
+    if (addonLevel == addon_log_t::LOG_DEBUG && Settings::GetInstance().GetNoDebug())
       return;
 
-    if (Settings::GetInstance().GetDebugNormal() && level == LogLevel::LEVEL_DEBUG)
+    if (addonLevel == addon_log_t::LOG_DEBUG && Settings::GetInstance().GetDebugNormal())
       addonLevel = addon_log_t::LOG_NOTICE;
 
     XBMC->Log(addonLevel, "%s", message);

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -338,6 +338,36 @@ PVR_ERROR GetChannels(ADDON_HANDLE handle, bool bRadio)
  * Live Streams
  **************************************************************************/
 
+PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL* channel, PVR_NAMED_VALUE* properties, unsigned int* iPropertiesCount)
+{
+  if (!settings.SetStreamProgramID())
+    return PVR_ERROR_NOT_IMPLEMENTED;
+
+  //
+  // We only use this function to set the program number which comes with every Enigma2 channel. For providers that
+  // use MPTS it allows the FFMPEG Demux to identify the correct Program/PID.
+  //
+
+  if (!channel || !properties || !iPropertiesCount)
+    return PVR_ERROR_SERVER_ERROR;
+
+  if (*iPropertiesCount < 1)
+    return PVR_ERROR_INVALID_PARAMETERS;
+
+  if (!enigma || !enigma->IsConnected())
+    return PVR_ERROR_SERVER_ERROR;
+
+  const std::string strStreamProgramNumber = std::to_string(enigma->GetChannelStreamProgramNumber(*channel));
+
+  Logger::Log(LEVEL_NOTICE, "%s - for channel: %s, set Stream Program Number to %s - %s", __FUNCTION__, channel->strChannelName, strStreamProgramNumber.c_str(), enigma->GetLiveStreamURL(*channel).c_str());
+
+  strncpy(properties[0].strName, "program", sizeof(properties[0].strName) - 1);
+  strncpy(properties[0].strValue, strStreamProgramNumber.c_str(), sizeof(properties[0].strValue) - 1);
+  *iPropertiesCount = 1;
+
+  return PVR_ERROR_NO_ERROR;
+}
+
 PVR_ERROR GetStreamReadChunkSize(int* chunksize)
 {
   if (!chunksize)
@@ -554,6 +584,39 @@ int GetRecordingLastPlayedPosition(const PVR_RECORDING &recording)
  * Recording Streams
  **************************************************************************/
 
+PVR_ERROR GetRecordingStreamProperties(const PVR_RECORDING* recording, PVR_NAMED_VALUE* properties, unsigned int* iPropertiesCount)
+{
+  if (!settings.SetStreamProgramID())
+    return PVR_ERROR_NOT_IMPLEMENTED;
+
+  //
+  // We only use this function to set the program number which may comes with every Enigma2 recording. For providers that
+  // use MPTS it allows the FFMPEG Demux to identify the correct Program/PID.
+  //
+
+  if (!recording || !properties || !iPropertiesCount)
+    return PVR_ERROR_SERVER_ERROR;
+
+  if (*iPropertiesCount < 1)
+    return PVR_ERROR_INVALID_PARAMETERS;
+
+  if (!enigma || !enigma->IsConnected())
+    return PVR_ERROR_SERVER_ERROR;
+
+  if (enigma->HasRecordingStreamProgramNumber(*recording))
+  {
+    const std::string strStreamProgramNumber = std::to_string(enigma->GetRecordingStreamProgramNumber(*recording));
+
+    Logger::Log(LEVEL_NOTICE, "%s - for recording for channel: %s, set Stream Program Number to %s - %s", __FUNCTION__, recording->strChannelName, strStreamProgramNumber.c_str(), recording->strRecordingId);
+
+    strncpy(properties[0].strName, "program", sizeof(properties[0].strName) - 1);
+    strncpy(properties[0].strValue, strStreamProgramNumber.c_str(), sizeof(properties[0].strValue) - 1);
+    *iPropertiesCount = 1;
+  }
+
+  return PVR_ERROR_NO_ERROR;
+}
+
 bool OpenRecordedStream(const PVR_RECORDING &recording)
 {
   if (recordingReader)
@@ -650,7 +713,6 @@ PVR_ERROR UpdateTimer(const PVR_TIMER &timer)
 
 /** UNUSED API FUNCTIONS */
 PVR_ERROR GetStreamProperties(PVR_STREAM_PROPERTIES* pProperties) { return PVR_ERROR_NOT_IMPLEMENTED; }
-PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL*, PVR_NAMED_VALUE*, unsigned int*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 void DemuxAbort(void) { return; }
 DemuxPacket* DemuxRead(void) { return nullptr; }
 void FillBuffer(bool mode) {}
@@ -660,7 +722,6 @@ PVR_ERROR DeleteChannel(const PVR_CHANNEL &channel) { return PVR_ERROR_NOT_IMPLE
 PVR_ERROR RenameChannel(const PVR_CHANNEL &channel) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR OpenDialogChannelSettings(const PVR_CHANNEL &channel) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR OpenDialogChannelAdd(const PVR_CHANNEL &channel) { return PVR_ERROR_NOT_IMPLEMENTED; }
-PVR_ERROR GetRecordingStreamProperties(const PVR_RECORDING* recording, PVR_NAMED_VALUE* properties, unsigned int* iPropertiesCount) { return PVR_ERROR_NOT_IMPLEMENTED; }
 void DemuxReset(void) {}
 void DemuxFlush(void) {}
 bool SeekTime(double,bool,double*) { return false; }

--- a/src/enigma2/ChannelGroups.cpp
+++ b/src/enigma2/ChannelGroups.cpp
@@ -254,7 +254,7 @@ bool ChannelGroups::LoadRadioChannelGroups()
 
   if (Settings::GetInstance().GetRadioChannelGroupMode() != ChannelGroupMode::FAVOURITES_GROUP)
   {
-    const std::string strTmp = StringUtils::Format("%sweb/getallservices?type=radio&renameserviceforxbmc=yes", Settings::GetInstance().GetConnectionURL().c_str());
+    const std::string strTmp = StringUtils::Format("%sweb/getservices?sRef=%s", Settings::GetInstance().GetConnectionURL().c_str(), WebUtils::URLEncodeInline("1:7:1:0:0:0:0:0:0:0:FROM BOUQUET \"bouquets.radio\" ORDER BY bouquet").c_str());
 
     const std::string strXML = WebUtils::GetHttpXML(strTmp);
 
@@ -267,25 +267,25 @@ bool ChannelGroups::LoadRadioChannelGroups()
 
     TiXmlHandle hDoc(&xmlDoc);
 
-    TiXmlElement* pElem = hDoc.FirstChildElement("e2servicelistrecursive").Element();
+    TiXmlElement* pElem = hDoc.FirstChildElement("e2servicelist").Element();
 
     if (!pElem)
     {
-      Logger::Log(LEVEL_ERROR, "%s Could not find <e2servicelistrecursive> element for radio groups!", __FUNCTION__);
+      Logger::Log(LEVEL_ERROR, "%s Could not find <e2servicelist> element!", __FUNCTION__);
       return false;
     }
 
     TiXmlHandle hRoot = TiXmlHandle(pElem);
 
-    TiXmlElement* pNode = hRoot.FirstChildElement("e2bouquet").Element();
+    TiXmlElement* pNode = hRoot.FirstChildElement("e2service").Element();
 
     if (!pNode)
     {
-      Logger::Log(LEVEL_ERROR, "%s Could not find <e2bouquet> element for radio groups", __FUNCTION__);
+      Logger::Log(LEVEL_ERROR, "%s Could not find <e2service> element", __FUNCTION__);
       return false;
     }
 
-    for (; pNode != nullptr; pNode = pNode->NextSiblingElement("e2bouquet"))
+    for (; pNode != nullptr; pNode = pNode->NextSiblingElement("e2service"))
     {
       ChannelGroup newChannelGroup;
 

--- a/src/enigma2/ChannelGroups.cpp
+++ b/src/enigma2/ChannelGroups.cpp
@@ -9,12 +9,14 @@
 #include "utilities/WebUtils.h"
 #include "utilities/FileUtils.h"
 
+#include <nlohmann/json.hpp>
 #include "util/XMLUtils.h"
 #include "p8-platform/util/StringUtils.h"
 
 using namespace enigma2;
 using namespace enigma2::data;
 using namespace enigma2::utilities;
+using json = nlohmann::json;
 
 void ChannelGroups::GetChannelGroups(std::vector<PVR_CHANNEL_GROUP> &kodiChannelGroups, bool radio) const
 {
@@ -39,7 +41,7 @@ void ChannelGroups::GetChannelGroups(std::vector<PVR_CHANNEL_GROUP> &kodiChannel
 
 PVR_ERROR ChannelGroups::GetChannelGroupMembers(std::vector<PVR_CHANNEL_GROUP_MEMBER> &channelGroupMembers, const std::string &groupName)
 {
-  std::shared_ptr<ChannelGroup> channelGroup = GetChannelGroup(groupName);
+  std::shared_ptr<ChannelGroup> channelGroup = GetChannelGroupUsingName(groupName);
 
   if (!channelGroup)
   {
@@ -100,9 +102,18 @@ std::shared_ptr<ChannelGroup> ChannelGroups::GetChannelGroup(int uniqueId)
   return m_channelGroups.at(uniqueId - 1);
 }
 
-std::shared_ptr<ChannelGroup> ChannelGroups::GetChannelGroup(std::string groupName)
+std::shared_ptr<ChannelGroup> ChannelGroups::GetChannelGroup(const std::string &groupServiceReference)
 {
-  std::shared_ptr<ChannelGroup> channelGroup = nullptr;
+  const auto channelGroupPair = m_channelGroupsServiceReferenceMap.find(groupServiceReference);
+  if (channelGroupPair != m_channelGroupsServiceReferenceMap.end())
+    return channelGroupPair->second;
+
+  return {};
+}
+
+std::shared_ptr<ChannelGroup> ChannelGroups::GetChannelGroupUsingName(const std::string &groupName)
+{
+  std::shared_ptr<ChannelGroup> channelGroup;
 
   auto channelGroupPair = m_channelGroupsNameMap.find(groupName);
   if (channelGroupPair != m_channelGroupsNameMap.end())
@@ -120,7 +131,7 @@ bool ChannelGroups::IsValid(int uniqueId) const
 
 bool ChannelGroups::IsValid(std::string groupName)
 {
-  return GetChannelGroup(groupName) != nullptr;
+  return GetChannelGroupUsingName(groupName) != nullptr;
 }
 
 int ChannelGroups::GetNumChannelGroups() const
@@ -132,8 +143,7 @@ void ChannelGroups::ClearChannelGroups()
 {
   m_channelGroups.clear();
   m_channelGroupsNameMap.clear();
-
-  m_extraDataChannelGroups.clear();
+  m_channelGroupsServiceReferenceMap.clear();
 
   Settings::GetInstance().SetUsesLastScannedChannelGroup(false);
 }
@@ -150,6 +160,7 @@ void ChannelGroups::AddChannelGroup(ChannelGroup& newChannelGroup)
 
     std::shared_ptr<ChannelGroup> channelGroup = m_channelGroups.back();
     m_channelGroupsNameMap.insert({channelGroup->GetGroupName(), channelGroup});
+    m_channelGroupsServiceReferenceMap.insert({channelGroup->GetServiceReference(), channelGroup});
   }
 }
 
@@ -218,7 +229,7 @@ bool ChannelGroups::LoadTVChannelGroups()
     {
       ChannelGroup newChannelGroup;
 
-      if (!newChannelGroup.UpdateFrom(pNode, false, m_extraDataChannelGroups))
+      if (!newChannelGroup.UpdateFrom(pNode, false))
         continue;
 
       AddChannelGroup(newChannelGroup);
@@ -226,6 +237,8 @@ bool ChannelGroups::LoadTVChannelGroups()
       Logger::Log(LEVEL_INFO, "%s Loaded channelgroup: %s", __FUNCTION__, newChannelGroup.GetGroupName().c_str());
     }
   }
+
+  LoadChannelGroupsStartPosition(false);
 
   if (Settings::GetInstance().GetTVFavouritesMode() == FavouritesGroupMode::AS_LAST_GROUP &&
       Settings::GetInstance().GetTVChannelGroupMode() != ChannelGroupMode::FAVOURITES_GROUP)
@@ -289,7 +302,7 @@ bool ChannelGroups::LoadRadioChannelGroups()
     {
       ChannelGroup newChannelGroup;
 
-      if (!newChannelGroup.UpdateFrom(pNode, true, m_extraDataChannelGroups))
+      if (!newChannelGroup.UpdateFrom(pNode, true))
         continue;
 
       AddChannelGroup(newChannelGroup);
@@ -297,6 +310,8 @@ bool ChannelGroups::LoadRadioChannelGroups()
       Logger::Log(LEVEL_INFO, "%s Loaded channelgroup: %s", __FUNCTION__, newChannelGroup.GetGroupName().c_str());
     }
   }
+
+  LoadChannelGroupsStartPosition(true);
 
   if (Settings::GetInstance().GetRadioFavouritesMode() == FavouritesGroupMode::AS_LAST_GROUP &&
       Settings::GetInstance().GetRadioChannelGroupMode() != ChannelGroupMode::FAVOURITES_GROUP)
@@ -354,4 +369,64 @@ void ChannelGroups::AddRadioLastScannedChannelGroup()
   AddChannelGroup(newChannelGroup);
   Settings::GetInstance().SetUsesLastScannedChannelGroup(true);
   Logger::Log(LEVEL_INFO, "%s Loaded channelgroup: %s", __FUNCTION__, newChannelGroup.GetGroupName().c_str());
+}
+
+void ChannelGroups::LoadChannelGroupsStartPosition(bool radio)
+{
+  if (Settings::GetInstance().SupportsChannelNumberGroupStartPos())
+  {
+    //We can use the JSON API so let's supplement the existing groups with start channel numbers
+    std::string jsonURL;
+
+    if (!radio)
+    {
+      Logger::Log(LEVEL_INFO, "%s loading channel group start channel number for all TV groups", __FUNCTION__);
+      jsonURL = StringUtils::Format("%sapi/getservices", Settings::GetInstance().GetConnectionURL().c_str());
+    }
+    else
+    {
+      Logger::Log(LEVEL_INFO, "%s loading channel group start channel number for all Radio groups", __FUNCTION__);
+      jsonURL = StringUtils::Format("%sapi/getservices?sRef=%s", Settings::GetInstance().GetConnectionURL().c_str(), WebUtils::URLEncodeInline("1:7:1:0:0:0:0:0:0:0:FROM BOUQUET \"bouquets.radio\" ORDER BY bouquet").c_str());
+    }
+
+    const std::string strJson = WebUtils::GetHttpXML(jsonURL);
+
+    try
+    {
+      auto jsonDoc = json::parse(strJson);
+
+      if (!jsonDoc["services"].empty())
+      {
+        for (const auto& it : jsonDoc["services"].items())
+        {
+          auto jsonGroup = it.value();
+
+          std::string serviceReference = jsonGroup["servicereference"].get<std::string>();
+
+          // Check whether the current element is not just a label or that it's not a hidden entry
+          if (serviceReference.compare(0, 5, "1:64:") == 0 || serviceReference.compare(0, 6, "1:320:") == 0)
+            continue;
+
+          auto group = GetChannelGroup(serviceReference);
+
+          if (group)
+          {
+            if (!jsonGroup["startpos"].empty())
+            {
+              Logger::Log(LEVEL_DEBUG, "%s For Group %s, set start pos for channel number is %d", __FUNCTION__, jsonGroup["servicename"].get<std::string>().c_str(), jsonGroup["startpos"].get<int>());
+              group->SetStartChannelNumber(jsonGroup["startpos"].get<int>());
+            }
+          }
+        }
+      }
+    }
+    catch (nlohmann::detail::parse_error& e)
+    {
+      Logger::Log(LEVEL_ERROR, "%s Invalid JSON received, cannot load start channel number for group from OpenWebIf - JSON parse error - message: %s, exception id: %d", __FUNCTION__, e.what(), e.id);
+    }
+    catch (nlohmann::detail::type_error& e)
+    {
+      Logger::Log(LEVEL_ERROR, "%s JSON type error - message: %s, exception id: %d", __FUNCTION__, e.what(), e.id);
+    }
+  }
 }

--- a/src/enigma2/ChannelGroups.h
+++ b/src/enigma2/ChannelGroups.h
@@ -42,14 +42,14 @@ namespace enigma2
     int GetChannelGroupUniqueId(const std::string &groupName) const;
     std::string GetChannelGroupServiceReference(const std::string &groupName);
     std::shared_ptr<enigma2::data::ChannelGroup> GetChannelGroup(int uniqueId);
-    std::shared_ptr<enigma2::data::ChannelGroup> GetChannelGroup(std::string groupName);
+    std::shared_ptr<enigma2::data::ChannelGroup> GetChannelGroup(const std::string &groupServiceReference);
+    std::shared_ptr<enigma2::data::ChannelGroup> GetChannelGroupUsingName(const std::string &groupName);
     bool IsValid(int uniqueId) const;
     bool IsValid(std::string groupName);
     int GetNumChannelGroups() const;
     void ClearChannelGroups();
     std::vector<std::shared_ptr<enigma2::data::ChannelGroup>>& GetChannelGroupsList();
     bool LoadChannelGroups();
-    const std::vector<std::shared_ptr<enigma2::data::ChannelGroup>>& GetExtraDataChannelGroupsList() const { return m_extraDataChannelGroups; };
 
   private:
     bool LoadTVChannelGroups();
@@ -59,12 +59,10 @@ namespace enigma2
     void AddTVLastScannedChannelGroup();
     void AddRadioLastScannedChannelGroup();
     void AddChannelGroup(enigma2::data::ChannelGroup& channelGroup);
+    void LoadChannelGroupsStartPosition(bool radio);
 
     std::vector<std::shared_ptr<enigma2::data::ChannelGroup>> m_channelGroups;
     std::unordered_map<std::string, std::shared_ptr<enigma2::data::ChannelGroup>> m_channelGroupsNameMap;
-
-    // This is a special vector containing all channel groups even ones we don't require
-    // This is needed to calculate the backend channel numbers and they work in an unusual way on enigma2
-    std::vector<std::shared_ptr<enigma2::data::ChannelGroup>> m_extraDataChannelGroups;
+    std::unordered_map<std::string, std::shared_ptr<enigma2::data::ChannelGroup>> m_channelGroupsServiceReferenceMap;
   };
 } //namespace enigma2

--- a/src/enigma2/Channels.h
+++ b/src/enigma2/Channels.h
@@ -70,7 +70,7 @@ namespace enigma2
   private:
     void AddChannel(enigma2::data::Channel &channel, std::shared_ptr<enigma2::data::ChannelGroup> &channelGroup);
     bool LoadChannels(const std::string groupServiceReference, const std::string groupName, std::shared_ptr<enigma2::data::ChannelGroup> &channelGroup);
-    int LoadChannelsExtraData(const std::string groupServiceReference, const std::string groupName, bool requiredGroup, int channelPositionOffset);
+    int LoadChannelsExtraData(const std::shared_ptr<enigma2::data::ChannelGroup> channelGroup, int lastGroupLatestChannelPosition);
 
     std::vector<std::shared_ptr<enigma2::data::Channel>> m_channels;
     std::unordered_map<std::string, std::shared_ptr<enigma2::data::Channel>> m_channelsServiceReferenceMap;

--- a/src/enigma2/Recordings.cpp
+++ b/src/enigma2/Recordings.cpp
@@ -29,28 +29,41 @@ Recordings::Recordings(Channels &channels, enigma2::extract::EpgEntryExtractor &
   m_randomDistribution = std::uniform_int_distribution<>(E2_DEVICE_LAST_PLAYED_SYNC_INTERVAL_MIN, E2_DEVICE_LAST_PLAYED_SYNC_INTERVAL_MAX);
 }
 
-void Recordings::GetRecordings(std::vector<PVR_RECORDING> &kodiRecordings)
+void Recordings::GetRecordings(std::vector<PVR_RECORDING> &kodiRecordings, bool deleted)
 {
-  for (auto& recording : m_recordings)
+  auto& recordings = (!deleted) ? m_recordings : m_deletedRecordings;
+
+  for (auto& recording : recordings)
   {
     Logger::Log(LEVEL_DEBUG, "%s - Transfer recording '%s', Recording Id '%s'", __FUNCTION__, recording.GetTitle().c_str(), recording.GetRecordingId().c_str());
     PVR_RECORDING kodiRecording = {0};
 
-    recording.UpdateTo(kodiRecording, m_channels, IsInRecordingFolder(recording.GetTitle()));
+    recording.UpdateTo(kodiRecording, m_channels, IsInRecordingFolder(recording.GetTitle(), deleted));
 
     kodiRecordings.emplace_back(kodiRecording);
   }
 }
 
-int Recordings::GetNumRecordings() const
+int Recordings::GetNumRecordings(bool deleted) const
 {
-  return m_recordings.size();
+  const auto& recordings = (!deleted) ? m_recordings : m_deletedRecordings;
+
+  return recordings.size();
 }
 
-void Recordings::ClearRecordings()
+void Recordings::ClearRecordings(bool deleted)
 {
-  m_recordings.clear();
-  m_recordingsIdMap.clear();
+  auto& recordings = (!deleted) ? m_recordings : m_deletedRecordings;
+
+  recordings.clear();
+
+  for (auto it = m_recordingsIdMap.begin(); it != m_recordingsIdMap.end(); )
+  {
+    if (it->second.IsDeleted() == deleted)
+      it = m_recordingsIdMap.erase(it);
+    else
+      ++it;
+  }
 }
 
 void Recordings::GetRecordingEdl(const std::string &recordingId, std::vector<PVR_EDL_ENTRY> &edlEntries) const
@@ -111,10 +124,12 @@ RecordingEntry Recordings::GetRecording(const std::string &recordingId) const
   return entry;
 }
 
-bool Recordings::IsInRecordingFolder(const std::string &recordingFolder) const
+bool Recordings::IsInRecordingFolder(const std::string &recordingFolder, bool deleted) const
 {
+  const auto& recordings = (!deleted) ? m_recordings : m_deletedRecordings;
+
   int iMatches = 0;
-  for (const auto& recording : m_recordings)
+  for (const auto& recording : recordings)
   {
     if (recordingFolder == recording.GetTitle())
     {
@@ -424,6 +439,36 @@ PVR_ERROR Recordings::DeleteRecording(const PVR_RECORDING &recinfo)
   return PVR_ERROR_NO_ERROR;
 }
 
+PVR_ERROR Recordings::UndeleteRecording(const PVR_RECORDING& recording)
+{
+  auto recordingEntry = GetRecording(recording.strRecordingId);
+
+  std::regex regex(TRASH_FOLDER);
+
+  const std::string newRecordingDirectory = regex_replace(recordingEntry.GetDirectory(), regex, "");
+
+  const std::string strTmp = StringUtils::Format("web/moviemove?sRef=%s&dirname=%s", WebUtils::URLEncodeInline(recordingEntry.GetRecordingId()).c_str(), WebUtils::URLEncodeInline(newRecordingDirectory).c_str());
+
+  std::string strResult;
+  if(!WebUtils::SendSimpleCommand(strTmp, strResult))
+    return PVR_ERROR_FAILED;
+
+  return PVR_ERROR_NO_ERROR;
+}
+
+PVR_ERROR Recordings::DeleteAllRecordingsFromTrash()
+{
+  for (const auto &deletedRecording : m_deletedRecordings)
+  {
+    const std::string strTmp = StringUtils::Format("web/moviedelete?sRef=%s", WebUtils::URLEncodeInline(deletedRecording.GetRecordingId()).c_str());
+
+    std::string strResult;
+    WebUtils::SendSimpleCommand(strTmp, strResult, true);
+  }
+
+  return PVR_ERROR_NO_ERROR;
+}
+
 const std::string Recordings::GetRecordingURL(const PVR_RECORDING &recinfo)
 {
   for (const auto& recording : m_recordings)
@@ -590,21 +635,26 @@ bool Recordings::LoadLocations()
   return true;
 }
 
-void Recordings::LoadRecordings()
+void Recordings::LoadRecordings(bool deleted)
 {
-  ClearRecordings();
+  ClearRecordings(deleted);
 
-  for (const auto& location : m_locations)
+  for (std::string location : m_locations)
   {
-    if (!GetRecordingsFromLocation(location))
+    if (deleted)
+      location += TRASH_FOLDER;
+
+    if (!GetRecordingsFromLocation(location, deleted))
     {
       Logger::Log(LEVEL_ERROR, "%s Error fetching lists for folder: '%s'", __FUNCTION__, location.c_str());
     }
   }
 }
 
-bool Recordings::GetRecordingsFromLocation(const std::string recordingLocation)
+bool Recordings::GetRecordingsFromLocation(const std::string recordingLocation, bool deleted)
 {
+  auto& recordings = (!deleted) ? m_recordings : m_deletedRecordings;
+
   std::string url;
   std::string directory;
 
@@ -656,7 +706,7 @@ bool Recordings::GetRecordingsFromLocation(const std::string recordingLocation)
 
       RecordingEntry recordingEntry;
 
-      if (!recordingEntry.UpdateFrom(pNode, directory, m_channels))
+      if (!recordingEntry.UpdateFrom(pNode, directory, deleted, m_channels))
         continue;
 
       if (m_entryExtractor.IsEnabled())
@@ -664,7 +714,7 @@ bool Recordings::GetRecordingsFromLocation(const std::string recordingLocation)
 
       iNumRecordings++;
 
-      m_recordings.emplace_back(recordingEntry);
+      recordings.emplace_back(recordingEntry);
       m_recordingsIdMap.insert({recordingEntry.GetRecordingId(), recordingEntry});
 
       Logger::Log(LEVEL_DEBUG, "%s loaded Recording entry '%s', start '%d', length '%d'", __FUNCTION__, recordingEntry.GetTitle().c_str(), recordingEntry.GetStartTime(), recordingEntry.GetDuration());

--- a/src/enigma2/Recordings.cpp
+++ b/src/enigma2/Recordings.cpp
@@ -469,6 +469,16 @@ PVR_ERROR Recordings::DeleteAllRecordingsFromTrash()
   return PVR_ERROR_NO_ERROR;
 }
 
+bool Recordings::HasRecordingStreamProgramNumber(const PVR_RECORDING& recording)
+{
+  return GetRecording(recording.strRecordingId).HasStreamProgramNumber();
+}
+
+int Recordings::GetRecordingStreamProgramNumber(const PVR_RECORDING& recording)
+{
+  return GetRecording(recording.strRecordingId).GetStreamProgramNumber();
+}
+
 const std::string Recordings::GetRecordingURL(const PVR_RECORDING &recinfo)
 {
   for (const auto& recording : m_recordings)

--- a/src/enigma2/Recordings.h
+++ b/src/enigma2/Recordings.h
@@ -38,42 +38,46 @@ namespace enigma2
   static int CUTS_LAST_PLAYED_TYPE = 3;
   static int E2_DEVICE_LAST_PLAYED_SYNC_INTERVAL_MIN = 300;
   static int E2_DEVICE_LAST_PLAYED_SYNC_INTERVAL_MAX = 600;
+  static constexpr const char* TRASH_FOLDER = ".Trash";
 
   class Recordings
   {
   public:
     Recordings(Channels &channels, enigma2::extract::EpgEntryExtractor &entryExtractor);
-    void GetRecordings(std::vector<PVR_RECORDING> &recordings);
-    int GetNumRecordings() const;
-    void ClearRecordings();
+    void GetRecordings(std::vector<PVR_RECORDING> &recordings, bool deleted);
+    int GetNumRecordings(bool deleted) const;
+    void ClearRecordings(bool deleted);
     void GetRecordingEdl(const std::string &recordingId, std::vector<PVR_EDL_ENTRY> &edlEntries) const;
     PVR_ERROR RenameRecording(const PVR_RECORDING &recording);
     PVR_ERROR SetRecordingPlayCount(const PVR_RECORDING &recording, int count);
     PVR_ERROR SetRecordingLastPlayedPosition(const PVR_RECORDING &recording, int lastplayedposition);
     int GetRecordingLastPlayedPosition(const PVR_RECORDING &recording);
-    bool IsInRecordingFolder(const std::string &strRecordingFolder) const;
     const std::string GetRecordingURL(const PVR_RECORDING &recinfo);
     PVR_ERROR DeleteRecording(const PVR_RECORDING &recinfo);
+    PVR_ERROR UndeleteRecording(const PVR_RECORDING& recording);
+    PVR_ERROR DeleteAllRecordingsFromTrash();
 
     std::vector<std::string>& GetLocations();
     void ClearLocations();
 
     bool LoadLocations();
-    void LoadRecordings();
+    void LoadRecordings(bool deleted);
 
   private:
     static const std::string FILE_NOT_FOUND_RESPONSE_SUFFIX;
 
-    bool GetRecordingsFromLocation(const std::string recordingFolder);
+    bool GetRecordingsFromLocation(const std::string recordingFolder, bool deleted);
     data::RecordingEntry GetRecording(const std::string &recordingId) const;
     bool ReadExtaRecordingCutsInfo(const data::RecordingEntry &recordingEntry, std::vector<std::pair<int, int64_t>> &cuts, std::vector<std::string> &tags);
     bool ReadExtraRecordingPlayCountInfo(const data::RecordingEntry &recordingEntry, std::vector<std::string> &tags);
     void SetRecordingNextSyncTime(data::RecordingEntry &recordingEntry, time_t nextSyncTime, std::vector<std::string> &oldTags);
+    bool IsInRecordingFolder(const std::string &strRecordingFolder, bool deleted) const;
 
     std::mt19937 m_randomGenerator;
     std::uniform_int_distribution<> m_randomDistribution;
 
     std::vector<enigma2::data::RecordingEntry> m_recordings;
+    std::vector<enigma2::data::RecordingEntry> m_deletedRecordings;
     std::unordered_map<std::string, enigma2::data::RecordingEntry> m_recordingsIdMap;
     std::vector<std::string> m_locations;
 

--- a/src/enigma2/Recordings.h
+++ b/src/enigma2/Recordings.h
@@ -56,6 +56,8 @@ namespace enigma2
     PVR_ERROR DeleteRecording(const PVR_RECORDING &recinfo);
     PVR_ERROR UndeleteRecording(const PVR_RECORDING& recording);
     PVR_ERROR DeleteAllRecordingsFromTrash();
+    bool HasRecordingStreamProgramNumber(const PVR_RECORDING& recording);
+    int GetRecordingStreamProgramNumber(const PVR_RECORDING& recording);
 
     std::vector<std::string>& GetLocations();
     void ClearLocations();

--- a/src/enigma2/Settings.cpp
+++ b/src/enigma2/Settings.cpp
@@ -66,6 +66,9 @@ void Settings::ReadFromAddon()
     m_connectioncCheckIntervalSecs = DEFAULT_CONNECTION_CHECK_INTERVAL_SECS;
 
   //General
+  if (!XBMC->GetSetting("setprogramid", &m_setStreamProgramId))
+    m_setStreamProgramId = false;
+
   if (!XBMC->GetSetting("onlinepicons", &m_onlinePicons))
     m_onlinePicons = true;
 
@@ -94,11 +97,11 @@ void Settings::ReadFromAddon()
     m_channelAndGroupUpdateHour = DEFAULT_CHANNEL_AND_GROUP_UPDATE_HOUR;
 
   //Channels
-  if (!XBMC->GetSetting("usestandardserviceref", &m_useStandardServiceReference))
-    m_useStandardServiceReference = true;
-
   if (!XBMC->GetSetting("zap", &m_zap))
     m_zap = false;
+
+  if (!XBMC->GetSetting("usestandardserviceref", &m_useStandardServiceReference))
+    m_useStandardServiceReference = true;
 
   if (!XBMC->GetSetting("tvgroupmode", &m_tvChannelGroupMode))
     m_tvChannelGroupMode = ChannelGroupMode::ALL_GROUPS;
@@ -386,6 +389,8 @@ ADDON_STATUS Settings::SetValue(const std::string &settingName, const void *sett
   else if (settingName == "connectioncheckinterval")
     return SetSetting<int, ADDON_STATUS>(settingName, settingValue, m_connectioncCheckIntervalSecs, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   //General
+  else if (settingName == "setprogramid")
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_setStreamProgramId, ADDON_STATUS_OK, ADDON_STATUS_OK);
   else if (settingName == "onlinepicons")
     return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_onlinePicons, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "usepiconseuformat")
@@ -403,10 +408,10 @@ ADDON_STATUS Settings::SetValue(const std::string &settingName, const void *sett
   else if (settingName == "channelandgroupupdatehour")
     return SetSetting<unsigned int, ADDON_STATUS>(settingName, settingValue, m_channelAndGroupUpdateHour, ADDON_STATUS_OK, ADDON_STATUS_OK);
   //Channels
-  else if (settingName == "usestandardserviceref")
-    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_useStandardServiceReference, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "zap")
     return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_zap, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  else if (settingName == "usestandardserviceref")
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_useStandardServiceReference, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "tvgroupmode")
     return SetSetting<ChannelGroupMode, ADDON_STATUS>(settingName, settingValue, m_tvChannelGroupMode, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "numtvgroups")

--- a/src/enigma2/Settings.cpp
+++ b/src/enigma2/Settings.cpp
@@ -339,8 +339,11 @@ void Settings::ReadFromAddon()
   if (!XBMC->GetSetting("streamreadchunksize", &m_streamReadChunkSize))
     m_streamReadChunkSize = 0;
 
+  if (!XBMC->GetSetting("nodebug", &m_noDebug))
+    m_noDebug = false;
+
   if (!XBMC->GetSetting("debugnormal", &m_debugNormal))
-    m_traceDebug = false;
+    m_debugNormal = false;
 
   if (!XBMC->GetSetting("tracedebug", &m_traceDebug))
     m_traceDebug = false;
@@ -507,6 +510,8 @@ ADDON_STATUS Settings::SetValue(const std::string &settingName, const void *sett
     return SetSetting<int, ADDON_STATUS>(settingName, settingValue, m_readTimeout, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "streamreadchunksize")
     return SetSetting<int, ADDON_STATUS>(settingName, settingValue, m_streamReadChunkSize, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  else if (settingName == "nodebug")
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_noDebug, ADDON_STATUS_OK, ADDON_STATUS_OK);
   else if (settingName == "debugnormal")
     return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_debugNormal, ADDON_STATUS_OK, ADDON_STATUS_OK);
   else if (settingName == "tracedebug")

--- a/src/enigma2/Settings.h
+++ b/src/enigma2/Settings.h
@@ -128,6 +128,7 @@ namespace enigma2
     int GetConnectioncCheckIntervalSecs() const { return m_connectioncCheckIntervalSecs; }
 
     //General
+    bool SetStreamProgramID() const { return m_setStreamProgramId; }
     bool UseOnlinePicons() const { return m_onlinePicons; }
     bool UsePiconsEuFormat() const { return m_usePiconsEuFormat; }
     bool UseOpenWebIfPiconPath() const { return m_useOpenWebIfPiconPath; }
@@ -138,8 +139,8 @@ namespace enigma2
     ChannelAndGroupUpdateMode GetChannelAndGroupUpdateMode() const { return m_channelAndGroupUpdateMode; }
 
     //Channel
-    bool UseStandardServiceReference() const { return m_useStandardServiceReference; }
     bool GetZapBeforeChannelSwitch() const { return m_zap; }
+    bool UseStandardServiceReference() const { return m_useStandardServiceReference; }
     const ChannelGroupMode& GetTVChannelGroupMode() const { return m_tvChannelGroupMode; }
     const std::string& GetCustomTVGroupsFile() const { return m_customTVGroupsFile; }
     const FavouritesGroupMode& GetTVFavouritesMode() const { return m_tvFavouritesMode; }
@@ -285,6 +286,7 @@ namespace enigma2
     int m_connectioncCheckIntervalSecs = DEFAULT_CONNECTION_CHECK_INTERVAL_SECS;
 
     //General
+    bool m_setStreamProgramId = false;
     bool m_onlinePicons = true;
     bool m_usePiconsEuFormat = false;
     bool m_useOpenWebIfPiconPath = false;
@@ -295,8 +297,8 @@ namespace enigma2
     unsigned int m_channelAndGroupUpdateHour = DEFAULT_CHANNEL_AND_GROUP_UPDATE_HOUR;
 
     //Channel
-    bool m_useStandardServiceReference = true;
     bool m_zap = false;
+    bool m_useStandardServiceReference = true;
     ChannelGroupMode m_tvChannelGroupMode = ChannelGroupMode::ALL_GROUPS;
     unsigned int m_numTVGroups = DEFAULT_NUM_GROUPS;
     std::string m_oneTVGroup = "";

--- a/src/enigma2/Settings.h
+++ b/src/enigma2/Settings.h
@@ -188,6 +188,7 @@ namespace enigma2
     PowerstateMode GetPowerstateModeOnAddonExit() const { return m_powerstateMode; }
     int GetReadTimeoutSecs() const { return m_readTimeout; }
     int GetStreamReadChunkSizeKb() const { return m_streamReadChunkSize; }
+    bool GetNoDebug() const { return m_noDebug; };
     bool GetDebugNormal() const { return m_debugNormal; };
     bool GetTraceDebug() const { return m_traceDebug; };
 
@@ -354,6 +355,7 @@ namespace enigma2
     PowerstateMode m_powerstateMode = PowerstateMode::DISABLED;
     int m_readTimeout = 0;
     int m_streamReadChunkSize = 0;
+    bool m_noDebug = false;
     bool m_debugNormal = false;
     bool m_traceDebug = false;
 

--- a/src/enigma2/Settings.h
+++ b/src/enigma2/Settings.h
@@ -226,6 +226,7 @@ namespace enigma2
     bool SupportsAutoTimers() const { return CheckOpenWebIfVersion(1, 3, 0); }
     bool SupportsTunerDetails() const { return CheckOpenWebIfVersion(1, 3, 5); }
     bool SupportsProviderNumberAndPiconForChannels() const { return CheckOpenWebIfVersion(1, 3, 5); }
+    bool SupportsChannelNumberGroupStartPos() const { return CheckOpenWebIfVersion(1, 3, 7); }
 
     bool UsesLastScannedChannelGroup() const { return m_usesLastScannedChannelGroup; }
     void SetUsesLastScannedChannelGroup(bool value) { m_usesLastScannedChannelGroup = value; }

--- a/src/enigma2/data/ChannelGroup.cpp
+++ b/src/enigma2/data/ChannelGroup.cpp
@@ -39,7 +39,7 @@ bool ChannelGroup::operator!=(const ChannelGroup &right) const
   return !(*this == right);
 }
 
-bool ChannelGroup::UpdateFrom(TiXmlElement* groupNode, bool radio, std::vector<std::shared_ptr<ChannelGroup>> &extraDataChannelGroups)
+bool ChannelGroup::UpdateFrom(TiXmlElement* groupNode, bool radio)
 {
   std::string serviceReference;
   std::string groupName;
@@ -61,9 +61,6 @@ bool ChannelGroup::UpdateFrom(TiXmlElement* groupNode, bool radio, std::vector<s
   m_serviceReference = serviceReference;
   m_groupName = groupName;
   m_radio = radio;
-
-  // we keep this group even if it get's discarded so we can calculate backend channel numbers later on
-  extraDataChannelGroups.emplace_back(new ChannelGroup(*this));
 
   if (!radio && (Settings::GetInstance().GetTVChannelGroupMode() == ChannelGroupMode::SOME_GROUPS ||
                  Settings::GetInstance().GetTVChannelGroupMode() == ChannelGroupMode::CUSTOM_GROUPS))

--- a/src/enigma2/data/ChannelGroup.h
+++ b/src/enigma2/data/ChannelGroup.h
@@ -40,7 +40,8 @@ namespace enigma2
     public:
       ChannelGroup() = default;
       ChannelGroup(ChannelGroup &c) : m_radio(c.IsRadio()), m_uniqueId(c.GetUniqueId()),
-        m_groupName(c.GetGroupName()), m_serviceReference(c.GetServiceReference()), m_lastScannedGroup(c.IsLastScannedGroup()), m_emptyGroup(c.IsEmptyGroup()) {};
+        m_groupName(c.GetGroupName()), m_serviceReference(c.GetServiceReference()), m_lastScannedGroup(c.IsLastScannedGroup()),
+        m_startChannelNumber(c.GetStartChannelNumber()), m_emptyGroup(c.IsEmptyGroup()) {};
       ~ChannelGroup() = default;
 
       bool IsRadio() const { return m_radio; }
@@ -61,9 +62,14 @@ namespace enigma2
       bool IsEmptyGroup() const { return m_emptyGroup; }
       void SetEmptyGroup(bool value) { m_emptyGroup = value; }
 
+      int GetStartChannelNumber() const { return m_startChannelNumber; }
+      void SetStartChannelNumber(int value) { m_startChannelNumber = value; }
+
+      bool HasStartChannelNumber() const { return m_startChannelNumber >= 0; }
+
       void AddChannel(std::shared_ptr<enigma2::data::Channel> channel);
 
-      bool UpdateFrom(TiXmlElement* groupNode, bool radio, std::vector<std::shared_ptr<ChannelGroup>> &extraDataChannelGroups);
+      bool UpdateFrom(TiXmlElement* groupNode, bool radio);
       void UpdateTo(PVR_CHANNEL_GROUP &left) const;
 
       std::vector<std::shared_ptr<enigma2::data::Channel>> GetChannelList() { return m_channelList; };
@@ -79,6 +85,7 @@ namespace enigma2
       std::string m_groupName;
       bool m_lastScannedGroup;
       bool m_emptyGroup;
+      int m_startChannelNumber = -1;
 
       std::vector<std::shared_ptr<enigma2::data::Channel>> m_channelList;
     };

--- a/src/enigma2/data/RecordingEntry.cpp
+++ b/src/enigma2/data/RecordingEntry.cpp
@@ -10,12 +10,13 @@ using namespace enigma2;
 using namespace enigma2::data;
 using namespace enigma2::utilities;
 
-bool RecordingEntry::UpdateFrom(TiXmlElement* recordingNode, const std::string &directory, Channels &channels)
+bool RecordingEntry::UpdateFrom(TiXmlElement* recordingNode, const std::string &directory, bool deleted, Channels &channels)
 {
   std::string strTmp;
   int iTmp;
 
   m_directory = directory;
+  m_deleted = deleted;
 
   if (XMLUtils::GetString(recordingNode, "e2servicereference", strTmp))
     m_recordingId = strTmp;
@@ -155,8 +156,9 @@ void RecordingEntry::UpdateTo(PVR_RECORDING &left, Channels &channels, bool isIn
   }
 
   strncpy(left.strDirectory, m_directory.c_str(), sizeof(left.strDirectory));
-  left.recordingTime     = m_startTime;
-  left.iDuration         = m_duration;
+  left.bIsDeleted = m_deleted;
+  left.recordingTime = m_startTime;
+  left.iDuration = m_duration;
 
   left.iChannelUid = m_channelUniqueId;
   left.channelType = PVR_RECORDING_CHANNEL_TYPE_UNKNOWN;

--- a/src/enigma2/data/RecordingEntry.cpp
+++ b/src/enigma2/data/RecordingEntry.cpp
@@ -192,7 +192,6 @@ std::shared_ptr<Channel> RecordingEntry::FindChannel(Channels &channels) const
   {
     m_radio = ReadTagValue(TAG_FOR_CHANNEL_TYPE) == VALUE_FOR_CHANNEL_TYPE_RADIO;
     m_haveChannelType = true;
-
   }
 
   m_anyChannelTimerSource = ContainsTag(TAG_FOR_ANY_CHANNEL);
@@ -200,9 +199,23 @@ std::shared_ptr<Channel> RecordingEntry::FindChannel(Channels &channels) const
   channel = GetChannelFromChannelNameSearch(channels);
 
   if (channel)
+  {
+    if (!m_hasStreamProgramNumber)
+    {
+      m_streamProgramNumber = channel->GetStreamProgramNumber();
+      m_hasStreamProgramNumber = true;
+    }
+
     return channel;
+  }
 
   channel = GetChannelFromChannelNameFuzzySearch(channels);
+
+  if (channel && !m_hasStreamProgramNumber)
+  {
+    m_streamProgramNumber = channel->GetStreamProgramNumber();
+    m_hasStreamProgramNumber = true;
+  }
 
   return channel;
 }
@@ -214,6 +227,9 @@ std::shared_ptr<Channel> RecordingEntry::GetChannelFromChannelReferenceTag(Chann
   if (ContainsTag(TAG_FOR_CHANNEL_REFERENCE))
   {
     channelServiceReference = Channel::NormaliseServiceReference(ReadTagValue(TAG_FOR_CHANNEL_REFERENCE, true));
+
+    std::sscanf(channelServiceReference.c_str(), "%*X:%*X:%*X:%X:%*s", &m_streamProgramNumber);
+    m_hasStreamProgramNumber = true;
   }
 
   return channels.GetChannel(channelServiceReference);

--- a/src/enigma2/data/RecordingEntry.h
+++ b/src/enigma2/data/RecordingEntry.h
@@ -80,7 +80,10 @@ namespace enigma2
       bool IsRadio() const { return m_radio; }
       void SetRadio(bool value) { m_radio = value; }
 
-      bool UpdateFrom(TiXmlElement* recordingNode, const std::string &directory, enigma2::Channels &channels);
+      bool IsDeleted() const { return m_deleted; }
+      void SetDeleted(bool value) { m_deleted = value; }
+
+      bool UpdateFrom(TiXmlElement* recordingNode, const std::string &directory, bool deleted, enigma2::Channels &channels);
       void UpdateTo(PVR_RECORDING &left, Channels &channels, bool isInRecordingFolder);
 
     private:
@@ -106,6 +109,7 @@ namespace enigma2
       mutable bool m_radio = false;
       mutable bool m_haveChannelType = false;
       mutable bool m_anyChannelTimerSource = false;
+      bool m_deleted = false;
     };
   } //namespace data
 } //namespace enigma2

--- a/src/enigma2/data/RecordingEntry.h
+++ b/src/enigma2/data/RecordingEntry.h
@@ -77,6 +77,11 @@ namespace enigma2
       const std::string& GetIconPath() const { return m_iconPath; }
       void SetIconPath(const std::string& value ) { m_iconPath = value; }
 
+      int GetStreamProgramNumber() const { return m_streamProgramNumber; }
+      void SetStreamProgramNumber(int value) { m_streamProgramNumber = value; }
+
+      bool HasStreamProgramNumber() const { return m_hasStreamProgramNumber; }
+
       bool IsRadio() const { return m_radio; }
       void SetRadio(bool value) { m_radio = value; }
 
@@ -110,6 +115,8 @@ namespace enigma2
       mutable bool m_haveChannelType = false;
       mutable bool m_anyChannelTimerSource = false;
       bool m_deleted = false;
+      mutable int m_streamProgramNumber;
+      mutable bool m_hasStreamProgramNumber = false;
     };
   } //namespace data
 } //namespace enigma2


### PR DESCRIPTION
v4.4.0
- Added: Set program id option for streams with superfluous program data
- Added: Undelete and trashcan (when configured on backend) for recordings
- Added: Use new API for backend channel numbers - openwebif 1.3.7
- Fixed: Radio groups parsed from wrong api
- Added: Support disabling addon debug logging in debug mode