### PR TITLE
Epg repeating timer matrix

### DIFF
--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="4.4.0"
+  version="4.5.0"
   name="Enigma2 Client"
   provider-name="Joerg Dembski and Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>
@@ -175,6 +175,9 @@
     <disclaimer lang="zh_TW">這是測試版軟體！其原創作者並無法對於以下情況負責，包含：錄影失敗，不正確的定時設定，多餘時數，或任何產生的其它不良影響...</disclaimer>
     <platform>@PLATFORM@</platform>
     <news>
+v4.5.0
+- Added: Allow creation of epg based repeating timer rules if autotimers are not available
+
 v4.4.0
 - Added: Set program id option for streams with superfluous program data
 - Added: Undelete and trashcan (when configured on backend) for recordings

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,3 +1,6 @@
+v4.5.0
+- Added: Allow creation of epg-based repeating timer rules if autotimers are not available
+
 v4.4.0
 - Added: Set program id option for streams with superfluous program data
 - Added: Undelete and trashcan (when configured on backend) for recordings

--- a/src/enigma2/Timers.cpp
+++ b/src/enigma2/Timers.cpp
@@ -336,23 +336,41 @@ void Timers::GetTimerTypes(std::vector<PVR_TIMER_TYPE> &types) const
   types.emplace_back(*t);
   delete t;
 
-  // This type can only be created on the Enigma2 device.
-  /* Repeating epg based */
-  t = new TimerType(
-    Timer::Type::EPG_REPEATING,
-    PVR_TIMER_TYPE_IS_REPEATING              |
-    PVR_TIMER_TYPE_FORBIDS_NEW_INSTANCES     |
-    PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE   |
-    PVR_TIMER_TYPE_SUPPORTS_CHANNELS         |
-    PVR_TIMER_TYPE_SUPPORTS_START_TIME       |
-    PVR_TIMER_TYPE_SUPPORTS_END_TIME         |
-    PVR_TIMER_TYPE_SUPPORTS_WEEKDAYS,
-    LocalizedString(30425)); // Repeating guide-based
-  types.emplace_back(*t);
-  delete t;
-
-  if (Settings::GetInstance().SupportsAutoTimers() && m_settings.GetAutoTimersEnabled())
+  if (!Settings::GetInstance().SupportsAutoTimers() || !m_settings.GetAutoTimersEnabled())
   {
+    // Allow this type of timer to be created from kodi if autotimers are not available
+    // as otherwise there is no way to create a repeating EPG timer rule
+    /* Repeating epg based */
+    t = new TimerType(
+      Timer::Type::EPG_REPEATING,
+      PVR_TIMER_TYPE_IS_REPEATING              |
+      PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE   |
+      PVR_TIMER_TYPE_SUPPORTS_CHANNELS         |
+      PVR_TIMER_TYPE_SUPPORTS_START_TIME       |
+      PVR_TIMER_TYPE_SUPPORTS_END_TIME         |
+      PVR_TIMER_TYPE_SUPPORTS_WEEKDAYS,
+      LocalizedString(30425)); // Repeating guide-based
+    types.emplace_back(*t);
+    delete t;
+  }
+  else
+  {
+    // This type can only be created on the Enigma2 device (i.e. not via kodi PVR) if autotimers are used.
+    // In this case this type is superflous and just clutters the UI on creation.
+    /* Repeating epg based */
+    t = new TimerType(
+      Timer::Type::EPG_REPEATING,
+      PVR_TIMER_TYPE_IS_REPEATING              |
+      PVR_TIMER_TYPE_FORBIDS_NEW_INSTANCES     |
+      PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE   |
+      PVR_TIMER_TYPE_SUPPORTS_CHANNELS         |
+      PVR_TIMER_TYPE_SUPPORTS_START_TIME       |
+      PVR_TIMER_TYPE_SUPPORTS_END_TIME         |
+      PVR_TIMER_TYPE_SUPPORTS_WEEKDAYS,
+      LocalizedString(30425)); // Repeating guide-based
+    types.emplace_back(*t);
+    delete t;
+
     /* PVR_Timer.iPreventDuplicateEpisodes values and presentation.*/
     static std::vector<std::pair<int, std::string>> deDupValues =
     {


### PR DESCRIPTION
v4.5.0
- Added: Allow creation of epg based repeating timer rules if autotimers are not available