### PR TITLE
Iptv matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build Status](https://travis-ci.org/kodi-pvr/pvr.vuplus.svg?branch=master)](https://travis-ci.org/kodi-pvr/pvr.vuplus)
-[![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-pvr/pvr.vuplus?svg=true)](https://ci.appveyor.com/project/xbmc/pvr-vuplus)
+[![Build Status](https://travis-ci.org/kodi-pvr/pvr.vuplus.svg?branch=Matrix)](https://travis-ci.org/kodi-pvr/pvr.vuplus/branches)
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-pvr/pvr.vuplus?branch=Matrix&svg=true)](https://ci.appveyor.com/project/kodi-pvr/pvr-vuplus?branch=Matrix)
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/5120/badge.svg)](https://scan.coverity.com/projects/5120)
 
 # Enigma2 PVR

--- a/README.md
+++ b/README.md
@@ -2,9 +2,15 @@
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-pvr/pvr.vuplus?svg=true)](https://ci.appveyor.com/project/xbmc/pvr-vuplus)
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/5120/badge.svg)](https://scan.coverity.com/projects/5120)
 
+# Enigma2 PVR
+Enigma2 PVR client addon for [Kodi](https://kodi.tv)
+
+## Overview
 Enigma2 is a open source TV-receiver/DVR platform which Linux-based firmware (OS images) can be loaded onto many Linux-based set-top boxes (satellite, terrestrial, cable or a combination of these) from different manufacturers.
 
 This addon leverages the OpenWebIf project to interact with the Enigma2 device via Restful APIs: (https://github.com/E2OpenPlugins/e2openplugin-OpenWebif)
+
+### Compatibility
 
 **Note:** Some images do not use OpenWebIf as the default web interface. In these images some standard functionality may still work but is not guaranteed. Some features that may not function include:
 * Autotimers
@@ -28,8 +34,11 @@ Some features are only available with at least certain OpenWebIf versions:
 * 1.3.7
   * Backend Channel Numbers
 
-# Enigma2 PVR
-Enigma2 PVR client addon for [Kodi](https://kodi.tv)
+### IPTV Streams
+
+The majority of Enigma2 devices support viewing and recording IPTV streams. They do not however support streaming IPTV from the device. The addon supports IPTV by simply passing the URL used on the device to Kodi PVR. This means that timeshifting cannot be used (and will not be supported in the future). Note that if your IPTV provider restricts the number of active streams each kodi instance viewing it will count as an active stream.
+
+The option `Enable automatic configuration for live streams` is ignored for channels that are IPTV Streams.
 
 ## Build instructions
 
@@ -98,7 +107,7 @@ Within this tab the connection options need to be configured before it can be su
 * **Use secure HTTP (https)**: Use https to connect to the web interface.
 * **Username**: If the webinterface of the set-top box is protected with a username/password combination this needs to be set in this option.
 * **Password**: If the webinterface of the set-top box is protected with a username/password combination this needs to be set in this option.
-* **Enable automatic configuration for live streams**: When enabled the stream URL will be read from an M3U file. When disabled it is constructed based on the filename.
+* **Enable automatic configuration for live streams**: When enabled the stream URL will be read from an M3U8 file. When disabled it is constructed based on the service reference of the channel. This option is rarely required and should not be enbaled unless you have a special use case. If viewing an IPTV Stream this option has no effect on those channels.
 * **Streaming port**: This option defines the streaming port the set-top box uses to stream live tv. The default is 8001 which should be fine if the user did not define a custom port within the webinterface.
 * **Use secure HTTP (https) for streams**: Use https to connect to streams.
 * **Use login for streams**: Use the login username and password for streams.

--- a/build-install-mac.sh
+++ b/build-install-mac.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if [ "$#" -ne 1 ] || ! [ -d "$1" ]; then
   echo "Usage: $0 <XBMC-SRC-DIR>" >&2
   exit 1
@@ -8,6 +10,16 @@ fi
 if [[ "$OSTYPE" != "darwin"* ]]; then
   echo "Error: Script only for use on MacOSX" >&2
   exit 1
+fi
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+if [[ "$1" = /* ]]
+then
+  #absolute path
+  SCRIPT_DIR=""  
+else
+  #relative
+  SCRIPT_DIR="$SCRIPT_DIR/"
 fi
 
 BINARY_ADDONS_TARGET_DIR="$1/tools/depends/target/binary-addons"
@@ -20,16 +32,15 @@ if [ ! -d "$BINARY_ADDONS_TARGET_DIR" ]; then
   exit 1
 fi
 
-XBMC_BUILD_ADDON_INSTALL_DIR=$(cd $1/addons/$ADDON_NAME 2> /dev/null && pwd -P)
-
 for DIR in "$BINARY_ADDONS_TARGET_DIR/"macosx*; do
     if [ -d "${DIR}" ]; then
-	MACOSX_BINARY_ADDONS_TARGET_DIR="${DIR}"
+	    MACOSX_BINARY_ADDONS_TARGET_DIR="${DIR}"
+      break
     fi
 done
 
 if [ -z "$MACOSX_BINARY_ADDONS_TARGET_DIR" ]; then
-  echo "Error: Could not find binary addons build directory at: $BINARY_ADDONS_DIR/macosx*" >&2
+  echo "Error: Could not find binary addons build directory at: $BINARY_ADDONS_TARGET_DIR/macosx*" >&2
   exit 1
 fi
 
@@ -40,5 +51,9 @@ fi
 
 cd "$MACOSX_BINARY_ADDONS_TARGET_DIR"
 make
+
+XBMC_BUILD_ADDON_INSTALL_DIR=$(cd "$SCRIPT_DIR$1/addons/$ADDON_NAME" 2> /dev/null && pwd -P)
 rm -rf "$KODI_ADDONS_DIR/$ADDON_NAME"
+echo "Removed previous addon build from: $KODI_ADDONS_DIR"
 cp -rf "$XBMC_BUILD_ADDON_INSTALL_DIR" "$KODI_ADDONS_DIR"
+echo "Copied new addon build to: $KODI_ADDONS_DIR"

--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="4.6.0"
+  version="4.7.0"
   name="Enigma2 Client"
   provider-name="Joerg Dembski and Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>
@@ -175,6 +175,21 @@
     <disclaimer lang="zh_TW">這是測試版軟體！其原創作者並無法對於以下情況負責，包含：錄影失敗，不正確的定時設定，多餘時數，或任何產生的其它不良影響...</disclaimer>
     <platform>@PLATFORM@</platform>
     <news>
+v4.7.0
+- Added: Support for IPTV Streams configured on E2 device (no timeshifting)
+- Added: Reload instead of reconnecting when channel/group changes are detected
+- Added: Use truly unique IDs for channels so EPG changes are correctly reflected
+- Fixed: Only get drive space for devices that have an HDD
+- Fixed: use correct function to lookup group when adding
+- Added: update README.md to show appveyor/travis badges per branch
+- Added: Update OSX build script
+- Added: update badge status for travis/appveyor
+- Added: add copyright notices to files
+- Fixed: Fix default path for genre text mapping file
+
+v4.6.0
+- Update: Recompile for 6.1.0 PVR Addon API compatibility
+
 v4.5.1
 - Update: Kodi VFS API 1.0.3
 - Update: Build sytem version

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,3 +1,15 @@
+v4.7.0
+- Added: Support for IPTV Streams configured on E2 device (no timeshifting)
+- Added: Reload instead of reconnecting when channel/group changes are detected
+- Added: Use truly unique IDs for channels so EPG changes are correctly reflected
+- Fixed: Only get drive space for devices that have an HDD
+- Fixed: use correct function to lookup group when adding
+- Added: update README.md to show appveyor/travis badges per branch
+- Added: Update OSX build script
+- Added: update badge status for travis/appveyor
+- Added: add copyright notices to files
+- Fixed: Fix default path for genre text mapping file
+
 v4.6.0
 - Update: Recompile for 6.1.0 PVR Addon API compatibility
 

--- a/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
@@ -889,7 +889,7 @@ msgstr ""
 
 #help: Connection - autoconfig
 msgctxt "#30606"
-msgid "When enabled the stream URL will be read from an M3U file. When disabled it is constructed based on the filename."
+msgid "When enabled the stream URL will be read from an M3U8 file. When disabled it is constructed based on the service reference of the channel. This option is rarely required and should not be enbaled unless you have a special use case. If viewing an IPTV Stream this option has no effect on those channels."
 msgstr ""
 
 #help: Connection - streamport

--- a/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
@@ -849,7 +849,17 @@ msgctxt "#30520"
 msgid "Invalid Channel"
 msgstr ""
 
-#empty strings from id 30521 to 30599
+#notification: Enigma2
+msgctxt "#30521"
+msgid "Enigma2: Channel group changes detected, reloading..."
+msgstr ""
+
+#notification: Enigma2
+msgctxt "#30522"
+msgid "Enigma2: Channel changes detected, reloading..."
+msgstr ""
+
+#empty strings from id 30523 to 30599
 
 #############
 # help info #

--- a/src/Enigma2.cpp
+++ b/src/Enigma2.cpp
@@ -22,20 +22,20 @@
 
 #include "Enigma2.h"
 
-#include <algorithm>
-#include <iostream>
-#include <fstream>
-#include <string>
-#include <regex>
-#include <stdlib.h>
-
 #include "client.h"
 #include "enigma2/utilities/CurlFile.h"
 #include "enigma2/utilities/LocalizedString.h"
 #include "enigma2/utilities/Logger.h"
 #include "enigma2/utilities/WebUtils.h"
-
 #include "util/XMLUtils.h"
+
+#include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <regex>
+#include <stdlib.h>
+#include <string>
+
 #include <p8-platform/util/StringUtils.h>
 
 using namespace ADDON;
@@ -45,7 +45,7 @@ using namespace enigma2::data;
 using namespace enigma2::extract;
 using namespace enigma2::utilities;
 
-Enigma2::Enigma2(PVR_PROPERTIES *pvrProps) : m_epgMaxDays(pvrProps->iEpgMaxDays)
+Enigma2::Enigma2(PVR_PROPERTIES* pvrProps) : m_epgMaxDays(pvrProps->iEpgMaxDays)
 {
   m_timers.AddTimerChangeWatcher(&m_dueRecordingUpdate);
 
@@ -188,7 +188,7 @@ bool Enigma2::Start()
   return true;
 }
 
-void *Enigma2::Process()
+void* Enigma2::Process()
 {
   Logger::Log(LEVEL_DEBUG, "%s - starting", __FUNCTION__);
 
@@ -212,7 +212,7 @@ void *Enigma2::Process()
   time_t lastUpdateTimeSeconds = time(nullptr);
   int lastUpdateHour = m_settings.GetChannelAndGroupUpdateHour(); //ignore if we start during same hour
 
-  while(!IsStopped() && m_isConnected)
+  while (!IsStopped() && m_isConnected)
   {
     Sleep(PROCESS_LOOP_WAIT_SECS * 1000);
 
@@ -362,7 +362,7 @@ PVR_ERROR Enigma2::GetChannelGroups(ADDON_HANDLE handle, bool radio)
   return PVR_ERROR_NO_ERROR;
 }
 
-PVR_ERROR Enigma2::GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &group)
+PVR_ERROR Enigma2::GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP& group)
 {
   std::vector<PVR_CHANNEL_GROUP_MEMBER> channelGroupMembers;
   {
@@ -397,7 +397,7 @@ PVR_ERROR Enigma2::GetChannels(ADDON_HANDLE handle, bool bRadio)
 
   Logger::Log(LEVEL_DEBUG, "%s - channels available '%d', radio = %d", __FUNCTION__, channels.size(), bRadio);
 
-  for (auto &channel : channels)
+  for (auto& channel : channels)
     PVR->TransferChannelEntry(handle, &channel);
 
   return PVR_ERROR_NO_ERROR;
@@ -439,7 +439,7 @@ PVR_ERROR Enigma2::GetEPGForChannel(ADDON_HANDLE handle, int iChannelUid, time_t
 /***************************************************************************
  * Livestream
  **************************************************************************/
-bool Enigma2::OpenLiveStream(const PVR_CHANNEL &channelinfo)
+bool Enigma2::OpenLiveStream(const PVR_CHANNEL& channelinfo)
 {
   Logger::Log(LEVEL_DEBUG, "%s: channel=%u", __FUNCTION__, channelinfo.iUniqueId);
   CLockObject lock(m_mutex);
@@ -457,7 +457,7 @@ bool Enigma2::OpenLiveStream(const PVR_CHANNEL &channelinfo)
       const std::string strCmd = StringUtils::Format("web/zap?sRef=%s", WebUtils::URLEncodeInline(strServiceReference).c_str());
 
       std::string strResult;
-      if(!WebUtils::SendSimpleCommand(strCmd, strResult, true))
+      if (!WebUtils::SendSimpleCommand(strCmd, strResult, true))
         return false;
     }
   }
@@ -470,7 +470,7 @@ void Enigma2::CloseLiveStream(void)
   m_currentChannel = -1;
 }
 
-const std::string Enigma2::GetLiveStreamURL(const PVR_CHANNEL &channelinfo)
+const std::string Enigma2::GetLiveStreamURL(const PVR_CHANNEL& channelinfo)
 {
   if (m_settings.GetAutoConfigLiveStreamsEnabled())
   {
@@ -489,7 +489,7 @@ bool Enigma2::IsIptvStream(const PVR_CHANNEL& channelinfo) const
   return m_channels.GetChannel(channelinfo.iUniqueId)->IsIptvStream();
 }
 
-int Enigma2::GetChannelStreamProgramNumber(const PVR_CHANNEL &channelinfo)
+int Enigma2::GetChannelStreamProgramNumber(const PVR_CHANNEL& channelinfo)
 {
   return m_channels.GetChannel(channelinfo.iUniqueId)->GetStreamProgramNumber();
 }
@@ -541,7 +541,7 @@ PVR_ERROR Enigma2::GetRecordings(ADDON_HANDLE handle, bool deleted)
   return PVR_ERROR_NO_ERROR;
 }
 
-PVR_ERROR Enigma2::DeleteRecording(const PVR_RECORDING &recinfo)
+PVR_ERROR Enigma2::DeleteRecording(const PVR_RECORDING& recinfo)
 {
   return m_recordings.DeleteRecording(recinfo);
 }
@@ -556,7 +556,7 @@ PVR_ERROR Enigma2::DeleteAllRecordingsFromTrash()
   return m_recordings.DeleteAllRecordingsFromTrash();
 }
 
-PVR_ERROR Enigma2::GetRecordingEdl(const PVR_RECORDING &recinfo, PVR_EDL_ENTRY edl[], int *size)
+PVR_ERROR Enigma2::GetRecordingEdl(const PVR_RECORDING& recinfo, PVR_EDL_ENTRY edl[], int* size)
 {
   std::vector<PVR_EDL_ENTRY> edlEntries;
   {
@@ -568,7 +568,7 @@ PVR_ERROR Enigma2::GetRecordingEdl(const PVR_RECORDING &recinfo, PVR_EDL_ENTRY e
 
   int index = 0;
   int maxSize = *size;
-  for (auto &edlEntry : edlEntries)
+  for (auto& edlEntry : edlEntries)
   {
     if (index >= maxSize)
       break;
@@ -584,7 +584,7 @@ PVR_ERROR Enigma2::GetRecordingEdl(const PVR_RECORDING &recinfo, PVR_EDL_ENTRY e
   return PVR_ERROR_NO_ERROR;
 }
 
-RecordingReader *Enigma2::OpenRecordedStream(const PVR_RECORDING &recinfo)
+RecordingReader* Enigma2::OpenRecordedStream(const PVR_RECORDING& recinfo)
 {
   CLockObject lock(m_mutex);
   std::time_t now = std::time(nullptr), start = 0, end = 0;
@@ -612,25 +612,25 @@ int Enigma2::GetRecordingStreamProgramNumber(const PVR_RECORDING& recording)
   return m_recordings.GetRecordingStreamProgramNumber(recording);
 }
 
-PVR_ERROR Enigma2::RenameRecording(const PVR_RECORDING &recording)
+PVR_ERROR Enigma2::RenameRecording(const PVR_RECORDING& recording)
 {
   CLockObject lock(m_mutex);
   return m_recordings.RenameRecording(recording);
 }
 
-PVR_ERROR Enigma2::SetRecordingPlayCount(const PVR_RECORDING &recording, int count)
+PVR_ERROR Enigma2::SetRecordingPlayCount(const PVR_RECORDING& recording, int count)
 {
   CLockObject lock(m_mutex);
   return m_recordings.SetRecordingPlayCount(recording, count);
 }
 
-PVR_ERROR Enigma2::SetRecordingLastPlayedPosition(const PVR_RECORDING &recording, int lastPlayedPosition)
+PVR_ERROR Enigma2::SetRecordingLastPlayedPosition(const PVR_RECORDING& recording, int lastPlayedPosition)
 {
   CLockObject lock(m_mutex);
   return m_recordings.SetRecordingLastPlayedPosition(recording, lastPlayedPosition);
 }
 
-int Enigma2::GetRecordingLastPlayedPosition(const PVR_RECORDING &recording)
+int Enigma2::GetRecordingLastPlayedPosition(const PVR_RECORDING& recording)
 {
   CLockObject lock(m_mutex);
   return m_recordings.GetRecordingLastPlayedPosition(recording);
@@ -640,7 +640,7 @@ int Enigma2::GetRecordingLastPlayedPosition(const PVR_RECORDING &recording)
  * Timers
  **************************************************************************/
 
-void Enigma2::GetTimerTypes(PVR_TIMER_TYPE types[], int *size)
+void Enigma2::GetTimerTypes(PVR_TIMER_TYPE types[], int* size)
 {
   std::vector<PVR_TIMER_TYPE> timerTypes;
   {
@@ -649,7 +649,7 @@ void Enigma2::GetTimerTypes(PVR_TIMER_TYPE types[], int *size)
   }
 
   int i = 0;
-  for (auto &timerType : timerTypes)
+  for (auto& timerType : timerTypes)
     types[i++] = timerType;
   *size = timerTypes.size();
   Logger::Log(LEVEL_NOTICE, "%s Transfered %u timer types", __FUNCTION__, *size);
@@ -672,23 +672,23 @@ PVR_ERROR Enigma2::GetTimers(ADDON_HANDLE handle)
 
   Logger::Log(LEVEL_DEBUG, "%s - timers available '%d'", __FUNCTION__, timers.size());
 
-  for (auto &timer : timers)
+  for (auto& timer : timers)
     PVR->TransferTimerEntry(handle, &timer);
 
   return PVR_ERROR_NO_ERROR;
 }
 
-PVR_ERROR Enigma2::AddTimer(const PVR_TIMER &timer)
+PVR_ERROR Enigma2::AddTimer(const PVR_TIMER& timer)
 {
   return m_timers.AddTimer(timer);
 }
 
-PVR_ERROR Enigma2::UpdateTimer(const PVR_TIMER &timer)
+PVR_ERROR Enigma2::UpdateTimer(const PVR_TIMER& timer)
 {
   return m_timers.UpdateTimer(timer);
 }
 
-PVR_ERROR Enigma2::DeleteTimer(const PVR_TIMER &timer)
+PVR_ERROR Enigma2::DeleteTimer(const PVR_TIMER& timer)
 {
   return m_timers.DeleteTimer(timer);
 }
@@ -697,12 +697,12 @@ PVR_ERROR Enigma2::DeleteTimer(const PVR_TIMER &timer)
  * Misc
  **************************************************************************/
 
-PVR_ERROR Enigma2::GetDriveSpace(long long *iTotal, long long *iUsed)
+PVR_ERROR Enigma2::GetDriveSpace(long long* iTotal, long long* iUsed)
 {
   return m_admin.GetDriveSpace(iTotal, iUsed, m_locations);
 }
 
-PVR_ERROR Enigma2::GetTunerSignal(PVR_SIGNAL_STATUS &signalStatus)
+PVR_ERROR Enigma2::GetTunerSignal(PVR_SIGNAL_STATUS& signalStatus)
 {
   if (m_currentChannel >= 0)
   {

--- a/src/Enigma2.cpp
+++ b/src/Enigma2.cpp
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2005-2015 Team XBMC
+ *      Copyright (C) 2005-2019 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify

--- a/src/Enigma2.cpp
+++ b/src/Enigma2.cpp
@@ -699,7 +699,10 @@ PVR_ERROR Enigma2::DeleteTimer(const PVR_TIMER& timer)
 
 PVR_ERROR Enigma2::GetDriveSpace(long long* iTotal, long long* iUsed)
 {
-  return m_admin.GetDriveSpace(iTotal, iUsed, m_locations);
+  if (m_admin.GetDeviceHasHDD())
+    return m_admin.GetDriveSpace(iTotal, iUsed, m_locations);
+
+  return PVR_ERROR_NOT_IMPLEMENTED;
 }
 
 PVR_ERROR Enigma2::GetTunerSignal(PVR_SIGNAL_STATUS& signalStatus)

--- a/src/Enigma2.cpp
+++ b/src/Enigma2.cpp
@@ -484,6 +484,11 @@ const std::string Enigma2::GetLiveStreamURL(const PVR_CHANNEL &channelinfo)
   return m_channels.GetChannel(channelinfo.iUniqueId)->GetStreamURL();
 }
 
+bool Enigma2::IsIptvStream(const PVR_CHANNEL& channelinfo) const
+{
+  return m_channels.GetChannel(channelinfo.iUniqueId)->IsIptvStream();
+}
+
 int Enigma2::GetChannelStreamProgramNumber(const PVR_CHANNEL &channelinfo)
 {
   return m_channels.GetChannel(channelinfo.iUniqueId)->GetStreamProgramNumber();

--- a/src/Enigma2.h
+++ b/src/Enigma2.h
@@ -1,6 +1,6 @@
 #pragma once
 /*
- *      Copyright (C) 2005-2015 Team XBMC
+ *      Copyright (C) 2005-2019 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -130,10 +130,10 @@ private:
 
   mutable enigma2::Channels m_channels;
   enigma2::ChannelGroups m_channelGroups;
-  enigma2::Recordings m_recordings = enigma2::Recordings(m_channels, m_entryExtractor);
+  enigma2::Recordings m_recordings{m_channels, m_entryExtractor};
   std::vector<std::string>& m_locations = m_recordings.GetLocations();
-  enigma2::Epg m_epg = enigma2::Epg(m_entryExtractor, m_epgMaxDays);
-  enigma2::Timers m_timers = enigma2::Timers(m_channels, m_channelGroups, m_locations, m_epg, m_entryExtractor);
+  enigma2::Epg m_epg{m_entryExtractor, m_epgMaxDays};
+  enigma2::Timers m_timers{m_channels, m_channelGroups, m_locations, m_epg, m_entryExtractor};
   enigma2::Settings& m_settings = enigma2::Settings::GetInstance();
   enigma2::Admin m_admin;
   enigma2::extract::EpgEntryExtractor m_entryExtractor;

--- a/src/Enigma2.h
+++ b/src/Enigma2.h
@@ -116,9 +116,9 @@ private:
   static const int PROCESS_LOOP_WAIT_SECS = 5;
 
   // helper functions
-  void Reset();
   std::string GetStreamURL(const std::string& strM3uURL);
   enigma2::ChannelsChangeState CheckForChannelAndGroupChanges();
+  void ReloadChannelsGroupsAndEPG();
 
   // members
   bool m_isConnected = false;

--- a/src/Enigma2.h
+++ b/src/Enigma2.h
@@ -21,13 +21,10 @@
  *
  */
 
-#include <atomic>
-#include <time.h>
-
 #include "client.h"
 #include "enigma2/Admin.h"
-#include "enigma2/Channels.h"
 #include "enigma2/ChannelGroups.h"
+#include "enigma2/Channels.h"
 #include "enigma2/ConnectionManager.h"
 #include "enigma2/Epg.h"
 #include "enigma2/IConnectionListener.h"
@@ -42,19 +39,21 @@
 #include "enigma2/data/RecordingEntry.h"
 #include "enigma2/extract/EpgEntryExtractor.h"
 #include "enigma2/utilities/SignalStatus.h"
-
-#include "tinyxml.h"
 #include "p8-platform/threads/threads.h"
+#include "tinyxml.h"
+
+#include <atomic>
+#include <time.h>
 
 // The windows build defines this but it breaks nlohmann/json.hpp's reference to std::snprintf
 #if defined(snprintf)
 #undef snprintf
 #endif
 
-class Enigma2  : public P8PLATFORM::CThread, public enigma2::IConnectionListener
+class Enigma2 : public P8PLATFORM::CThread, public enigma2::IConnectionListener
 {
 public:
-  Enigma2(PVR_PROPERTIES *pvrProps);
+  Enigma2(PVR_PROPERTIES* pvrProps);
   ~Enigma2();
 
   // IConnectionListener implementation
@@ -67,46 +66,46 @@ public:
   //device and helper functions
   bool Start();
   void SendPowerstate();
-  const char * GetServerName() const;
-  const char * GetServerVersion() const;
+  const char* GetServerName() const;
+  const char* GetServerVersion() const;
   bool IsConnected() const;
 
   //groups, channels and EPG
   unsigned int GetNumChannelGroups(void) const;
   PVR_ERROR GetChannelGroups(ADDON_HANDLE handle, bool radio);
-  PVR_ERROR GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &group);
+  PVR_ERROR GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP& group);
   int GetChannelsAmount(void) const;
   PVR_ERROR GetChannels(ADDON_HANDLE handle, bool bRadio);
   PVR_ERROR GetEPGForChannel(ADDON_HANDLE handle, int iChannelUid, time_t iStart, time_t iEnd);
 
   //live streams, recordings and Timers
-  bool OpenLiveStream(const PVR_CHANNEL &channelinfo);
+  bool OpenLiveStream(const PVR_CHANNEL& channelinfo);
   void CloseLiveStream();
-  const std::string GetLiveStreamURL(const PVR_CHANNEL &channelinfo);
+  const std::string GetLiveStreamURL(const PVR_CHANNEL& channelinfo);
   bool IsIptvStream(const PVR_CHANNEL& channelinfo) const;
-  int GetChannelStreamProgramNumber(const PVR_CHANNEL &channelinfo);
+  int GetChannelStreamProgramNumber(const PVR_CHANNEL& channelinfo);
   unsigned int GetRecordingsAmount(bool deleted);
   PVR_ERROR GetRecordings(ADDON_HANDLE handle, bool deleted);
-  PVR_ERROR DeleteRecording(const PVR_RECORDING &recinfo);
+  PVR_ERROR DeleteRecording(const PVR_RECORDING& recinfo);
   PVR_ERROR UndeleteRecording(const PVR_RECORDING& recording);
   PVR_ERROR DeleteAllRecordingsFromTrash();
   bool GetRecordingsFromLocation(std::string strRecordingFolder);
-  PVR_ERROR GetRecordingEdl(const PVR_RECORDING &recinfo, PVR_EDL_ENTRY edl[], int *size);
-  PVR_ERROR RenameRecording(const PVR_RECORDING &recording);
-  PVR_ERROR SetRecordingPlayCount(const PVR_RECORDING &recording, int count);
-  PVR_ERROR SetRecordingLastPlayedPosition(const PVR_RECORDING &recording, int lastplayedposition);
-  int GetRecordingLastPlayedPosition(const PVR_RECORDING &recording);
+  PVR_ERROR GetRecordingEdl(const PVR_RECORDING& recinfo, PVR_EDL_ENTRY edl[], int* size);
+  PVR_ERROR RenameRecording(const PVR_RECORDING& recording);
+  PVR_ERROR SetRecordingPlayCount(const PVR_RECORDING& recording, int count);
+  PVR_ERROR SetRecordingLastPlayedPosition(const PVR_RECORDING& recording, int lastplayedposition);
+  int GetRecordingLastPlayedPosition(const PVR_RECORDING& recording);
   bool HasRecordingStreamProgramNumber(const PVR_RECORDING& recording);
   int GetRecordingStreamProgramNumber(const PVR_RECORDING& recording);
-  enigma2::RecordingReader *OpenRecordedStream(const PVR_RECORDING &recinfo);
-  void GetTimerTypes(PVR_TIMER_TYPE types[], int *size);
+  enigma2::RecordingReader* OpenRecordedStream(const PVR_RECORDING& recinfo);
+  void GetTimerTypes(PVR_TIMER_TYPE types[], int* size);
   int GetTimersAmount(void);
   PVR_ERROR GetTimers(ADDON_HANDLE handle);
-  PVR_ERROR AddTimer(const PVR_TIMER &timer);
-  PVR_ERROR UpdateTimer(const PVR_TIMER &timer);
-  PVR_ERROR DeleteTimer(const PVR_TIMER &timer);
-  PVR_ERROR GetDriveSpace(long long *iTotal, long long *iUsed);
-  PVR_ERROR GetTunerSignal(PVR_SIGNAL_STATUS &signalStatus);
+  PVR_ERROR AddTimer(const PVR_TIMER& timer);
+  PVR_ERROR UpdateTimer(const PVR_TIMER& timer);
+  PVR_ERROR DeleteTimer(const PVR_TIMER& timer);
+  PVR_ERROR GetDriveSpace(long long* iTotal, long long* iUsed);
+  PVR_ERROR GetTunerSignal(PVR_SIGNAL_STATUS& signalStatus);
 
 protected:
   void* Process() override;
@@ -135,11 +134,11 @@ private:
   std::vector<std::string>& m_locations = m_recordings.GetLocations();
   enigma2::Epg m_epg = enigma2::Epg(m_entryExtractor, m_epgMaxDays);
   enigma2::Timers m_timers = enigma2::Timers(m_channels, m_channelGroups, m_locations, m_epg, m_entryExtractor);
-  enigma2::Settings &m_settings = enigma2::Settings::GetInstance();
+  enigma2::Settings& m_settings = enigma2::Settings::GetInstance();
   enigma2::Admin m_admin;
   enigma2::extract::EpgEntryExtractor m_entryExtractor;
   enigma2::utilities::SignalStatus m_signalStatus;
-  enigma2::ConnectionManager *connectionManager;
+  enigma2::ConnectionManager* connectionManager;
 
   mutable P8PLATFORM::CMutex m_mutex;
   P8PLATFORM::CCondition<bool> m_started;

--- a/src/Enigma2.h
+++ b/src/Enigma2.h
@@ -83,6 +83,7 @@ public:
   bool OpenLiveStream(const PVR_CHANNEL &channelinfo);
   void CloseLiveStream();
   const std::string GetLiveStreamURL(const PVR_CHANNEL &channelinfo);
+  bool IsIptvStream(const PVR_CHANNEL& channelinfo) const;
   int GetChannelStreamProgramNumber(const PVR_CHANNEL &channelinfo);
   unsigned int GetRecordingsAmount(bool deleted);
   PVR_ERROR GetRecordings(ADDON_HANDLE handle, bool deleted);
@@ -128,7 +129,7 @@ private:
   bool m_skipInitialEpgLoad;
   int m_epgMaxDays;
 
-  enigma2::Channels m_channels;
+  mutable enigma2::Channels m_channels;
   enigma2::ChannelGroups m_channelGroups;
   enigma2::Recordings m_recordings = enigma2::Recordings(m_channels, m_entryExtractor);
   std::vector<std::string>& m_locations = m_recordings.GetLocations();

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -22,8 +22,6 @@
 
 #include "client.h"
 
-#include <stdlib.h>
-
 #include "Enigma2.h"
 #include "enigma2/RecordingReader.h"
 #include "enigma2/Settings.h"
@@ -31,10 +29,12 @@
 #include "enigma2/TimeshiftBuffer.h"
 #include "enigma2/utilities/LocalizedString.h"
 #include "enigma2/utilities/Logger.h"
-
 #include "p8-platform/util/util.h"
-#include <p8-platform/util/StringUtils.h>
 #include "kodi/xbmc_pvr_dll.h"
+
+#include <stdlib.h>
+
+#include <p8-platform/util/StringUtils.h>
 
 using namespace ADDON;
 using namespace enigma2;
@@ -43,16 +43,17 @@ using namespace enigma2::utilities;
 
 bool m_created = false;
 ADDON_STATUS m_currentStatus = ADDON_STATUS_UNKNOWN;
-IStreamReader *streamReader = nullptr;
+IStreamReader* streamReader = nullptr;
 int m_streamReadChunkSize = 64;
-RecordingReader *recordingReader = nullptr;
-Settings &settings = Settings::GetInstance();
+RecordingReader* recordingReader = nullptr;
+Settings& settings = Settings::GetInstance();
 
-CHelper_libXBMC_addon *XBMC = nullptr;
-CHelper_libXBMC_pvr *PVR = nullptr;
-Enigma2 *enigma = nullptr;
+CHelper_libXBMC_addon* XBMC = nullptr;
+CHelper_libXBMC_pvr* PVR = nullptr;
+Enigma2* enigma = nullptr;
 
-extern "C" {
+extern "C"
+{
 
 /***************************************************************************
  * Addon Calls
@@ -87,7 +88,7 @@ ADDON_STATUS ADDON_Create(void* hdl, void* props)
   m_currentStatus = ADDON_STATUS_UNKNOWN;
 
   /* Configure the logger */
-  Logger::GetInstance().SetImplementation([](LogLevel level, const char *message)
+  Logger::GetInstance().SetImplementation([](LogLevel level, const char* message)
   {
     /* Don't log trace messages unless told so */
     if (level == LogLevel::LEVEL_TRACE && !Settings::GetInstance().GetTraceDebug())
@@ -158,7 +159,7 @@ void ADDON_Destroy()
   m_currentStatus = ADDON_STATUS_UNKNOWN;
 }
 
-ADDON_STATUS ADDON_SetSetting(const char *settingName, const void *settingValue)
+ADDON_STATUS ADDON_SetSetting(const char* settingName, const void* settingValue)
 {
   if (!XBMC || !enigma)
     return ADDON_STATUS_OK;
@@ -188,13 +189,9 @@ void OnSystemWake()
     enigma->OnWake();
 }
 
-void OnPowerSavingActivated()
-{
-}
+void OnPowerSavingActivated() {}
 
-void OnPowerSavingDeactivated()
-{
-}
+void OnPowerSavingDeactivated() {}
 
 PVR_ERROR GetAddonCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities)
 {
@@ -221,21 +218,21 @@ PVR_ERROR GetAddonCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities)
   return PVR_ERROR_NO_ERROR;
 }
 
-const char *GetBackendName(void)
+const char* GetBackendName(void)
 {
-  static const char *backendName = enigma ? enigma->GetServerName() : LocalizedString(30081).c_str(); //unknown
+  static const char* backendName = enigma ? enigma->GetServerName() : LocalizedString(30081).c_str(); //unknown
   return backendName;
 }
 
-const char *GetBackendVersion(void)
+const char* GetBackendVersion(void)
 {
-  static const char *backendVersion = enigma ? enigma->GetServerVersion() : LocalizedString(30081).c_str(); //unknown
+  static const char* backendVersion = enigma ? enigma->GetServerVersion() : LocalizedString(30081).c_str(); //unknown
   return backendVersion;
 }
 
 static std::string connectionString;
 
-const char *GetConnectionString(void)
+const char* GetConnectionString(void)
 {
   if (enigma)
     connectionString = StringUtils::Format("%s%s", settings.GetHostname().c_str(), enigma->IsConnected() ? "" : LocalizedString(30082).c_str()); // (Not connected!)
@@ -249,7 +246,7 @@ const char* GetBackendHostname(void)
   return settings.GetHostname().c_str();
 }
 
-PVR_ERROR GetDriveSpace(long long *iTotal, long long *iUsed)
+PVR_ERROR GetDriveSpace(long long* iTotal, long long* iUsed)
 {
   if (!enigma || !enigma->IsConnected())
     return PVR_ERROR_SERVER_ERROR;
@@ -258,7 +255,7 @@ PVR_ERROR GetDriveSpace(long long *iTotal, long long *iUsed)
 }
 
 
-PVR_ERROR SignalStatus(PVR_SIGNAL_STATUS &signalStatus)
+PVR_ERROR SignalStatus(PVR_SIGNAL_STATUS& signalStatus)
 {
   // SNR = Signal to Noise Ratio - which means signal quality
   // AGC = Automatic Gain Control - which means signal strength
@@ -298,7 +295,7 @@ PVR_ERROR GetChannelGroups(ADDON_HANDLE handle, bool bRadio)
   return enigma->GetChannelGroups(handle, bRadio);
 }
 
-PVR_ERROR GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &group)
+PVR_ERROR GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP& group)
 {
   if (!enigma || !enigma->IsConnected())
     return PVR_ERROR_SERVER_ERROR;
@@ -392,7 +389,7 @@ PVR_ERROR GetStreamReadChunkSize(int* chunksize)
 }
 
 /* live stream functions */
-bool OpenLiveStream(const PVR_CHANNEL &channel)
+bool OpenLiveStream(const PVR_CHANNEL& channel)
 {
   if (!enigma || !enigma->IsConnected())
     return false;
@@ -401,8 +398,7 @@ bool OpenLiveStream(const PVR_CHANNEL &channel)
     return false;
 
   /* queue a warning if the timeshift buffer path does not exist */
-  if (settings.GetTimeshift() != Timeshift::OFF
-      && !settings.IsTimeshiftBufferPathValid())
+  if (settings.GetTimeshift() != Timeshift::OFF && !settings.IsTimeshiftBufferPathValid())
     XBMC->QueueNotification(QUEUE_ERROR, LocalizedString(30514).c_str());
 
   const std::string streamURL = enigma->GetLiveStreamURL(channel);
@@ -444,7 +440,7 @@ bool CanSeekStream(void)
   return (settings.GetTimeshift() != Timeshift::OFF);
 }
 
-int ReadLiveStream(unsigned char *buffer, unsigned int size)
+int ReadLiveStream(unsigned char* buffer, unsigned int size)
 {
   return (streamReader) ? streamReader->ReadData(buffer, size) : 0;
 }
@@ -459,7 +455,7 @@ long long LengthLiveStream(void)
   return (streamReader) ? streamReader->Length() : -1;
 }
 
-PVR_ERROR GetStreamTimes(PVR_STREAM_TIMES *times)
+PVR_ERROR GetStreamTimes(PVR_STREAM_TIMES* times)
 {
   if (!times)
     return PVR_ERROR_INVALID_PARAMETERS;
@@ -493,9 +489,9 @@ void PauseStream(bool paused)
     return;
 
   /* start timeshift on pause */
-  if (paused && settings.GetTimeshift() == Timeshift::ON_PAUSE
-      && streamReader && !streamReader->IsTimeshifting()
-      && settings.IsTimeshiftBufferPathValid())
+  if (paused && settings.GetTimeshift() == Timeshift::ON_PAUSE &&
+      streamReader && !streamReader->IsTimeshifting() &&
+      settings.IsTimeshiftBufferPathValid())
   {
     streamReader = new TimeshiftBuffer(streamReader, settings.GetTimeshiftBufferPath(), settings.GetReadTimeoutSecs());
     (void)streamReader->Start();
@@ -522,7 +518,7 @@ PVR_ERROR GetRecordings(ADDON_HANDLE handle, bool deleted)
   return enigma->GetRecordings(handle, deleted);
 }
 
-PVR_ERROR DeleteRecording(const PVR_RECORDING &recording)
+PVR_ERROR DeleteRecording(const PVR_RECORDING& recording)
 {
   if (!enigma || !enigma->IsConnected())
     return PVR_ERROR_SERVER_ERROR;
@@ -546,7 +542,7 @@ PVR_ERROR DeleteAllRecordingsFromTrash()
   return enigma->DeleteAllRecordingsFromTrash();
 }
 
-PVR_ERROR GetRecordingEdl(const PVR_RECORDING &recinfo, PVR_EDL_ENTRY edl[], int *size)
+PVR_ERROR GetRecordingEdl(const PVR_RECORDING& recinfo, PVR_EDL_ENTRY edl[], int* size)
 {
   if (!enigma || !enigma->IsConnected())
     return PVR_ERROR_SERVER_ERROR;
@@ -560,7 +556,7 @@ PVR_ERROR GetRecordingEdl(const PVR_RECORDING &recinfo, PVR_EDL_ENTRY edl[], int
   return enigma->GetRecordingEdl(recinfo, edl, size);
 }
 
-PVR_ERROR RenameRecording(const PVR_RECORDING &recording)
+PVR_ERROR RenameRecording(const PVR_RECORDING& recording)
 {
   if (!enigma || !enigma->IsConnected())
     return PVR_ERROR_SERVER_ERROR;
@@ -568,7 +564,7 @@ PVR_ERROR RenameRecording(const PVR_RECORDING &recording)
   return enigma->RenameRecording(recording);
 }
 
-PVR_ERROR SetRecordingPlayCount(const PVR_RECORDING &recording, int count)
+PVR_ERROR SetRecordingPlayCount(const PVR_RECORDING& recording, int count)
 {
   if (!enigma || !enigma->IsConnected())
     return PVR_ERROR_SERVER_ERROR;
@@ -576,7 +572,7 @@ PVR_ERROR SetRecordingPlayCount(const PVR_RECORDING &recording, int count)
   return enigma->SetRecordingPlayCount(recording, count);
 }
 
-PVR_ERROR SetRecordingLastPlayedPosition(const PVR_RECORDING &recording, int lastPlayedPosition)
+PVR_ERROR SetRecordingLastPlayedPosition(const PVR_RECORDING& recording, int lastPlayedPosition)
 {
   if (!enigma || !enigma->IsConnected())
     return PVR_ERROR_SERVER_ERROR;
@@ -584,7 +580,7 @@ PVR_ERROR SetRecordingLastPlayedPosition(const PVR_RECORDING &recording, int las
   return enigma->SetRecordingLastPlayedPosition(recording, lastPlayedPosition);
 }
 
-int GetRecordingLastPlayedPosition(const PVR_RECORDING &recording)
+int GetRecordingLastPlayedPosition(const PVR_RECORDING& recording)
 {
   if (!enigma || !enigma->IsConnected())
     return PVR_ERROR_SERVER_ERROR;
@@ -629,7 +625,7 @@ PVR_ERROR GetRecordingStreamProperties(const PVR_RECORDING* recording, PVR_NAMED
   return PVR_ERROR_NO_ERROR;
 }
 
-bool OpenRecordedStream(const PVR_RECORDING &recording)
+bool OpenRecordedStream(const PVR_RECORDING& recording)
 {
   if (recordingReader)
     SAFE_DELETE(recordingReader);
@@ -647,7 +643,7 @@ void CloseRecordedStream(void)
     SAFE_DELETE(recordingReader);
 }
 
-int ReadRecordedStream(unsigned char *buffer, unsigned int size)
+int ReadRecordedStream(unsigned char* buffer, unsigned int size)
 {
   if (!recordingReader)
     return 0;
@@ -675,7 +671,7 @@ long long LengthRecordedStream(void)
  * Timers
  **************************************************************************/
 
-PVR_ERROR GetTimerTypes(PVR_TIMER_TYPE types[], int *size)
+PVR_ERROR GetTimerTypes(PVR_TIMER_TYPE types[], int* size)
 {
   *size = 0;
   if (enigma && enigma->IsConnected())
@@ -699,7 +695,7 @@ PVR_ERROR GetTimers(ADDON_HANDLE handle)
   return enigma->GetTimers(handle);
 }
 
-PVR_ERROR AddTimer(const PVR_TIMER &timer)
+PVR_ERROR AddTimer(const PVR_TIMER& timer)
 {
   if (!enigma || !enigma->IsConnected())
     return PVR_ERROR_SERVER_ERROR;
@@ -707,7 +703,7 @@ PVR_ERROR AddTimer(const PVR_TIMER &timer)
   return enigma->AddTimer(timer);
 }
 
-PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete)
+PVR_ERROR DeleteTimer(const PVR_TIMER& timer, bool bForceDelete)
 {
   if (!enigma || !enigma->IsConnected())
     return PVR_ERROR_SERVER_ERROR;
@@ -715,7 +711,7 @@ PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete)
   return enigma->DeleteTimer(timer);
 }
 
-PVR_ERROR UpdateTimer(const PVR_TIMER &timer)
+PVR_ERROR UpdateTimer(const PVR_TIMER& timer)
 {
   if (!enigma || !enigma->IsConnected())
     return PVR_ERROR_SERVER_ERROR;
@@ -729,20 +725,20 @@ void DemuxAbort(void) { return; }
 DemuxPacket* DemuxRead(void) { return nullptr; }
 void FillBuffer(bool mode) {}
 PVR_ERROR OpenDialogChannelScan(void) { return PVR_ERROR_NOT_IMPLEMENTED; }
-PVR_ERROR CallMenuHook(const PVR_MENUHOOK &menuhook, const PVR_MENUHOOK_DATA &item) { return PVR_ERROR_NOT_IMPLEMENTED; }
-PVR_ERROR DeleteChannel(const PVR_CHANNEL &channel) { return PVR_ERROR_NOT_IMPLEMENTED; }
-PVR_ERROR RenameChannel(const PVR_CHANNEL &channel) { return PVR_ERROR_NOT_IMPLEMENTED; }
-PVR_ERROR OpenDialogChannelSettings(const PVR_CHANNEL &channel) { return PVR_ERROR_NOT_IMPLEMENTED; }
-PVR_ERROR OpenDialogChannelAdd(const PVR_CHANNEL &channel) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR CallMenuHook(const PVR_MENUHOOK& menuhook, const PVR_MENUHOOK_DATA& item) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR DeleteChannel(const PVR_CHANNEL& channel) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR RenameChannel(const PVR_CHANNEL& channel) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR OpenDialogChannelSettings(const PVR_CHANNEL& channel) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR OpenDialogChannelAdd(const PVR_CHANNEL& channel) { return PVR_ERROR_NOT_IMPLEMENTED; }
 void DemuxReset(void) {}
 void DemuxFlush(void) {}
-bool SeekTime(double,bool,double*) { return false; }
-void SetSpeed(int) {};
+bool SeekTime(double, bool, double*) { return false; }
+void SetSpeed(int){};
 PVR_ERROR SetEPGTimeFrame(int) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR GetDescrambleInfo(PVR_DESCRAMBLE_INFO*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR SetRecordingLifetime(const PVR_RECORDING*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR IsEPGTagRecordable(const EPG_TAG*, bool*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR IsEPGTagPlayable(const EPG_TAG*, bool*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR GetEPGTagStreamProperties(const EPG_TAG*, PVR_NAMED_VALUE*, unsigned int*) { return PVR_ERROR_NOT_IMPLEMENTED; }
-PVR_ERROR GetEPGTagEdl(const EPG_TAG* epgTag, PVR_EDL_ENTRY edl[], int *size) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR GetEPGTagEdl(const EPG_TAG* epgTag, PVR_EDL_ENTRY edl[], int* size) { return PVR_ERROR_NOT_IMPLEMENTED; }
 }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2005-2015 Team XBMC
+ *      Copyright (C) 2005-2019 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify

--- a/src/client.h
+++ b/src/client.h
@@ -1,6 +1,6 @@
 #pragma once
 /*
- *      Copyright (C) 2005-2015 Team XBMC
+ *      Copyright (C) 2005-2019 Team XBMC
  *      http://www.xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify

--- a/src/client.h
+++ b/src/client.h
@@ -24,5 +24,5 @@
 #include "kodi/libXBMC_addon.h"
 #include "kodi/libXBMC_pvr.h"
 
-extern ADDON::CHelper_libXBMC_addon *XBMC;
-extern CHelper_libXBMC_pvr *PVR;
+extern ADDON::CHelper_libXBMC_addon* XBMC;
+extern CHelper_libXBMC_pvr* PVR;

--- a/src/enigma2/Admin.cpp
+++ b/src/enigma2/Admin.cpp
@@ -1,3 +1,25 @@
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
 #include "Admin.h"
 
 #include "../Enigma2.h"

--- a/src/enigma2/Admin.cpp
+++ b/src/enigma2/Admin.cpp
@@ -31,6 +31,7 @@
 #include "utilities/Logger.h"
 #include "utilities/WebUtils.h"
 
+#include <cstdlib>
 #include <regex>
 
 #include <nlohmann/json.hpp>
@@ -247,7 +248,7 @@ unsigned int Admin::ParseWebIfVersion(const std::string& webIfVersion)
   unsigned int webIfVersionAsNum = 0;
 
   std::regex regex("^.*[0-9]+\\.[0-9]+\\.[0-9].*$");
-  if (regex_match(webIfVersion, regex))
+  if (std::regex_match(webIfVersion, regex))
   {
     int count = 0;
     unsigned int versionPart = 0;
@@ -257,15 +258,15 @@ unsigned int Admin::ParseWebIfVersion(const std::string& webIfVersion)
         switch (count)
         {
           case 0:
-            versionPart = atoi(i->str().c_str());
+            versionPart = std::atoi(i->str().c_str());
             webIfVersionAsNum = versionPart << 16;
             break;
           case 1:
-              versionPart = atoi(i->str().c_str());
+              versionPart = std::atoi(i->str().c_str());
               webIfVersionAsNum |= versionPart << 8;
             break;
           case 2:
-              versionPart = atoi(i->str().c_str());
+              versionPart = std::atoi(i->str().c_str());
               webIfVersionAsNum |= versionPart;
             break;
         }
@@ -431,12 +432,12 @@ bool Admin::LoadRecordingMarginSettings()
 
     if (settingName == "config.recording.margin_before")
     {
-      m_deviceSettings.SetGlobalRecordingStartMargin(atoi(settingValue.c_str()));
+      m_deviceSettings.SetGlobalRecordingStartMargin(std::atoi(settingValue.c_str()));
       readMarginBefore = true;
     }
     else if (settingName == "config.recording.margin_after")
     {
-       m_deviceSettings.SetGlobalRecordingEndMargin(atoi(settingValue.c_str()));
+       m_deviceSettings.SetGlobalRecordingEndMargin(std::atoi(settingValue.c_str()));
        readMarginAfter = true;
     }
 
@@ -586,9 +587,9 @@ long long Admin::GetKbFromString(const std::string& stringInMbGbTb) const
     std::regex regexSize("^.* " + size);
     std::regex regexReplaceSize(" " + size);
 
-    if (regex_match(stringInMbGbTb, regexSize))
+    if (std::regex_match(stringInMbGbTb, regexSize))
     {
-      double sizeValue = atof(regex_replace(stringInMbGbTb, regexReplaceSize, replaceWith).c_str());
+      double sizeValue = std::atof(std::regex_replace(stringInMbGbTb, regexReplaceSize, replaceWith).c_str());
 
       sizeInKb += static_cast<long long>(sizeValue * multiplier);
 
@@ -657,9 +658,9 @@ bool Admin::GetTunerSignal(SignalStatus& signalStatus, const std::shared_ptr<dat
   std::string regexReplace = "";
 
   // For some reason the iSNR and iSignal values need to multiplied by 655!
-  signalStatus.m_snrPercentage = atoi(regex_replace(snrPercentage, regexReplacePercent, regexReplace).c_str()) * 655;
-  signalStatus.m_ber = atol(ber.c_str());
-  signalStatus.m_signalStrength = atoi(regex_replace(signalStrength, regexReplacePercent, regexReplace).c_str()) * 655;
+  signalStatus.m_snrPercentage = std::atoi(std::regex_replace(snrPercentage, regexReplacePercent, regexReplace).c_str()) * 655;
+  signalStatus.m_ber = std::atol(ber.c_str());
+  signalStatus.m_signalStrength = std::atoi(std::regex_replace(signalStrength, regexReplacePercent, regexReplace).c_str()) * 655;
 
   if (Settings::GetInstance().SupportsTunerDetails())
   {

--- a/src/enigma2/Admin.cpp
+++ b/src/enigma2/Admin.cpp
@@ -1,17 +1,17 @@
 #include "Admin.h"
 
-#include <regex>
-
-#include "../client.h"
 #include "../Enigma2.h"
+#include "../client.h"
+#include "p8-platform/util/StringUtils.h"
+#include "util/XMLUtils.h"
 #include "utilities/FileUtils.h"
 #include "utilities/LocalizedString.h"
 #include "utilities/Logger.h"
 #include "utilities/WebUtils.h"
 
+#include <regex>
+
 #include <nlohmann/json.hpp>
-#include "util/XMLUtils.h"
-#include "p8-platform/util/StringUtils.h"
 
 using namespace enigma2;
 using namespace enigma2::data;
@@ -40,7 +40,7 @@ void Admin::SendPowerstate()
     if (Settings::GetInstance().GetPowerstateModeOnAddonExit() == PowerstateMode::STANDBY ||
       Settings::GetInstance().GetPowerstateModeOnAddonExit() == PowerstateMode::WAKEUP_THEN_STANDBY)
     {
-      const std::string strCmd  = StringUtils::Format("web/powerstate?newstate=5"); //Standby
+      const std::string strCmd = StringUtils::Format("web/powerstate?newstate=5"); //Standby
 
       std::string strResult;
       WebUtils::SendSimpleCommand(strCmd, strResult, true);
@@ -48,7 +48,7 @@ void Admin::SendPowerstate()
 
     if (Settings::GetInstance().GetPowerstateModeOnAddonExit() == PowerstateMode::DEEP_STANDBY)
     {
-      const std::string strCmd  = StringUtils::Format("web/powerstate?newstate=1"); //Deep Standby
+      const std::string strCmd = StringUtils::Format("web/powerstate?newstate=1"); //Deep Standby
 
       std::string strResult;
       WebUtils::SendSimpleCommand(strCmd, strResult, true);
@@ -220,11 +220,11 @@ bool Admin::LoadDeviceInfo()
   return true;
 }
 
-unsigned int Admin::ParseWebIfVersion(const std::string &webIfVersion)
+unsigned int Admin::ParseWebIfVersion(const std::string& webIfVersion)
 {
   unsigned int webIfVersionAsNum = 0;
 
-  std::regex regex ("^.*[0-9]+\\.[0-9]+\\.[0-9].*$");
+  std::regex regex("^.*[0-9]+\\.[0-9]+\\.[0-9].*$");
   if (regex_match(webIfVersion, regex))
   {
     int count = 0;
@@ -476,7 +476,7 @@ bool Admin::SendGlobalRecordingEndMarginSetting(int newValue)
   return true;
 }
 
-PVR_ERROR Admin::GetDriveSpace(long long *iTotal, long long *iUsed, std::vector<std::string> &locations)
+PVR_ERROR Admin::GetDriveSpace(long long* iTotal, long long* iUsed, std::vector<std::string>& locations)
 {
   long long totalKb = 0;
   long long freeKb = 0;
@@ -551,7 +551,7 @@ PVR_ERROR Admin::GetDriveSpace(long long *iTotal, long long *iUsed, std::vector<
   return PVR_ERROR_NO_ERROR;
 }
 
-long long Admin::GetKbFromString(const std::string &stringInMbGbTb) const
+long long Admin::GetKbFromString(const std::string& stringInMbGbTb) const
 {
   long long sizeInKb = 0;
 
@@ -560,8 +560,8 @@ long long Admin::GetKbFromString(const std::string &stringInMbGbTb) const
   std::string replaceWith = "";
   for (const std::string& size : sizes)
   {
-    std::regex regexSize ("^.* " + size);
-    std::regex regexReplaceSize (" " + size);
+    std::regex regexSize("^.* " + size);
+    std::regex regexReplaceSize(" " + size);
 
     if (regex_match(stringInMbGbTb, regexSize))
     {
@@ -578,7 +578,7 @@ long long Admin::GetKbFromString(const std::string &stringInMbGbTb) const
   return sizeInKb;
 }
 
-bool Admin::GetTunerSignal(SignalStatus &signalStatus, const std::shared_ptr<data::Channel> &channel)
+bool Admin::GetTunerSignal(SignalStatus& signalStatus, const std::shared_ptr<data::Channel>& channel)
 {
   const std::string url = StringUtils::Format("%s%s", Settings::GetInstance().GetConnectionURL().c_str(), "web/signal");
 
@@ -630,7 +630,7 @@ bool Admin::GetTunerSignal(SignalStatus &signalStatus, const std::shared_ptr<dat
     return false;
   }
 
-  std::regex regexReplacePercent (" %");
+  std::regex regexReplacePercent(" %");
   std::string regexReplace = "";
 
   // For some reason the iSNR and iSignal values need to multiplied by 655!
@@ -648,7 +648,7 @@ bool Admin::GetTunerSignal(SignalStatus &signalStatus, const std::shared_ptr<dat
   return true;
 }
 
-StreamStatus Admin::GetStreamDetails(const std::shared_ptr<data::Channel> &channel)
+StreamStatus Admin::GetStreamDetails(const std::shared_ptr<data::Channel>& channel)
 {
   StreamStatus streamStatus;
 
@@ -719,7 +719,7 @@ StreamStatus Admin::GetStreamDetails(const std::shared_ptr<data::Channel> &chann
   return streamStatus;
 }
 
-void Admin::GetTunerDetails(SignalStatus &signalStatus, const std::shared_ptr<data::Channel> &channel)
+void Admin::GetTunerDetails(SignalStatus& signalStatus, const std::shared_ptr<data::Channel>& channel)
 {
   const std::string jsonUrl = StringUtils::Format("%s%s", Settings::GetInstance().GetConnectionURL().c_str(), "api/tunersignal");
 
@@ -739,7 +739,7 @@ void Admin::GetTunerDetails(SignalStatus &signalStatus, const std::shared_ptr<da
 
         if (m_tuners.size() > tunerNumber)
         {
-          Tuner &tuner = m_tuners.at(tunerNumber);
+          Tuner& tuner = m_tuners.at(tunerNumber);
 
           signalStatus.m_adapterName = tuner.m_tunerName + " - " + tuner.m_tunerModel;
         }

--- a/src/enigma2/Admin.cpp
+++ b/src/enigma2/Admin.cpp
@@ -516,6 +516,7 @@ PVR_ERROR Admin::GetDriveSpace(long long* iTotal, long long* iUsed, std::vector<
 
   if (!hddNode)
   {
+    m_deviceHasHDD = false;
     Logger::Log(LEVEL_ERROR, "%s Could not find <e2hdd> element", __FUNCTION__);
     return PVR_ERROR_SERVER_ERROR;
   }

--- a/src/enigma2/Admin.h
+++ b/src/enigma2/Admin.h
@@ -1,6 +1,6 @@
 #pragma once
 /*
- *      Copyright (C) 2005-2015 Team XBMC
+ *      Copyright (C) 2005-2019 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify

--- a/src/enigma2/Admin.h
+++ b/src/enigma2/Admin.h
@@ -21,17 +21,16 @@
  *
  */
 
-#include <string>
-#include <vector>
-
 #include "data/Channel.h"
+#include "kodi/libXBMC_pvr.h"
 #include "utilities/DeviceInfo.h"
 #include "utilities/DeviceSettings.h"
 #include "utilities/SignalStatus.h"
 #include "utilities/StreamStatus.h"
 #include "utilities/Tuner.h"
 
-#include "kodi/libXBMC_pvr.h"
+#include <string>
+#include <vector>
 
 namespace enigma2
 {
@@ -47,7 +46,7 @@ namespace enigma2
     bool SendGlobalRecordingStartMarginSetting(int newValue);
     bool SendGlobalRecordingEndMarginSetting(int newValue);
     const utilities::DeviceInfo& GetDeviceInfo() const { return m_deviceInfo; }
-    PVR_ERROR GetDriveSpace(long long *iTotal, long long *iUsed, std::vector<std::string> &locations);
+    PVR_ERROR GetDriveSpace(long long* iTotal, long long* iUsed, std::vector<std::string>& locations);
     const char* GetServerName() const { return m_serverName; }
     const char* GetServerVersion() const { return m_serverVersion; }
     const std::string& GetDeviceName() const { return m_deviceInfo.GetServerName(); }
@@ -57,17 +56,17 @@ namespace enigma2
     const std::string& GetWebIfVersion() const { return m_deviceInfo.GetWebIfVersion(); }
     unsigned int GetWebIfVersionAsNum() const { return m_deviceInfo.GetWebIfVersionAsNum(); }
     const std::string& GetAddonVersion() const { return m_addonVersion; }
-    bool GetTunerSignal(utilities::SignalStatus &signalStatus, const std::shared_ptr<data::Channel> &channel);
+    bool GetTunerSignal(utilities::SignalStatus& signalStatus, const std::shared_ptr<data::Channel>& channel);
 
   private:
     static void SetCharString(char* target, const std::string value);
     bool LoadDeviceInfo();
     bool LoadAutoTimerSettings();
     bool LoadRecordingMarginSettings();
-    unsigned int ParseWebIfVersion(const std::string &webIfVersion);
-    long long GetKbFromString(const std::string &stringInMbGbTb) const;
-    utilities::StreamStatus GetStreamDetails(const std::shared_ptr<data::Channel> &channel);
-    void GetTunerDetails(utilities::SignalStatus &signalStatus, const std::shared_ptr<data::Channel> &channel);
+    unsigned int ParseWebIfVersion(const std::string& webIfVersion);
+    long long GetKbFromString(const std::string& stringInMbGbTb) const;
+    utilities::StreamStatus GetStreamDetails(const std::shared_ptr<data::Channel>& channel);
+    void GetTunerDetails(utilities::SignalStatus& signalStatus, const std::shared_ptr<data::Channel>& channel);
 
     char m_serverName[256];
     char m_serverVersion[256];

--- a/src/enigma2/Admin.h
+++ b/src/enigma2/Admin.h
@@ -57,6 +57,7 @@ namespace enigma2
     unsigned int GetWebIfVersionAsNum() const { return m_deviceInfo.GetWebIfVersionAsNum(); }
     const std::string& GetAddonVersion() const { return m_addonVersion; }
     bool GetTunerSignal(utilities::SignalStatus& signalStatus, const std::shared_ptr<data::Channel>& channel);
+    bool GetDeviceHasHDD() const { return m_deviceHasHDD; };
 
   private:
     static void SetCharString(char* target, const std::string value);
@@ -70,6 +71,7 @@ namespace enigma2
 
     char m_serverName[256];
     char m_serverVersion[256];
+    bool m_deviceHasHDD = true;
     const std::string m_addonVersion;
     enigma2::utilities::DeviceInfo m_deviceInfo;
     enigma2::utilities::DeviceSettings m_deviceSettings;

--- a/src/enigma2/ChannelGroups.cpp
+++ b/src/enigma2/ChannelGroups.cpp
@@ -76,16 +76,6 @@ PVR_ERROR ChannelGroups::GetChannelGroupMembers(std::vector<PVR_CHANNEL_GROUP_ME
   return PVR_ERROR_NO_ERROR;
 }
 
-int ChannelGroups::GetChannelGroupUniqueId(const std::string& groupName) const
-{
-  for (const auto& channelGroup : m_channelGroups)
-  {
-    if (groupName == channelGroup->GetGroupName())
-      return channelGroup->GetUniqueId();
-  }
-  return -1;
-}
-
 std::string ChannelGroups::GetChannelGroupServiceReference(const std::string& groupName)
 {
   for (const auto& channelGroup : m_channelGroups)
@@ -94,11 +84,6 @@ std::string ChannelGroups::GetChannelGroupServiceReference(const std::string& gr
       return channelGroup->GetServiceReference();
   }
   return "error";
-}
-
-std::shared_ptr<ChannelGroup> ChannelGroups::GetChannelGroup(int uniqueId)
-{
-  return m_channelGroups.at(uniqueId - 1);
 }
 
 std::shared_ptr<ChannelGroup> ChannelGroups::GetChannelGroup(const std::string& groupServiceReference)
@@ -121,11 +106,6 @@ std::shared_ptr<ChannelGroup> ChannelGroups::GetChannelGroupUsingName(const std:
   }
 
   return channelGroup;
-}
-
-bool ChannelGroups::IsValid(int uniqueId) const
-{
-  return (uniqueId - 1) < m_channelGroups.size();
 }
 
 bool ChannelGroups::IsValid(std::string groupName)

--- a/src/enigma2/ChannelGroups.cpp
+++ b/src/enigma2/ChannelGroups.cpp
@@ -1,24 +1,24 @@
 #include "ChannelGroups.h"
 
-#include <regex>
-
-#include "../client.h"
 #include "../Enigma2.h"
+#include "../client.h"
+#include "p8-platform/util/StringUtils.h"
+#include "util/XMLUtils.h"
+#include "utilities/FileUtils.h"
 #include "utilities/LocalizedString.h"
 #include "utilities/Logger.h"
 #include "utilities/WebUtils.h"
-#include "utilities/FileUtils.h"
+
+#include <regex>
 
 #include <nlohmann/json.hpp>
-#include "util/XMLUtils.h"
-#include "p8-platform/util/StringUtils.h"
 
 using namespace enigma2;
 using namespace enigma2::data;
 using namespace enigma2::utilities;
 using json = nlohmann::json;
 
-void ChannelGroups::GetChannelGroups(std::vector<PVR_CHANNEL_GROUP> &kodiChannelGroups, bool radio) const
+void ChannelGroups::GetChannelGroups(std::vector<PVR_CHANNEL_GROUP>& kodiChannelGroups, bool radio) const
 {
   Logger::Log(LEVEL_DEBUG, "%s - Starting to get ChannelGroups for PVR", __FUNCTION__);
 
@@ -39,7 +39,7 @@ void ChannelGroups::GetChannelGroups(std::vector<PVR_CHANNEL_GROUP> &kodiChannel
   Logger::Log(LEVEL_DEBUG, "%s - Finished getting ChannelGroups for PVR", __FUNCTION__);
 }
 
-PVR_ERROR ChannelGroups::GetChannelGroupMembers(std::vector<PVR_CHANNEL_GROUP_MEMBER> &channelGroupMembers, const std::string &groupName)
+PVR_ERROR ChannelGroups::GetChannelGroupMembers(std::vector<PVR_CHANNEL_GROUP_MEMBER>& channelGroupMembers, const std::string& groupName)
 {
   std::shared_ptr<ChannelGroup> channelGroup = GetChannelGroupUsingName(groupName);
 
@@ -62,10 +62,9 @@ PVR_ERROR ChannelGroups::GetChannelGroupMembers(std::vector<PVR_CHANNEL_GROUP_ME
 
     strncpy(tag.strGroupName, groupName.c_str(), sizeof(tag.strGroupName));
     tag.iChannelUniqueId = channel->GetUniqueId();
-    tag.iChannelNumber   = channelNumberInGroup; //Keep the channels in list order as per the groups on the STB
+    tag.iChannelNumber = channelNumberInGroup; //Keep the channels in list order as per the groups on the STB
 
-    Logger::Log(LEVEL_DEBUG, "%s - add channel %s (%d) to group '%s' channel number %d",
-        __FUNCTION__, channel->GetChannelName().c_str(), tag.iChannelUniqueId, groupName.c_str(), channel->GetChannelNumber());
+    Logger::Log(LEVEL_DEBUG, "%s - add channel %s (%d) to group '%s' channel number %d", __FUNCTION__, channel->GetChannelName().c_str(), tag.iChannelUniqueId, groupName.c_str(), channel->GetChannelNumber());
 
     channelGroupMembers.emplace_back(tag);
 
@@ -77,7 +76,7 @@ PVR_ERROR ChannelGroups::GetChannelGroupMembers(std::vector<PVR_CHANNEL_GROUP_ME
   return PVR_ERROR_NO_ERROR;
 }
 
-int ChannelGroups::GetChannelGroupUniqueId(const std::string &groupName) const
+int ChannelGroups::GetChannelGroupUniqueId(const std::string& groupName) const
 {
   for (const auto& channelGroup : m_channelGroups)
   {
@@ -87,7 +86,7 @@ int ChannelGroups::GetChannelGroupUniqueId(const std::string &groupName) const
   return -1;
 }
 
-std::string ChannelGroups::GetChannelGroupServiceReference(const std::string &groupName)
+std::string ChannelGroups::GetChannelGroupServiceReference(const std::string& groupName)
 {
   for (const auto& channelGroup : m_channelGroups)
   {
@@ -102,7 +101,7 @@ std::shared_ptr<ChannelGroup> ChannelGroups::GetChannelGroup(int uniqueId)
   return m_channelGroups.at(uniqueId - 1);
 }
 
-std::shared_ptr<ChannelGroup> ChannelGroups::GetChannelGroup(const std::string &groupServiceReference)
+std::shared_ptr<ChannelGroup> ChannelGroups::GetChannelGroup(const std::string& groupServiceReference)
 {
   const auto channelGroupPair = m_channelGroupsServiceReferenceMap.find(groupServiceReference);
   if (channelGroupPair != m_channelGroupsServiceReferenceMap.end())
@@ -111,7 +110,7 @@ std::shared_ptr<ChannelGroup> ChannelGroups::GetChannelGroup(const std::string &
   return {};
 }
 
-std::shared_ptr<ChannelGroup> ChannelGroups::GetChannelGroupUsingName(const std::string &groupName)
+std::shared_ptr<ChannelGroup> ChannelGroups::GetChannelGroupUsingName(const std::string& groupName)
 {
   std::shared_ptr<ChannelGroup> channelGroup;
 

--- a/src/enigma2/ChannelGroups.cpp
+++ b/src/enigma2/ChannelGroups.cpp
@@ -1,3 +1,25 @@
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
 #include "ChannelGroups.h"
 
 #include "../Enigma2.h"

--- a/src/enigma2/ChannelGroups.cpp
+++ b/src/enigma2/ChannelGroups.cpp
@@ -129,7 +129,7 @@ void ChannelGroups::ClearChannelGroups()
 
 void ChannelGroups::AddChannelGroup(ChannelGroup& newChannelGroup)
 {
-  std::shared_ptr<ChannelGroup> foundChannelGroup = GetChannelGroup(newChannelGroup.GetGroupName());
+  std::shared_ptr<ChannelGroup> foundChannelGroup = GetChannelGroupUsingName(newChannelGroup.GetGroupName());
 
   if (!foundChannelGroup)
   {

--- a/src/enigma2/ChannelGroups.h
+++ b/src/enigma2/ChannelGroups.h
@@ -1,6 +1,6 @@
 #pragma once
 /*
- *      Copyright (C) 2005-2015 Team XBMC
+ *      Copyright (C) 2005-2019 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify

--- a/src/enigma2/ChannelGroups.h
+++ b/src/enigma2/ChannelGroups.h
@@ -38,12 +38,9 @@ namespace enigma2
     void GetChannelGroups(std::vector<PVR_CHANNEL_GROUP>& channelGroups, bool radio) const;
     PVR_ERROR GetChannelGroupMembers(std::vector<PVR_CHANNEL_GROUP_MEMBER>& channelGroupMembers, const std::string& groupName);
 
-    int GetChannelGroupUniqueId(const std::string& groupName) const;
     std::string GetChannelGroupServiceReference(const std::string& groupName);
-    std::shared_ptr<enigma2::data::ChannelGroup> GetChannelGroup(int uniqueId);
     std::shared_ptr<enigma2::data::ChannelGroup> GetChannelGroup(const std::string& groupServiceReference);
     std::shared_ptr<enigma2::data::ChannelGroup> GetChannelGroupUsingName(const std::string& groupName);
-    bool IsValid(int uniqueId) const;
     bool IsValid(std::string groupName);
     int GetNumChannelGroups() const;
     void ClearChannelGroups();

--- a/src/enigma2/ChannelGroups.h
+++ b/src/enigma2/ChannelGroups.h
@@ -21,29 +21,28 @@
  *
  */
 
+#include "data/Channel.h"
+#include "data/ChannelGroup.h"
+#include "kodi/libXBMC_pvr.h"
+
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
-
-#include "data/Channel.h"
-#include "data/ChannelGroup.h"
-
-#include "kodi/libXBMC_pvr.h"
 
 namespace enigma2
 {
   class ChannelGroups
   {
   public:
-    void GetChannelGroups(std::vector<PVR_CHANNEL_GROUP> &channelGroups, bool radio) const;
-    PVR_ERROR GetChannelGroupMembers(std::vector<PVR_CHANNEL_GROUP_MEMBER> &channelGroupMembers, const std::string &groupName);
+    void GetChannelGroups(std::vector<PVR_CHANNEL_GROUP>& channelGroups, bool radio) const;
+    PVR_ERROR GetChannelGroupMembers(std::vector<PVR_CHANNEL_GROUP_MEMBER>& channelGroupMembers, const std::string& groupName);
 
-    int GetChannelGroupUniqueId(const std::string &groupName) const;
-    std::string GetChannelGroupServiceReference(const std::string &groupName);
+    int GetChannelGroupUniqueId(const std::string& groupName) const;
+    std::string GetChannelGroupServiceReference(const std::string& groupName);
     std::shared_ptr<enigma2::data::ChannelGroup> GetChannelGroup(int uniqueId);
-    std::shared_ptr<enigma2::data::ChannelGroup> GetChannelGroup(const std::string &groupServiceReference);
-    std::shared_ptr<enigma2::data::ChannelGroup> GetChannelGroupUsingName(const std::string &groupName);
+    std::shared_ptr<enigma2::data::ChannelGroup> GetChannelGroup(const std::string& groupServiceReference);
+    std::shared_ptr<enigma2::data::ChannelGroup> GetChannelGroupUsingName(const std::string& groupName);
     bool IsValid(int uniqueId) const;
     bool IsValid(std::string groupName);
     int GetNumChannelGroups() const;

--- a/src/enigma2/Channels.cpp
+++ b/src/enigma2/Channels.cpp
@@ -1,30 +1,31 @@
 #include "Channels.h"
 
-#include <regex>
-
-#include "../client.h"
 #include "../Enigma2.h"
+#include "../client.h"
 #include "Admin.h"
 #include "ChannelGroups.h"
+#include "p8-platform/util/StringUtils.h"
+#include "util/XMLUtils.h"
 #include "utilities/Logger.h"
 #include "utilities/WebUtils.h"
 
+#include <regex>
+
 #include <nlohmann/json.hpp>
-#include "util/XMLUtils.h"
-#include "p8-platform/util/StringUtils.h"
 
 using namespace enigma2;
 using namespace enigma2::data;
 using namespace enigma2::utilities;
 using json = nlohmann::json;
 
-void Channels::GetChannels(std::vector<PVR_CHANNEL> &kodiChannels, bool bRadio) const
+void Channels::GetChannels(std::vector<PVR_CHANNEL>& kodiChannels, bool bRadio) const
 {
   for (const auto& channel : m_channels)
   {
     if (channel->IsRadio() == bRadio)
     {
-      Logger::Log(LEVEL_DEBUG, "%s - Transfer channel '%s', ChannelIndex '%d'", __FUNCTION__, channel->GetChannelName().c_str(), channel->GetUniqueId());
+      Logger::Log(LEVEL_DEBUG, "%s - Transfer channel '%s', ChannelIndex '%d'", __FUNCTION__, channel->GetChannelName().c_str(),
+                  channel->GetUniqueId());
       PVR_CHANNEL kodiChannel = {0};
 
       channel->UpdateTo(kodiChannel);
@@ -34,7 +35,7 @@ void Channels::GetChannels(std::vector<PVR_CHANNEL> &kodiChannels, bool bRadio) 
   }
 }
 
-int Channels::GetChannelUniqueId(const std::string &channelServiceReference)
+int Channels::GetChannelUniqueId(const std::string& channelServiceReference)
 {
   std::shared_ptr<Channel> channel = GetChannel(channelServiceReference);
   int uniqueId = PVR_CHANNEL_INVALID_UID;
@@ -50,7 +51,7 @@ std::shared_ptr<Channel> Channels::GetChannel(int uniqueId)
   return m_channels.at(uniqueId - 1);
 }
 
-std::shared_ptr<Channel> Channels::GetChannel(const std::string &channelServiceReference)
+std::shared_ptr<Channel> Channels::GetChannel(const std::string& channelServiceReference)
 {
   std::shared_ptr<Channel> channel = nullptr;
 
@@ -63,7 +64,7 @@ std::shared_ptr<Channel> Channels::GetChannel(const std::string &channelServiceR
   return channel;
 }
 
-std::shared_ptr<Channel> Channels::GetChannel(const std::string &channelName, bool isRadio)
+std::shared_ptr<Channel> Channels::GetChannel(const std::string& channelName, bool isRadio)
 {
   for (const auto& channel : m_channels)
   {
@@ -95,7 +96,7 @@ void Channels::ClearChannels()
   m_channelsServiceReferenceMap.clear();
 }
 
-void Channels::AddChannel(Channel &newChannel, std::shared_ptr<ChannelGroup> &channelGroup)
+void Channels::AddChannel(Channel& newChannel, std::shared_ptr<ChannelGroup>& channelGroup)
 {
   std::shared_ptr<Channel> foundChannel = GetChannel(newChannel.GetServiceReference());
 
@@ -124,7 +125,7 @@ std::vector<std::shared_ptr<Channel>>& Channels::GetChannelsList()
   return m_channels;
 }
 
-std::string Channels::GetChannelIconPath(std::string &channelName)
+std::string Channels::GetChannelIconPath(std::string& channelName)
 {
   for (const auto& channel : m_channels)
   {
@@ -134,7 +135,7 @@ std::string Channels::GetChannelIconPath(std::string &channelName)
   return "";
 }
 
-bool Channels::LoadChannels(ChannelGroups &channelGroups)
+bool Channels::LoadChannels(ChannelGroups& channelGroups)
 {
   m_channelGroups = channelGroups;
 
@@ -162,7 +163,7 @@ bool Channels::LoadChannels(ChannelGroups &channelGroups)
   return bOk;
 }
 
-bool Channels::LoadChannels(const std::string groupServiceReference, const std::string groupName, std::shared_ptr<ChannelGroup> &channelGroup)
+bool Channels::LoadChannels(const std::string groupServiceReference, const std::string groupName, std::shared_ptr<ChannelGroup>& channelGroup)
 {
   Logger::Log(LEVEL_INFO, "%s loading channel group: '%s'", __FUNCTION__, groupName.c_str());
 
@@ -280,7 +281,7 @@ int Channels::LoadChannelsExtraData(const std::shared_ptr<enigma2::data::Channel
               if (!jsonChannel["picon"].empty())
               {
                 std::string connectionURL = Settings::GetInstance().GetConnectionURL();
-                connectionURL = connectionURL.substr(0, connectionURL.size()-1);
+                connectionURL = connectionURL.substr(0, connectionURL.size() - 1);
                 channel->SetIconPath(StringUtils::Format("%s%s", connectionURL.c_str(), jsonChannel["picon"].get<std::string>().c_str()));
 
                 Logger::Log(LEVEL_DEBUG, "%s For Channel %s, using OpenWebPiconPath: %s", __FUNCTION__, jsonChannel["servicename"].get<std::string>().c_str(), channel->GetIconPath().c_str());
@@ -310,7 +311,7 @@ int Channels::LoadChannelsExtraData(const std::shared_ptr<enigma2::data::Channel
   return newChannelPositionOffset;
 }
 
-ChannelsChangeState Channels::CheckForChannelAndGroupChanges(enigma2::ChannelGroups &latestChannelGroups, enigma2::Channels &latestChannels)
+ChannelsChangeState Channels::CheckForChannelAndGroupChanges(enigma2::ChannelGroups& latestChannelGroups, enigma2::Channels& latestChannels)
 {
   if (GetNumChannels() != latestChannels.GetNumChannels())
     return ChannelsChangeState::CHANNELS_CHANGED;

--- a/src/enigma2/Channels.cpp
+++ b/src/enigma2/Channels.cpp
@@ -1,3 +1,25 @@
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
 #include "Channels.h"
 
 #include "../Enigma2.h"

--- a/src/enigma2/Channels.cpp
+++ b/src/enigma2/Channels.cpp
@@ -89,28 +89,20 @@ int Channels::GetChannelUniqueId(const std::string& channelServiceReference)
 
 std::shared_ptr<Channel> Channels::GetChannel(int uniqueId)
 {
-  std::shared_ptr<Channel> channel = nullptr;
-
   auto channelPair = m_channelsUniqueIdMap.find(uniqueId);
   if (channelPair != m_channelsUniqueIdMap.end())
-  {
-    channel = channelPair->second;
-  }
+    return channelPair->second;
 
-  return channel;
+  return {};
 }
 
 std::shared_ptr<Channel> Channels::GetChannel(const std::string& channelServiceReference)
 {
-  std::shared_ptr<Channel> channel = nullptr;
-
   auto channelPair = m_channelsServiceReferenceMap.find(channelServiceReference);
   if (channelPair != m_channelsServiceReferenceMap.end())
-  {
-    channel = channelPair->second;
-  }
+    return channelPair->second;
 
-  return channel;
+  return {};
 }
 
 std::shared_ptr<Channel> Channels::GetChannel(const std::string& channelName, bool isRadio)

--- a/src/enigma2/Channels.h
+++ b/src/enigma2/Channels.h
@@ -1,6 +1,6 @@
 #pragma once
 /*
- *      Copyright (C) 2005-2015 Team XBMC
+ *      Copyright (C) 2005-2019 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify

--- a/src/enigma2/Channels.h
+++ b/src/enigma2/Channels.h
@@ -21,15 +21,14 @@
  *
  */
 
+#include "ChannelGroups.h"
+#include "data/Channel.h"
+#include "kodi/libXBMC_pvr.h"
+
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
-
-#include "ChannelGroups.h"
-#include "data/Channel.h"
-
-#include "kodi/libXBMC_pvr.h"
 
 namespace enigma2
 {
@@ -40,8 +39,7 @@ namespace enigma2
     class ChannelGroup;
   }
 
-  enum class ChannelsChangeState
-    : int // same type as addon settings
+  enum class ChannelsChangeState : int // same type as addon settings
   {
     NO_CHANGE = 0,
     CHANNEL_GROUPS_CHANGED,
@@ -51,25 +49,27 @@ namespace enigma2
   class Channels
   {
   public:
-    void GetChannels(std::vector<PVR_CHANNEL> &timers, bool bRadio) const;
+    void GetChannels(std::vector<PVR_CHANNEL>& timers, bool bRadio) const;
 
-    int GetChannelUniqueId(const std::string &channelServiceReference);
+    int GetChannelUniqueId(const std::string& channelServiceReference);
     std::shared_ptr<enigma2::data::Channel> GetChannel(int uniqueId);
-    std::shared_ptr<enigma2::data::Channel> GetChannel(const std::string &channelServiceReference);
-    std::shared_ptr<enigma2::data::Channel> GetChannel(const std::string &channelName, bool isRadio);
+    std::shared_ptr<enigma2::data::Channel> GetChannel(const std::string& channelServiceReference);
+    std::shared_ptr<enigma2::data::Channel> GetChannel(const std::string& channelName, bool isRadio);
     bool IsValid(int uniqueId) const;
-    bool IsValid(const std::string &channelServiceReference);
+    bool IsValid(const std::string& channelServiceReference);
     int GetNumChannels() const;
     void ClearChannels();
     std::vector<std::shared_ptr<enigma2::data::Channel>>& GetChannelsList();
-    std::string GetChannelIconPath(std::string &channelName);
-    bool LoadChannels(enigma2::ChannelGroups &channelGroups);
+    std::string GetChannelIconPath(std::string& channelName);
+    bool LoadChannels(enigma2::ChannelGroups& channelGroups);
 
-    ChannelsChangeState CheckForChannelAndGroupChanges(enigma2::ChannelGroups &latestChannelGroups, enigma2::Channels &latestChannels);
+    ChannelsChangeState CheckForChannelAndGroupChanges(enigma2::ChannelGroups& latestChannelGroups, enigma2::Channels& latestChannels);
 
   private:
-    void AddChannel(enigma2::data::Channel &channel, std::shared_ptr<enigma2::data::ChannelGroup> &channelGroup);
-    bool LoadChannels(const std::string groupServiceReference, const std::string groupName, std::shared_ptr<enigma2::data::ChannelGroup> &channelGroup);
+    void AddChannel(enigma2::data::Channel& channel, std::shared_ptr<enigma2::data::ChannelGroup>& channelGroup);
+    bool LoadChannels(const std::string groupServiceReference,
+                      const std::string groupName,
+                      std::shared_ptr<enigma2::data::ChannelGroup>& channelGroup);
     int LoadChannelsExtraData(const std::shared_ptr<enigma2::data::ChannelGroup> channelGroup, int lastGroupLatestChannelPosition);
 
     std::vector<std::shared_ptr<enigma2::data::Channel>> m_channels;

--- a/src/enigma2/Channels.h
+++ b/src/enigma2/Channels.h
@@ -55,7 +55,7 @@ namespace enigma2
     std::shared_ptr<enigma2::data::Channel> GetChannel(int uniqueId);
     std::shared_ptr<enigma2::data::Channel> GetChannel(const std::string& channelServiceReference);
     std::shared_ptr<enigma2::data::Channel> GetChannel(const std::string& channelName, bool isRadio);
-    bool IsValid(int uniqueId) const;
+    bool IsValid(int uniqueId);
     bool IsValid(const std::string& channelServiceReference);
     int GetNumChannels() const;
     void ClearChannels();
@@ -73,6 +73,7 @@ namespace enigma2
     int LoadChannelsExtraData(const std::shared_ptr<enigma2::data::ChannelGroup> channelGroup, int lastGroupLatestChannelPosition);
 
     std::vector<std::shared_ptr<enigma2::data::Channel>> m_channels;
+    std::unordered_map<int, std::shared_ptr<enigma2::data::Channel>> m_channelsUniqueIdMap;
     std::unordered_map<std::string, std::shared_ptr<enigma2::data::Channel>> m_channelsServiceReferenceMap;
 
     ChannelGroups m_channelGroups;

--- a/src/enigma2/ConnectionManager.cpp
+++ b/src/enigma2/ConnectionManager.cpp
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2005-2011 Team XBMC
+ *      Copyright (C) 2005-2019 Team XBMC
  *      http://www.xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify

--- a/src/enigma2/ConnectionManager.cpp
+++ b/src/enigma2/ConnectionManager.cpp
@@ -21,12 +21,11 @@
 
 #include "ConnectionManager.h"
 
-#include "p8-platform/os.h"
-#include "p8-platform/util/StringUtils.h"
-
 #include "../client.h"
 #include "IConnectionListener.h"
 #include "Settings.h"
+#include "p8-platform/os.h"
+#include "p8-platform/util/StringUtils.h"
 #include "utilities/Logger.h"
 #include "utilities/WebUtils.h"
 
@@ -38,7 +37,7 @@ using namespace enigma2::utilities;
  * Enigma2 Connection handler
  */
 
-ConnectionManager::ConnectionManager (IConnectionListener& connectionListener)
+ConnectionManager::ConnectionManager(IConnectionListener& connectionListener)
   : m_connectionListener(connectionListener), m_suspended(false), m_state(PVR_CONNECTION_STATE_UNKNOWN)
 {
 }
@@ -81,7 +80,7 @@ void ConnectionManager::OnWake()
   m_suspended = false;
 }
 
-void ConnectionManager::SetState ( PVR_CONNECTION_STATE state )
+void ConnectionManager::SetState(PVR_CONNECTION_STATE state)
 {
   PVR_CONNECTION_STATE prevState(PVR_CONNECTION_STATE_UNKNOWN);
   PVR_CONNECTION_STATE newState(PVR_CONNECTION_STATE_UNKNOWN);
@@ -93,8 +92,8 @@ void ConnectionManager::SetState ( PVR_CONNECTION_STATE state )
     if (m_state != state && !m_suspended)
     {
       prevState = m_state;
-      newState  = state;
-      m_state   = newState;
+      newState = state;
+      m_state = newState;
 
       Logger::Log(LogLevel::LEVEL_DEBUG, "connection state change (%d -> %d)", prevState, newState);
     }

--- a/src/enigma2/ConnectionManager.h
+++ b/src/enigma2/ConnectionManager.h
@@ -1,8 +1,8 @@
 #pragma once
 
 /*
- *      Copyright (C) 2017 Team Kodi
- *      http://kodi.tv
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -16,7 +16,8 @@
  *
  *  You should have received a copy of the GNU General Public License
  *  along with XBMC; see the file COPYING.  If not, write to
- *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
  *  http://www.gnu.org/copyleft/gpl.html
  *
  */

--- a/src/enigma2/ConnectionManager.h
+++ b/src/enigma2/ConnectionManager.h
@@ -21,12 +21,11 @@
  *
  */
 
-#include <string>
-
 #include "kodi/libXBMC_pvr.h"
-
 #include "p8-platform/threads/mutex.h"
 #include "p8-platform/threads/threads.h"
+
+#include <string>
 
 namespace enigma2
 {

--- a/src/enigma2/Epg.cpp
+++ b/src/enigma2/Epg.cpp
@@ -1,17 +1,17 @@
 #include "Epg.h"
 
+#include "../Enigma2.h"
+#include "../client.h"
+#include "p8-platform/util/StringUtils.h"
+#include "util/XMLUtils.h"
+#include "utilities/Logger.h"
+#include "utilities/WebUtils.h"
+
 #include <chrono>
 #include <cmath>
 #include <regex>
 
-#include "../client.h"
-#include "../Enigma2.h"
-#include "utilities/Logger.h"
-#include "utilities/WebUtils.h"
-
 #include <nlohmann/json.hpp>
-#include "util/XMLUtils.h"
-#include "p8-platform/util/StringUtils.h"
 
 using namespace enigma2;
 using namespace enigma2::data;
@@ -20,12 +20,12 @@ using namespace enigma2::utilities;
 using namespace P8PLATFORM;
 using json = nlohmann::json;
 
-Epg::Epg(enigma2::extract::EpgEntryExtractor &entryExtractor, int epgMaxDays)
+Epg::Epg(enigma2::extract::EpgEntryExtractor& entryExtractor, int epgMaxDays)
       : m_entryExtractor(entryExtractor), m_epgMaxDays(epgMaxDays) {}
 
-Epg::Epg(const Epg &epg) : m_entryExtractor(epg.m_entryExtractor) {}
+Epg::Epg(const Epg& epg) : m_entryExtractor(epg.m_entryExtractor) {}
 
-bool Epg::Initialise(enigma2::Channels &channels, enigma2::ChannelGroups &channelGroups)
+bool Epg::Initialise(enigma2::Channels& channels, enigma2::ChannelGroups& channelGroups)
 {
   m_epgMaxDaysSeconds = m_epgMaxDays * 24 * 60 * 60;
 
@@ -94,8 +94,7 @@ bool Epg::Initialise(enigma2::Channels &channels, enigma2::ChannelGroups &channe
       break;
   }
 
-  int milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(
-                      std::chrono::high_resolution_clock::now() - started).count();
+  int milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - started).count();
 
   Logger::Log(LEVEL_NOTICE, "%s Initial EPG Loaded - %d (ms)", __FUNCTION__, milliseconds);
 
@@ -104,7 +103,7 @@ bool Epg::Initialise(enigma2::Channels &channels, enigma2::ChannelGroups &channe
   return true;
 }
 
-std::shared_ptr<data::EpgChannel> Epg::GetEpgChannel(const std::string &serviceReference)
+std::shared_ptr<data::EpgChannel> Epg::GetEpgChannel(const std::string& serviceReference)
 {
   std::shared_ptr<data::EpgChannel> epgChannel = std::make_shared<data::EpgChannel>();
 
@@ -115,7 +114,7 @@ std::shared_ptr<data::EpgChannel> Epg::GetEpgChannel(const std::string &serviceR
   return epgChannel;
 }
 
-std::shared_ptr<data::EpgChannel> Epg::GetEpgChannelNeedingInitialEpg(const std::string &serviceReference)
+std::shared_ptr<data::EpgChannel> Epg::GetEpgChannelNeedingInitialEpg(const std::string& serviceReference)
 {
   std::shared_ptr<data::EpgChannel> epgChannel = std::make_shared<data::EpgChannel>();
 
@@ -126,14 +125,14 @@ std::shared_ptr<data::EpgChannel> Epg::GetEpgChannelNeedingInitialEpg(const std:
   return epgChannel;
 }
 
-bool Epg::ChannelNeedsInitialEpg(const std::string &serviceReference)
+bool Epg::ChannelNeedsInitialEpg(const std::string& serviceReference)
 {
   auto needsInitialEpgSearch = m_needsInitialEpgChannelsMap.find(serviceReference);
 
   return needsInitialEpgSearch != m_needsInitialEpgChannelsMap.end();
 }
 
-bool Epg::InitialEpgLoadedForChannel(const std::string &serviceReference)
+bool Epg::InitialEpgLoadedForChannel(const std::string& serviceReference)
 {
   return m_needsInitialEpgChannelsMap.erase(serviceReference) == 1;
 }
@@ -162,7 +161,7 @@ void Epg::TriggerEpgUpdatesForChannels()
   }
 }
 
-void Epg::MarkChannelAsInitialEpgRead(const std::string &serviceReference)
+void Epg::MarkChannelAsInitialEpgRead(const std::string& serviceReference)
 {
   std::shared_ptr<data::EpgChannel> epgChannel = GetEpgChannel(serviceReference);
 
@@ -174,7 +173,7 @@ void Epg::MarkChannelAsInitialEpgRead(const std::string &serviceReference)
   }
 }
 
-PVR_ERROR Epg::GetEPGForChannel(ADDON_HANDLE handle, const std::string &serviceReference, time_t iStart, time_t iEnd)
+PVR_ERROR Epg::GetEPGForChannel(ADDON_HANDLE handle, const std::string& serviceReference, time_t iStart, time_t iEnd)
 {
   std::shared_ptr<data::EpgChannel> epgChannel = GetEpgChannel(serviceReference);
 
@@ -189,8 +188,8 @@ PVR_ERROR Epg::GetEPGForChannel(ADDON_HANDLE handle, const std::string &serviceR
       return TransferInitialEPGForChannel(handle, epgChannel, iStart, iEnd);
     }
 
-    const std::string url = StringUtils::Format("%s%s%s",  Settings::GetInstance().GetConnectionURL().c_str(), "web/epgservice?sRef=",
-                                                WebUtils::URLEncodeInline(serviceReference).c_str());
+    const std::string url = StringUtils::Format("%s%s%s", Settings::GetInstance().GetConnectionURL().c_str(),
+                                                "web/epgservice?sRef=", WebUtils::URLEncodeInline(serviceReference).c_str());
 
     const std::string strXML = WebUtils::GetHttpXML(url);
 
@@ -259,7 +258,7 @@ PVR_ERROR Epg::GetEPGForChannel(ADDON_HANDLE handle, const std::string &serviceR
   return PVR_ERROR_NO_ERROR;
 }
 
-PVR_ERROR Epg::TransferInitialEPGForChannel(ADDON_HANDLE handle, const std::shared_ptr<EpgChannel> &epgChannel, time_t iStart, time_t iEnd)
+PVR_ERROR Epg::TransferInitialEPGForChannel(ADDON_HANDLE handle, const std::shared_ptr<EpgChannel>& epgChannel, time_t iStart, time_t iEnd)
 {
   for (const auto& entry : epgChannel->GetInitialEPG())
   {
@@ -278,11 +277,12 @@ PVR_ERROR Epg::TransferInitialEPGForChannel(ADDON_HANDLE handle, const std::shar
   return PVR_ERROR_NO_ERROR;
 }
 
-std::string Epg::LoadEPGEntryShortDescription(const std::string &serviceReference, unsigned int epgUid)
+std::string Epg::LoadEPGEntryShortDescription(const std::string& serviceReference, unsigned int epgUid)
 {
   std::string shortDescription;
 
-  const std::string jsonUrl = StringUtils::Format("%sapi/event?sref=%s&idev=%u", Settings::GetInstance().GetConnectionURL().c_str(), WebUtils::URLEncodeInline(serviceReference).c_str(), epgUid);
+  const std::string jsonUrl = StringUtils::Format("%sapi/event?sref=%s&idev=%u", Settings::GetInstance().GetConnectionURL().c_str(),
+                                                  WebUtils::URLEncodeInline(serviceReference).c_str(), epgUid);
 
   const std::string strJson = WebUtils::GetHttpXML(jsonUrl);
 
@@ -314,11 +314,12 @@ std::string Epg::LoadEPGEntryShortDescription(const std::string &serviceReferenc
   return shortDescription;
 }
 
-EpgPartialEntry Epg::LoadEPGEntryPartialDetails(const std::string &serviceReference, unsigned int epgUid)
+EpgPartialEntry Epg::LoadEPGEntryPartialDetails(const std::string& serviceReference, unsigned int epgUid)
 {
   EpgPartialEntry partialEntry;
 
-  const std::string jsonUrl = StringUtils::Format("%sapi/event?sref=%s&idev=%u", Settings::GetInstance().GetConnectionURL().c_str(), WebUtils::URLEncodeInline(serviceReference).c_str(), epgUid);
+  const std::string jsonUrl = StringUtils::Format("%sapi/event?sref=%s&idev=%u", Settings::GetInstance().GetConnectionURL().c_str(),
+                                                  WebUtils::URLEncodeInline(serviceReference).c_str(), epgUid);
 
   const std::string strJson = WebUtils::GetHttpXML(jsonUrl);
 
@@ -364,7 +365,7 @@ EpgPartialEntry Epg::LoadEPGEntryPartialDetails(const std::string &serviceRefere
   return partialEntry;
 }
 
-EpgPartialEntry Epg::LoadEPGEntryPartialDetails(const std::string &serviceReference, time_t startTime)
+EpgPartialEntry Epg::LoadEPGEntryPartialDetails(const std::string& serviceReference, time_t startTime)
 {
   EpgPartialEntry partialEntry;
 
@@ -419,7 +420,7 @@ EpgPartialEntry Epg::LoadEPGEntryPartialDetails(const std::string &serviceRefere
   return partialEntry;
 }
 
-std::string Epg::FindServiceReference(const std::string &title, int epgUid, time_t startTime, time_t endTime) const
+std::string Epg::FindServiceReference(const std::string& title, int epgUid, time_t startTime, time_t endTime) const
 {
   std::string serviceReference;
 
@@ -458,8 +459,7 @@ std::string Epg::FindServiceReference(const std::string &title, int epgUid, time
     Logger::Log(LEVEL_ERROR, "%s JSON type error - message: %s, exception id: %d", __FUNCTION__, e.what(), e.id);
   }
 
-  int milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(
-                      std::chrono::high_resolution_clock::now() - started).count();
+  int milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - started).count();
 
   Logger::Log(LEVEL_DEBUG, "%s Service reference search time - %d (ms)", __FUNCTION__, milliseconds);
 
@@ -468,8 +468,8 @@ std::string Epg::FindServiceReference(const std::string &title, int epgUid, time
 
 bool Epg::LoadInitialEPGForGroup(const std::shared_ptr<ChannelGroup> group)
 {
-  const std::string url = StringUtils::Format("%s%s%s",  Settings::GetInstance().GetConnectionURL().c_str(), "web/epgnownext?bRef=",
-                                                WebUtils::URLEncodeInline(group->GetServiceReference()).c_str());
+  const std::string url = StringUtils::Format("%s%s%s", Settings::GetInstance().GetConnectionURL().c_str(),
+                                              "web/epgnownext?bRef=", WebUtils::URLEncodeInline(group->GetServiceReference()).c_str());
 
   const std::string strXML = WebUtils::GetHttpXML(url);
 
@@ -526,7 +526,7 @@ bool Epg::LoadInitialEPGForGroup(const std::shared_ptr<ChannelGroup> group)
   return true;
 }
 
-void Epg::UpdateTimerEPGFallbackEntries(const std::vector<enigma2::data::EpgEntry> &timerBasedEntries)
+void Epg::UpdateTimerEPGFallbackEntries(const std::vector<enigma2::data::EpgEntry>& timerBasedEntries)
 {
   CLockObject lock(m_mutex);
   time_t now = time(nullptr);

--- a/src/enigma2/Epg.cpp
+++ b/src/enigma2/Epg.cpp
@@ -1,3 +1,25 @@
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
 #include "Epg.h"
 
 #include "../Enigma2.h"

--- a/src/enigma2/Epg.h
+++ b/src/enigma2/Epg.h
@@ -1,6 +1,6 @@
 #pragma once
 /*
- *      Copyright (C) 2005-2015 Team XBMC
+ *      Copyright (C) 2005-2019 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify

--- a/src/enigma2/Epg.h
+++ b/src/enigma2/Epg.h
@@ -21,20 +21,18 @@
  *
  */
 
+#include "ChannelGroups.h"
+#include "Channels.h"
+#include "data/EpgChannel.h"
+#include "data/EpgPartialEntry.h"
+#include "extract/EpgEntryExtractor.h"
+#include "kodi/libXBMC_pvr.h"
+#include "p8-platform/threads/threads.h"
+
 #include <map>
 #include <memory>
 #include <string>
 #include <vector>
-
-#include "Channels.h"
-#include "ChannelGroups.h"
-#include "data/EpgPartialEntry.h"
-#include "data/EpgChannel.h"
-#include "extract/EpgEntryExtractor.h"
-
-#include "kodi/libXBMC_pvr.h"
-
-#include "p8-platform/threads/threads.h"
 
 namespace enigma2
 {
@@ -43,31 +41,31 @@ namespace enigma2
   class Epg
   {
   public:
-    Epg(enigma2::extract::EpgEntryExtractor &entryExtractor, int epgMaxDays);
+    Epg(enigma2::extract::EpgEntryExtractor& entryExtractor, int epgMaxDays);
     Epg(const enigma2::Epg& epg);
 
-    bool Initialise(enigma2::Channels &channels, enigma2::ChannelGroups &channelGroups);
+    bool Initialise(enigma2::Channels& channels, enigma2::ChannelGroups& channelGroups);
     bool IsInitialEpgCompleted();
     void TriggerEpgUpdatesForChannels();
-    void MarkChannelAsInitialEpgRead(const std::string &serviceReference);
-    PVR_ERROR GetEPGForChannel(ADDON_HANDLE handle, const std::string &serviceReference, time_t iStart, time_t iEnd);
-    std::string LoadEPGEntryShortDescription(const std::string &serviceReference, unsigned int epgUid);
-    data::EpgPartialEntry LoadEPGEntryPartialDetails(const std::string &serviceReference, time_t startTime);
-    data::EpgPartialEntry LoadEPGEntryPartialDetails(const std::string &serviceReference, unsigned int epgUid);
-    std::string FindServiceReference(const std::string &title, int epgUid, time_t startTime, time_t endTime) const;
-    void UpdateTimerEPGFallbackEntries(const std::vector<enigma2::data::EpgEntry> &timerBasedEntries);
+    void MarkChannelAsInitialEpgRead(const std::string& serviceReference);
+    PVR_ERROR GetEPGForChannel(ADDON_HANDLE handle, const std::string& serviceReference, time_t iStart, time_t iEnd);
+    std::string LoadEPGEntryShortDescription(const std::string& serviceReference, unsigned int epgUid);
+    data::EpgPartialEntry LoadEPGEntryPartialDetails(const std::string& serviceReference, time_t startTime);
+    data::EpgPartialEntry LoadEPGEntryPartialDetails(const std::string& serviceReference, unsigned int epgUid);
+    std::string FindServiceReference(const std::string& title, int epgUid, time_t startTime, time_t endTime) const;
+    void UpdateTimerEPGFallbackEntries(const std::vector<enigma2::data::EpgEntry>& timerBasedEntries);
 
   private:
-    PVR_ERROR TransferInitialEPGForChannel(ADDON_HANDLE handle, const std::shared_ptr<data::EpgChannel> &epgChannel, time_t iStart, time_t iEnd);
-    std::shared_ptr<data::EpgChannel> GetEpgChannel(const std::string &serviceReference);
+    PVR_ERROR TransferInitialEPGForChannel(ADDON_HANDLE handle, const std::shared_ptr<data::EpgChannel>& epgChannel, time_t iStart, time_t iEnd);
+    std::shared_ptr<data::EpgChannel> GetEpgChannel(const std::string& serviceReference);
     bool LoadInitialEPGForGroup(const std::shared_ptr<enigma2::data::ChannelGroup> group);
-    bool ChannelNeedsInitialEpg(const std::string &serviceReference);
-    bool InitialEpgLoadedForChannel(const std::string &serviceReference);
-    bool InitialEpgReadForChannel(const std::string &serviceReference);
-    std::shared_ptr<data::EpgChannel> GetEpgChannelNeedingInitialEpg(const std::string &serviceReference);
+    bool ChannelNeedsInitialEpg(const std::string& serviceReference);
+    bool InitialEpgLoadedForChannel(const std::string& serviceReference);
+    bool InitialEpgReadForChannel(const std::string& serviceReference);
+    std::shared_ptr<data::EpgChannel> GetEpgChannelNeedingInitialEpg(const std::string& serviceReference);
     int TransferTimerBasedEntries(ADDON_HANDLE handle, int epgChannelId);
 
-    enigma2::extract::EpgEntryExtractor &m_entryExtractor;
+    enigma2::extract::EpgEntryExtractor& m_entryExtractor;
 
     bool m_initialEpgReady = false;
     int m_epgMaxDays;

--- a/src/enigma2/IConnectionListener.h
+++ b/src/enigma2/IConnectionListener.h
@@ -1,8 +1,8 @@
 #pragma once
 
 /*
- *      Copyright (C) 2017 Team Kodi
- *      http://kodi.tv
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -16,7 +16,8 @@
  *
  *  You should have received a copy of the GNU General Public License
  *  along with XBMC; see the file COPYING.  If not, write to
- *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
  *  http://www.gnu.org/copyleft/gpl.html
  *
  */

--- a/src/enigma2/IStreamReader.h
+++ b/src/enigma2/IStreamReader.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <ctime>
-
 #include "kodi/libXBMC_addon.h"
+
+#include <ctime>
 
 namespace enigma2
 {
@@ -11,7 +11,7 @@ namespace enigma2
   public:
     virtual ~IStreamReader(void) = default;
     virtual bool Start() = 0;
-    virtual ssize_t ReadData(unsigned char *buffer, unsigned int size) = 0;
+    virtual ssize_t ReadData(unsigned char* buffer, unsigned int size) = 0;
     virtual int64_t Seek(long long position, int whence) = 0;
     virtual int64_t Position() = 0;
     virtual int64_t Length() = 0;

--- a/src/enigma2/IStreamReader.h
+++ b/src/enigma2/IStreamReader.h
@@ -1,4 +1,25 @@
 #pragma once
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
 
 #include "kodi/libXBMC_addon.h"
 

--- a/src/enigma2/LocalizedString.h
+++ b/src/enigma2/LocalizedString.h
@@ -1,4 +1,25 @@
 #pragma once
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
 
 #include "client.h"
 

--- a/src/enigma2/LocalizedString.h
+++ b/src/enigma2/LocalizedString.h
@@ -16,7 +16,7 @@ namespace enigma2
 
     bool Load(int id)
     {
-      char *str;
+      char* str;
       if ((str = XBMC->GetLocalizedString(id)))
       {
         m_localizedString = str;
@@ -46,7 +46,7 @@ namespace enigma2
   private:
     LocalizedString() = delete;
     LocalizedString(const LocalizedString&) = delete;
-    LocalizedString &operator =(const LocalizedString&) = delete;
+    LocalizedString& operator=(const LocalizedString&) = delete;
 
     std::string m_localizedString;
   };

--- a/src/enigma2/RecordingReader.cpp
+++ b/src/enigma2/RecordingReader.cpp
@@ -1,17 +1,16 @@
 #include "RecordingReader.h"
 
-#include <algorithm>
-
 #include "../client.h"
+#include "p8-platform/threads/mutex.h"
 #include "utilities/Logger.h"
 
-#include "p8-platform/threads/mutex.h"
+#include <algorithm>
 
 using namespace ADDON;
 using namespace enigma2;
 using namespace enigma2::utilities;
 
-RecordingReader::RecordingReader(const std::string &streamURL, std::time_t start, std::time_t end, int duration)
+RecordingReader::RecordingReader(const std::string& streamURL, std::time_t start, std::time_t end, int duration)
   : m_streamURL(streamURL), m_start(start), m_end(end), m_duration(duration)
 {
   m_readHandle = XBMC->CURLCreate(m_streamURL.c_str());
@@ -25,8 +24,8 @@ RecordingReader::RecordingReader(const std::string &streamURL, std::time_t start
     m_duration = static_cast<int>(end - start);
   }
 
-  Logger::Log(LEVEL_DEBUG, "%s RecordingReader: Started - url=%s, start=%u, end=%u, duration=%d", __FUNCTION__,
-      m_streamURL.c_str(), m_start, m_end, m_duration);
+  Logger::Log(LEVEL_DEBUG, "%s RecordingReader: Started - url=%s, start=%u, end=%u, duration=%d", __FUNCTION__, m_streamURL.c_str(),
+              m_start, m_end, m_duration);
 }
 
 RecordingReader::~RecordingReader(void)
@@ -41,7 +40,7 @@ bool RecordingReader::Start()
   return (m_readHandle != nullptr);
 }
 
-ssize_t RecordingReader::ReadData(unsigned char *buffer, unsigned int size)
+ssize_t RecordingReader::ReadData(unsigned char* buffer, unsigned int size)
 {
   /* check for playback of ongoing recording */
   if (m_end)

--- a/src/enigma2/RecordingReader.cpp
+++ b/src/enigma2/RecordingReader.cpp
@@ -1,3 +1,25 @@
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
 #include "RecordingReader.h"
 
 #include "../client.h"

--- a/src/enigma2/RecordingReader.h
+++ b/src/enigma2/RecordingReader.h
@@ -1,4 +1,25 @@
 #pragma once
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
 
 #include "kodi/libXBMC_addon.h"
 

--- a/src/enigma2/RecordingReader.h
+++ b/src/enigma2/RecordingReader.h
@@ -1,20 +1,20 @@
 #pragma once
 
+#include "kodi/libXBMC_addon.h"
+
 #include <ctime>
 #include <string>
-
-#include "kodi/libXBMC_addon.h"
 
 namespace enigma2
 {
   class RecordingReader
   {
   public:
-    RecordingReader(const std::string &streamURL, std::time_t start, std::time_t end, int duration);
+    RecordingReader(const std::string& streamURL, std::time_t start, std::time_t end, int duration);
     ~RecordingReader(void);
 
     bool Start();
-    ssize_t ReadData(unsigned char *buffer, unsigned int size);
+    ssize_t ReadData(unsigned char* buffer, unsigned int size);
     int64_t Seek(long long position, int whence);
     int64_t Position();
     int64_t Length();
@@ -25,8 +25,8 @@ namespace enigma2
     static const int REOPEN_INTERVAL = 30;
     static const int REOPEN_INTERVAL_FAST = 10;
 
-    const std::string &m_streamURL;
-    void *m_readHandle;
+    const std::string& m_streamURL;
+    void* m_readHandle;
 
     int m_duration;
 
@@ -35,7 +35,7 @@ namespace enigma2
     std::time_t m_end;
 
     std::time_t m_nextReopen;
-    uint64_t m_pos = { 0 };
+    uint64_t m_pos = {0};
     uint64_t m_len;
   };
 } // namespace enigma2

--- a/src/enigma2/Recordings.cpp
+++ b/src/enigma2/Recordings.cpp
@@ -470,7 +470,7 @@ PVR_ERROR Recordings::UndeleteRecording(const PVR_RECORDING& recording)
 
   std::regex regex(TRASH_FOLDER);
 
-  const std::string newRecordingDirectory = regex_replace(recordingEntry.GetDirectory(), regex, "");
+  const std::string newRecordingDirectory = std::regex_replace(recordingEntry.GetDirectory(), regex, "");
 
   const std::string strTmp = StringUtils::Format("web/moviemove?sRef=%s&dirname=%s", WebUtils::URLEncodeInline(recordingEntry.GetRecordingId()).c_str(), WebUtils::URLEncodeInline(newRecordingDirectory).c_str());
 

--- a/src/enigma2/Recordings.cpp
+++ b/src/enigma2/Recordings.cpp
@@ -1,17 +1,17 @@
 #include "Recordings.h"
 
+#include "../Enigma2.h"
+#include "../client.h"
+#include "p8-platform/util/StringUtils.h"
+#include "util/XMLUtils.h"
+#include "utilities/Logger.h"
+#include "utilities/WebUtils.h"
+
 #include <iostream>
 #include <regex>
 #include <sstream>
 
-#include "../client.h"
-#include "../Enigma2.h"
-#include "utilities/Logger.h"
-#include "utilities/WebUtils.h"
-
 #include <nlohmann/json.hpp>
-#include "util/XMLUtils.h"
-#include "p8-platform/util/StringUtils.h"
 
 using namespace enigma2;
 using namespace enigma2::data;
@@ -21,15 +21,15 @@ using json = nlohmann::json;
 
 const std::string Recordings::FILE_NOT_FOUND_RESPONSE_SUFFIX = "not found";
 
-Recordings::Recordings(Channels &channels, enigma2::extract::EpgEntryExtractor &entryExtractor)
+Recordings::Recordings(Channels& channels, enigma2::extract::EpgEntryExtractor& entryExtractor)
       : m_channels(channels), m_entryExtractor(entryExtractor)
 {
-  std::random_device randomDevice;  //Will be used to obtain a seed for the random number engine
+  std::random_device randomDevice; //Will be used to obtain a seed for the random number engine
   m_randomGenerator = std::mt19937(randomDevice()); //Standard mersenne_twister_engine seeded with randomDevice()
   m_randomDistribution = std::uniform_int_distribution<>(E2_DEVICE_LAST_PLAYED_SYNC_INTERVAL_MIN, E2_DEVICE_LAST_PLAYED_SYNC_INTERVAL_MAX);
 }
 
-void Recordings::GetRecordings(std::vector<PVR_RECORDING> &kodiRecordings, bool deleted)
+void Recordings::GetRecordings(std::vector<PVR_RECORDING>& kodiRecordings, bool deleted)
 {
   auto& recordings = (!deleted) ? m_recordings : m_deletedRecordings;
 
@@ -57,7 +57,7 @@ void Recordings::ClearRecordings(bool deleted)
 
   recordings.clear();
 
-  for (auto it = m_recordingsIdMap.begin(); it != m_recordingsIdMap.end(); )
+  for (auto it = m_recordingsIdMap.begin(); it != m_recordingsIdMap.end();)
   {
     if (it->second.IsDeleted() == deleted)
       it = m_recordingsIdMap.erase(it);
@@ -66,7 +66,7 @@ void Recordings::ClearRecordings(bool deleted)
   }
 }
 
-void Recordings::GetRecordingEdl(const std::string &recordingId, std::vector<PVR_EDL_ENTRY> &edlEntries) const
+void Recordings::GetRecordingEdl(const std::string& recordingId, std::vector<PVR_EDL_ENTRY>& edlEntries) const
 {
   const RecordingEntry recordingEntry = GetRecording(recordingId);
 
@@ -86,24 +86,25 @@ void Recordings::GetRecordingEdl(const std::string &recordingId, std::vector<PVR
         lineNumber++;
         if (std::sscanf(line.c_str(), "%f %f %u", &start, &stop, &type) < 2 || type > PVR_EDL_TYPE_COMBREAK)
         {
-          Logger::Log(LEVEL_NOTICE, "%s Unable to parse EDL entry for recording '%s' at line %d. Skipping.", __FUNCTION__, recordingEntry.GetTitle().c_str(), lineNumber);
+          Logger::Log(LEVEL_NOTICE, "%s Unable to parse EDL entry for recording '%s' at line %d. Skipping.", __FUNCTION__,
+                      recordingEntry.GetTitle().c_str(), lineNumber);
           continue;
         }
 
         start += static_cast<float>(Settings::GetInstance().GetEDLStartTimePadding()) / 1000.0f;
-        stop  += static_cast<float>(Settings::GetInstance().GetEDLStopTimePadding()) / 1000.0f;
+        stop += static_cast<float>(Settings::GetInstance().GetEDLStopTimePadding()) / 1000.0f;
 
         start = std::max(start, 0.0f);
-        stop  = std::max(stop,  0.0f);
+        stop = std::max(stop, 0.0f);
         start = std::min(start, stop);
-        stop  = std::max(start, stop);
+        stop = std::max(start, stop);
 
         Logger::Log(LEVEL_NOTICE, "%s EDL for '%s', line %d -  start: %f stop: %f type: %d", __FUNCTION__, recordingEntry.GetTitle().c_str(), lineNumber, start, stop, type);
 
         PVR_EDL_ENTRY edlEntry;
         edlEntry.start = static_cast<int64_t>(start * 1000.0f);
-        edlEntry.end   = static_cast<int64_t>(stop  * 1000.0f);
-        edlEntry.type  = static_cast<PVR_EDL_TYPE>(type);
+        edlEntry.end = static_cast<int64_t>(stop * 1000.0f);
+        edlEntry.type = static_cast<PVR_EDL_TYPE>(type);
 
         edlEntries.emplace_back(edlEntry);
       }
@@ -111,7 +112,7 @@ void Recordings::GetRecordingEdl(const std::string &recordingId, std::vector<PVR
   }
 }
 
-RecordingEntry Recordings::GetRecording(const std::string &recordingId) const
+RecordingEntry Recordings::GetRecording(const std::string& recordingId) const
 {
   RecordingEntry entry;
 
@@ -124,7 +125,7 @@ RecordingEntry Recordings::GetRecording(const std::string &recordingId) const
   return entry;
 }
 
-bool Recordings::IsInRecordingFolder(const std::string &recordingFolder, bool deleted) const
+bool Recordings::IsInRecordingFolder(const std::string& recordingFolder, bool deleted) const
 {
   const auto& recordings = (!deleted) ? m_recordings : m_deletedRecordings;
 
@@ -146,14 +147,16 @@ bool Recordings::IsInRecordingFolder(const std::string &recordingFolder, bool de
   return false;
 }
 
-PVR_ERROR Recordings::RenameRecording(const PVR_RECORDING &recording)
+PVR_ERROR Recordings::RenameRecording(const PVR_RECORDING& recording)
 {
   auto recordingEntry = GetRecording(recording.strRecordingId);
 
   if (!recordingEntry.GetRecordingId().empty())
   {
     Logger::Log(LEVEL_DEBUG, "%s Sending rename command for recording '%s' to '%s'", __FUNCTION__, recordingEntry.GetTitle().c_str(), recording.strTitle);
-    const std::string jsonUrl = StringUtils::Format("%sapi/movieinfo?sref=%s&title=%s", Settings::GetInstance().GetConnectionURL().c_str(), WebUtils::URLEncodeInline(recordingEntry.GetRecordingId()).c_str(), WebUtils::URLEncodeInline(recording.strTitle).c_str());
+    const std::string jsonUrl = StringUtils::Format("%sapi/movieinfo?sref=%s&title=%s", Settings::GetInstance().GetConnectionURL().c_str(),
+                                                    WebUtils::URLEncodeInline(recordingEntry.GetRecordingId()).c_str(),
+                                                    WebUtils::URLEncodeInline(recording.strTitle).c_str());
     std::string strResult;
 
     if (WebUtils::SendSimpleJsonCommand(jsonUrl, strResult))
@@ -168,7 +171,7 @@ PVR_ERROR Recordings::RenameRecording(const PVR_RECORDING &recording)
   return PVR_ERROR_SERVER_ERROR;
 }
 
-PVR_ERROR Recordings::SetRecordingPlayCount(const PVR_RECORDING &recording, int count)
+PVR_ERROR Recordings::SetRecordingPlayCount(const PVR_RECORDING& recording, int count)
 {
   auto recordingEntry = GetRecording(recording.strRecordingId);
 
@@ -214,7 +217,7 @@ PVR_ERROR Recordings::SetRecordingPlayCount(const PVR_RECORDING &recording, int 
   return PVR_ERROR_SERVER_ERROR;
 }
 
-PVR_ERROR Recordings::SetRecordingLastPlayedPosition(const PVR_RECORDING &recording, int lastPlayedPosition)
+PVR_ERROR Recordings::SetRecordingLastPlayedPosition(const PVR_RECORDING& recording, int lastPlayedPosition)
 {
   auto recordingEntry = GetRecording(recording.strRecordingId);
 
@@ -310,7 +313,7 @@ PVR_ERROR Recordings::SetRecordingLastPlayedPosition(const PVR_RECORDING &record
   return PVR_ERROR_SERVER_ERROR;
 }
 
-int Recordings::GetRecordingLastPlayedPosition(const PVR_RECORDING &recording)
+int Recordings::GetRecordingLastPlayedPosition(const PVR_RECORDING& recording)
 {
   auto recordingEntry = GetRecording(recording.strRecordingId);
 
@@ -392,7 +395,7 @@ int Recordings::GetRecordingLastPlayedPosition(const PVR_RECORDING &recording)
   }
 }
 
-void Recordings::SetRecordingNextSyncTime(RecordingEntry &recordingEntry, time_t nextSyncTime, std::vector<std::string> &oldTags)
+void Recordings::SetRecordingNextSyncTime(RecordingEntry& recordingEntry, time_t nextSyncTime, std::vector<std::string>& oldTags)
 {
   Logger::Log(LEVEL_DEBUG, "%s Setting next sync time in tags for recording '%s' to '%ld'", __FUNCTION__, recordingEntry.GetTitle().c_str(), nextSyncTime);
 
@@ -425,12 +428,12 @@ void Recordings::SetRecordingNextSyncTime(RecordingEntry &recordingEntry, time_t
   }
 }
 
-PVR_ERROR Recordings::DeleteRecording(const PVR_RECORDING &recinfo)
+PVR_ERROR Recordings::DeleteRecording(const PVR_RECORDING& recinfo)
 {
   const std::string strTmp = StringUtils::Format("web/moviedelete?sRef=%s", WebUtils::URLEncodeInline(recinfo.strRecordingId).c_str());
 
   std::string strResult;
-  if(!WebUtils::SendSimpleCommand(strTmp, strResult))
+  if (!WebUtils::SendSimpleCommand(strTmp, strResult))
     return PVR_ERROR_FAILED;
 
   // No need to call PVR->TriggerRecordingUpdate() as it is handled by kodi PVR.
@@ -450,7 +453,7 @@ PVR_ERROR Recordings::UndeleteRecording(const PVR_RECORDING& recording)
   const std::string strTmp = StringUtils::Format("web/moviemove?sRef=%s&dirname=%s", WebUtils::URLEncodeInline(recordingEntry.GetRecordingId()).c_str(), WebUtils::URLEncodeInline(newRecordingDirectory).c_str());
 
   std::string strResult;
-  if(!WebUtils::SendSimpleCommand(strTmp, strResult))
+  if (!WebUtils::SendSimpleCommand(strTmp, strResult))
     return PVR_ERROR_FAILED;
 
   return PVR_ERROR_NO_ERROR;
@@ -458,9 +461,10 @@ PVR_ERROR Recordings::UndeleteRecording(const PVR_RECORDING& recording)
 
 PVR_ERROR Recordings::DeleteAllRecordingsFromTrash()
 {
-  for (const auto &deletedRecording : m_deletedRecordings)
+  for (const auto& deletedRecording : m_deletedRecordings)
   {
-    const std::string strTmp = StringUtils::Format("web/moviedelete?sRef=%s", WebUtils::URLEncodeInline(deletedRecording.GetRecordingId()).c_str());
+    const std::string strTmp =
+        StringUtils::Format("web/moviedelete?sRef=%s", WebUtils::URLEncodeInline(deletedRecording.GetRecordingId()).c_str());
 
     std::string strResult;
     WebUtils::SendSimpleCommand(strTmp, strResult, true);
@@ -479,7 +483,7 @@ int Recordings::GetRecordingStreamProgramNumber(const PVR_RECORDING& recording)
   return GetRecording(recording.strRecordingId).GetStreamProgramNumber();
 }
 
-const std::string Recordings::GetRecordingURL(const PVR_RECORDING &recinfo)
+const std::string Recordings::GetRecordingURL(const PVR_RECORDING& recinfo)
 {
   for (const auto& recording : m_recordings)
   {
@@ -489,9 +493,10 @@ const std::string Recordings::GetRecordingURL(const PVR_RECORDING &recinfo)
   return "";
 }
 
-bool Recordings::ReadExtaRecordingCutsInfo(const data::RecordingEntry &recordingEntry, std::vector<std::pair<int, int64_t>> &cuts, std::vector<std::string> &tags)
+bool Recordings::ReadExtaRecordingCutsInfo(const data::RecordingEntry& recordingEntry, std::vector<std::pair<int, int64_t>>& cuts, std::vector<std::string>& tags)
 {
-  const std::string jsonUrl = StringUtils::Format("%sapi/movieinfo?sref=%s", Settings::GetInstance().GetConnectionURL().c_str(), WebUtils::URLEncodeInline(recordingEntry.GetRecordingId()).c_str());
+  const std::string jsonUrl = StringUtils::Format("%sapi/movieinfo?sref=%s", Settings::GetInstance().GetConnectionURL().c_str(),
+                                                  WebUtils::URLEncodeInline(recordingEntry.GetRecordingId()).c_str());
 
   const std::string strJson = WebUtils::GetHttpXML(jsonUrl);
 
@@ -546,9 +551,10 @@ bool Recordings::ReadExtaRecordingCutsInfo(const data::RecordingEntry &recording
   return false;
 }
 
-bool Recordings::ReadExtraRecordingPlayCountInfo(const data::RecordingEntry &recordingEntry, std::vector<std::string> &tags)
+bool Recordings::ReadExtraRecordingPlayCountInfo(const data::RecordingEntry& recordingEntry, std::vector<std::string>& tags)
 {
-  const std::string jsonUrl = StringUtils::Format("%sapi/movieinfo?sref=%s", Settings::GetInstance().GetConnectionURL().c_str(), WebUtils::URLEncodeInline(recordingEntry.GetRecordingId()).c_str());
+  const std::string jsonUrl = StringUtils::Format("%sapi/movieinfo?sref=%s", Settings::GetInstance().GetConnectionURL().c_str(),
+                                                  WebUtils::URLEncodeInline(recordingEntry.GetRecordingId()).c_str());
 
   const std::string strJson = WebUtils::GetHttpXML(jsonUrl);
 
@@ -598,9 +604,9 @@ bool Recordings::LoadLocations()
 {
   std::string url;
   if (Settings::GetInstance().GetRecordingsFromCurrentLocationOnly())
-    url = StringUtils::Format("%s%s",  Settings::GetInstance().GetConnectionURL().c_str(), "web/getcurrlocation");
+    url = StringUtils::Format("%s%s", Settings::GetInstance().GetConnectionURL().c_str(), "web/getcurrlocation");
   else
-    url = StringUtils::Format("%s%s",  Settings::GetInstance().GetConnectionURL().c_str(), "web/getlocations");
+    url = StringUtils::Format("%s%s", Settings::GetInstance().GetConnectionURL().c_str(), "web/getlocations");
 
   const std::string strXML = WebUtils::GetHttpXML(url);
 

--- a/src/enigma2/Recordings.cpp
+++ b/src/enigma2/Recordings.cpp
@@ -1,3 +1,25 @@
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
 #include "Recordings.h"
 
 #include "../Enigma2.h"

--- a/src/enigma2/Recordings.h
+++ b/src/enigma2/Recordings.h
@@ -21,16 +21,15 @@
  *
  */
 
+#include "Channels.h"
+#include "data/RecordingEntry.h"
+#include "extract/EpgEntryExtractor.h"
+#include "kodi/libXBMC_pvr.h"
+
 #include <random>
 #include <string>
 #include <unordered_map>
 #include <vector>
-
-#include "Channels.h"
-#include "data/RecordingEntry.h"
-#include "extract/EpgEntryExtractor.h"
-
-#include "kodi/libXBMC_pvr.h"
 
 namespace enigma2
 {
@@ -43,17 +42,17 @@ namespace enigma2
   class Recordings
   {
   public:
-    Recordings(Channels &channels, enigma2::extract::EpgEntryExtractor &entryExtractor);
-    void GetRecordings(std::vector<PVR_RECORDING> &recordings, bool deleted);
+    Recordings(Channels& channels, enigma2::extract::EpgEntryExtractor& entryExtractor);
+    void GetRecordings(std::vector<PVR_RECORDING>& recordings, bool deleted);
     int GetNumRecordings(bool deleted) const;
     void ClearRecordings(bool deleted);
-    void GetRecordingEdl(const std::string &recordingId, std::vector<PVR_EDL_ENTRY> &edlEntries) const;
-    PVR_ERROR RenameRecording(const PVR_RECORDING &recording);
-    PVR_ERROR SetRecordingPlayCount(const PVR_RECORDING &recording, int count);
-    PVR_ERROR SetRecordingLastPlayedPosition(const PVR_RECORDING &recording, int lastplayedposition);
-    int GetRecordingLastPlayedPosition(const PVR_RECORDING &recording);
-    const std::string GetRecordingURL(const PVR_RECORDING &recinfo);
-    PVR_ERROR DeleteRecording(const PVR_RECORDING &recinfo);
+    void GetRecordingEdl(const std::string& recordingId, std::vector<PVR_EDL_ENTRY>& edlEntries) const;
+    PVR_ERROR RenameRecording(const PVR_RECORDING& recording);
+    PVR_ERROR SetRecordingPlayCount(const PVR_RECORDING& recording, int count);
+    PVR_ERROR SetRecordingLastPlayedPosition(const PVR_RECORDING& recording, int lastplayedposition);
+    int GetRecordingLastPlayedPosition(const PVR_RECORDING& recording);
+    const std::string GetRecordingURL(const PVR_RECORDING& recinfo);
+    PVR_ERROR DeleteRecording(const PVR_RECORDING& recinfo);
     PVR_ERROR UndeleteRecording(const PVR_RECORDING& recording);
     PVR_ERROR DeleteAllRecordingsFromTrash();
     bool HasRecordingStreamProgramNumber(const PVR_RECORDING& recording);
@@ -69,11 +68,11 @@ namespace enigma2
     static const std::string FILE_NOT_FOUND_RESPONSE_SUFFIX;
 
     bool GetRecordingsFromLocation(const std::string recordingFolder, bool deleted);
-    data::RecordingEntry GetRecording(const std::string &recordingId) const;
-    bool ReadExtaRecordingCutsInfo(const data::RecordingEntry &recordingEntry, std::vector<std::pair<int, int64_t>> &cuts, std::vector<std::string> &tags);
-    bool ReadExtraRecordingPlayCountInfo(const data::RecordingEntry &recordingEntry, std::vector<std::string> &tags);
-    void SetRecordingNextSyncTime(data::RecordingEntry &recordingEntry, time_t nextSyncTime, std::vector<std::string> &oldTags);
-    bool IsInRecordingFolder(const std::string &strRecordingFolder, bool deleted) const;
+    data::RecordingEntry GetRecording(const std::string& recordingId) const;
+    bool ReadExtaRecordingCutsInfo(const data::RecordingEntry& recordingEntry, std::vector<std::pair<int, int64_t>>& cuts, std::vector<std::string>& tags);
+    bool ReadExtraRecordingPlayCountInfo(const data::RecordingEntry& recordingEntry, std::vector<std::string>& tags);
+    void SetRecordingNextSyncTime(data::RecordingEntry& recordingEntry, time_t nextSyncTime, std::vector<std::string>& oldTags);
+    bool IsInRecordingFolder(const std::string& strRecordingFolder, bool deleted) const;
 
     std::mt19937 m_randomGenerator;
     std::uniform_int_distribution<> m_randomDistribution;
@@ -83,7 +82,7 @@ namespace enigma2
     std::unordered_map<std::string, enigma2::data::RecordingEntry> m_recordingsIdMap;
     std::vector<std::string> m_locations;
 
-    Channels &m_channels;
-    enigma2::extract::EpgEntryExtractor &m_entryExtractor;
+    Channels& m_channels;
+    enigma2::extract::EpgEntryExtractor& m_entryExtractor;
   };
 } //namespace enigma2

--- a/src/enigma2/Recordings.h
+++ b/src/enigma2/Recordings.h
@@ -1,6 +1,6 @@
 #pragma once
 /*
- *      Copyright (C) 2005-2015 Team XBMC
+ *      Copyright (C) 2005-2019 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify

--- a/src/enigma2/Settings.cpp
+++ b/src/enigma2/Settings.cpp
@@ -1,12 +1,11 @@
 #include "Settings.h"
 
 #include "../client.h"
-#include "utilities/FileUtils.h"
-#include "utilities/LocalizedString.h"
-
+#include "p8-platform/util/StringUtils.h"
 #include "tinyxml.h"
 #include "util/XMLUtils.h"
-#include "p8-platform/util/StringUtils.h"
+#include "utilities/FileUtils.h"
+#include "utilities/LocalizedString.h"
 
 using namespace ADDON;
 using namespace enigma2;
@@ -363,7 +362,7 @@ void Settings::ReadFromAddon()
     m_connectionURL = StringUtils::Format("https://%s%s:%u/", m_connectionURL.c_str(), m_hostname.c_str(), m_portWeb);
 }
 
-ADDON_STATUS Settings::SetValue(const std::string &settingName, const void *settingValue)
+ADDON_STATUS Settings::SetValue(const std::string& settingName, const void* settingValue)
 {
   //Connection
   if (settingName == "host")
@@ -541,7 +540,7 @@ bool Settings::IsTimeshiftBufferPathValid() const
   return XBMC->DirectoryExists(m_timeshiftBufferPath.c_str());
 }
 
-bool Settings::LoadCustomChannelGroupFile(std::string &xmlFile, std::vector<std::string> &channelGroupNameList)
+bool Settings::LoadCustomChannelGroupFile(std::string& xmlFile, std::vector<std::string>& channelGroupNameList)
 {
   channelGroupNameList.clear();
 

--- a/src/enigma2/Settings.cpp
+++ b/src/enigma2/Settings.cpp
@@ -1,3 +1,25 @@
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
 #include "Settings.h"
 
 #include "../client.h"

--- a/src/enigma2/Settings.h
+++ b/src/enigma2/Settings.h
@@ -47,7 +47,7 @@ namespace enigma2
   static const std::string ADDON_DATA_BASE_DIR = "special://userdata/addon_data/pvr.vuplus";
   static const std::string DEFAULT_SHOW_INFO_FILE = ADDON_DATA_BASE_DIR + "/showInfo/English-ShowInfo.xml";
   static const std::string DEFAULT_GENRE_ID_MAP_FILE = ADDON_DATA_BASE_DIR + "/genres/genreIdMappings/Sky-UK.xml";
-  static const std::string DEFAULT_GENRE_TEXT_MAP_FILE = ADDON_DATA_BASE_DIR + "/genres/genreTextMappings/Rytec-UK-Ireland.xml";
+  static const std::string DEFAULT_GENRE_TEXT_MAP_FILE = ADDON_DATA_BASE_DIR + "/genres/genreRytecTextMappings/Rytec-UK-Ireland.xml";
   static const std::string DEFAULT_CUSTOM_TV_GROUPS_FILE = ADDON_DATA_BASE_DIR + "/channelGroups/customRadioGroups-example.xml";
   static const std::string DEFAULT_CUSTOM_RADIO_GROUPS_FILE = ADDON_DATA_BASE_DIR + "/channelGroups/customRadioGroups-example.xml";
   static const int DEFAULT_NUM_GEN_REPEAT_TIMERS = 1;

--- a/src/enigma2/Settings.h
+++ b/src/enigma2/Settings.h
@@ -1,4 +1,25 @@
 #pragma once
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
 
 #include "Admin.h"
 #include "utilities/DeviceInfo.h"

--- a/src/enigma2/Settings.h
+++ b/src/enigma2/Settings.h
@@ -1,14 +1,14 @@
 #pragma once
 
-#include <string>
-
 #include "Admin.h"
-#include "utilities/Logger.h"
 #include "utilities/DeviceInfo.h"
 #include "utilities/DeviceSettings.h"
+#include "utilities/Logger.h"
+#include "kodi/xbmc_addon_types.h"
+
+#include <string>
 
 #include <p8-platform/util/StringUtils.h>
-#include "kodi/xbmc_addon_types.h"
 
 class Vu;
 
@@ -112,13 +112,13 @@ namespace enigma2
     }
 
     void ReadFromAddon();
-    ADDON_STATUS SetValue(const std::string &settingName, const void *settingValue);
+    ADDON_STATUS SetValue(const std::string& settingName, const void* settingValue);
 
     //Connection
     const std::string& GetHostname() const { return m_hostname; }
     int GetWebPortNum() const { return m_portWeb; }
     bool GetUseSecureConnection() const { return m_useSecureHTTP; }
-    const std::string& GetUsername() const {return m_username; }
+    const std::string& GetUsername() const { return m_username; }
     const std::string& GetPassword() const { return m_password; }
     bool GetAutoConfigLiveStreamsEnabled() const { return m_autoConfig; }
     int GetStreamPortNum() const { return m_portStream; }
@@ -238,13 +238,13 @@ namespace enigma2
   private:
     Settings() = default;
 
-    Settings(Settings const &) = delete;
-    void operator=(Settings const &) = delete;
+    Settings(Settings const&) = delete;
+    void operator=(Settings const&) = delete;
 
-    template <typename T, typename V>
+    template<typename T, typename V>
     V SetSetting(const std::string& settingName, const void* settingValue, T& currentValue, V returnValueIfChanged, V defaultReturnValue)
     {
-      T newValue =  *static_cast<const T*>(settingValue);
+      T newValue = *static_cast<const T*>(settingValue);
       if (newValue != currentValue)
       {
         utilities::Logger::Log(utilities::LogLevel::LEVEL_NOTICE, "%s - Changed Setting '%s' from %d to %d", __FUNCTION__, settingName.c_str(), currentValue, newValue);
@@ -255,8 +255,8 @@ namespace enigma2
       return defaultReturnValue;
     };
 
-    template <typename V>
-    V SetStringSetting(const std::string &settingName, const void* settingValue, std::string &currentValue, V returnValueIfChanged, V defaultReturnValue)
+    template<typename V>
+    V SetStringSetting(const std::string& settingName, const void* settingValue, std::string& currentValue, V returnValueIfChanged, V defaultReturnValue)
     {
       const std::string strSettingValue = static_cast<const char*>(settingValue);
 
@@ -270,7 +270,7 @@ namespace enigma2
       return defaultReturnValue;
     }
 
-    static bool LoadCustomChannelGroupFile(std::string &file, std::vector<std::string> &channelGroupNameList);
+    static bool LoadCustomChannelGroupFile(std::string& file, std::vector<std::string>& channelGroupNameList);
 
     //Connection
     std::string m_hostname = DEFAULT_HOST;
@@ -343,7 +343,7 @@ namespace enigma2
 
     //Timers
     bool m_enableGenRepeatTimers = true;
-    int  m_numGenRepeatTimers = DEFAULT_NUM_GEN_REPEAT_TIMERS;
+    int m_numGenRepeatTimers = DEFAULT_NUM_GEN_REPEAT_TIMERS;
     bool m_automaticTimerlistCleanup = false;
     bool m_enableAutoTimers = true;
     bool m_limitAnyChannelAutoTimers = true;

--- a/src/enigma2/Settings.h
+++ b/src/enigma2/Settings.h
@@ -262,7 +262,7 @@ namespace enigma2
 
       if (strSettingValue != currentValue)
       {
-        utilities::Logger::Log(utilities::LogLevel::LEVEL_NOTICE, "%s - Changed Setting '%s' from %s to %s", __FUNCTION__, settingName.c_str(), currentValue.c_str(), strSettingValue.c_str());
+        utilities::Logger::Log(utilities::LogLevel::LEVEL_NOTICE, "%s - Changed Setting '%s' from '%s' to '%s'", __FUNCTION__, settingName.c_str(), currentValue.c_str(), strSettingValue.c_str());
         currentValue = strSettingValue;
         return returnValueIfChanged;
       }

--- a/src/enigma2/StreamReader.cpp
+++ b/src/enigma2/StreamReader.cpp
@@ -7,13 +7,11 @@ using namespace ADDON;
 using namespace enigma2;
 using namespace enigma2::utilities;
 
-StreamReader::StreamReader(const std::string &streamURL,
-  const unsigned int readTimeout)
+StreamReader::StreamReader(const std::string& streamURL, const unsigned int readTimeout)
 {
   m_streamHandle = XBMC->CURLCreate(streamURL.c_str());
   if (readTimeout > 0)
-    XBMC->CURLAddOption(m_streamHandle, XFILE::CURL_OPTION_PROTOCOL,
-      "connection-timeout", std::to_string(readTimeout).c_str());
+    XBMC->CURLAddOption(m_streamHandle, XFILE::CURL_OPTION_PROTOCOL, "connection-timeout", std::to_string(readTimeout).c_str());
 
   Logger::Log(LEVEL_DEBUG, "%s StreamReader: Started; url=%s", __FUNCTION__, streamURL.c_str());
 }
@@ -30,7 +28,7 @@ bool StreamReader::Start()
   return XBMC->CURLOpen(m_streamHandle, XFILE::READ_NO_CACHE);
 }
 
-ssize_t StreamReader::ReadData(unsigned char *buffer, unsigned int size)
+ssize_t StreamReader::ReadData(unsigned char* buffer, unsigned int size)
 {
   return XBMC->ReadFile(m_streamHandle, buffer, size);
 }

--- a/src/enigma2/StreamReader.cpp
+++ b/src/enigma2/StreamReader.cpp
@@ -1,3 +1,25 @@
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
 #include "StreamReader.h"
 
 #include "../client.h"

--- a/src/enigma2/StreamReader.h
+++ b/src/enigma2/StreamReader.h
@@ -6,16 +6,14 @@
 
 namespace enigma2
 {
-  class StreamReader
-    : public IStreamReader
+  class StreamReader : public IStreamReader
   {
   public:
-    StreamReader(const std::string &streamURL,
-        const unsigned int m_readTimeout);
+    StreamReader(const std::string& streamURL, const unsigned int m_readTimeout);
     ~StreamReader(void);
 
     bool Start() override;
-    ssize_t ReadData(unsigned char *buffer, unsigned int size) override;
+    ssize_t ReadData(unsigned char* buffer, unsigned int size) override;
     int64_t Seek(long long position, int whence) override;
     int64_t Position() override;
     int64_t Length() override;
@@ -25,7 +23,7 @@ namespace enigma2
     bool IsTimeshifting() override;
 
   private:
-    void *m_streamHandle;
+    void* m_streamHandle;
     std::time_t m_start = time(nullptr);
   };
 } // namespace enigma2

--- a/src/enigma2/StreamReader.h
+++ b/src/enigma2/StreamReader.h
@@ -1,4 +1,25 @@
 #pragma once
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
 
 #include "IStreamReader.h"
 

--- a/src/enigma2/Timers.cpp
+++ b/src/enigma2/Timers.cpp
@@ -184,7 +184,7 @@ std::string Timers::ConvertToAutoTimerTag(std::string tag)
   std::regex regex(" ");
   std::string replaceWith = "_";
 
-  return regex_replace(tag, regex, replaceWith);
+  return std::regex_replace(tag, regex, replaceWith);
 }
 
 std::vector<AutoTimer> Timers::LoadAutoTimers() const
@@ -787,7 +787,7 @@ std::string Timers::RemovePaddingTag(std::string tag)
   std::regex regex(" Padding=[0-9]+,[0-9]+ *");
   std::string replaceWith = "";
 
-  return regex_replace(tag, regex, replaceWith);
+  return std::regex_replace(tag, regex, replaceWith);
 }
 
 PVR_ERROR Timers::UpdateAutoTimer(const PVR_TIMER& timer)

--- a/src/enigma2/Timers.cpp
+++ b/src/enigma2/Timers.cpp
@@ -1,3 +1,25 @@
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
 #include "Timers.h"
 
 #include "../Enigma2.h"

--- a/src/enigma2/Timers.cpp
+++ b/src/enigma2/Timers.cpp
@@ -1,30 +1,28 @@
 #include "Timers.h"
 
-#include <cstdlib>
-#include <algorithm>
-#include <regex>
-
-#include "../client.h"
 #include "../Enigma2.h"
+#include "../client.h"
+#include "inttypes.h"
+#include "p8-platform/util/StringUtils.h"
+#include "util/XMLUtils.h"
 #include "utilities/LocalizedString.h"
 #include "utilities/Logger.h"
 #include "utilities/UpdateState.h"
 #include "utilities/WebUtils.h"
 
-#include "inttypes.h"
-#include "util/XMLUtils.h"
-#include "p8-platform/util/StringUtils.h"
+#include <algorithm>
+#include <cstdlib>
+#include <regex>
 
 using namespace ADDON;
 using namespace enigma2;
 using namespace enigma2::data;
 using namespace enigma2::utilities;
 
-template <typename T>
-T *Timers::GetTimer(std::function<bool (const T&)> func,
-  std::vector<T> &timerlist)
+template<typename T>
+T* Timers::GetTimer(std::function<bool(const T&)> func, std::vector<T>& timerlist)
 {
-  for (auto &timer : timerlist)
+  for (auto& timer : timerlist)
   {
     if (func(timer))
       return &timer;
@@ -79,8 +77,8 @@ std::vector<Timer> Timers::LoadTimers() const
 
     timers.emplace_back(newTimer);
 
-    if ((newTimer.GetType() == Timer::MANUAL_REPEATING || newTimer.GetType() == Timer::EPG_REPEATING)
-        && m_settings.GetGenRepeatTimersEnabled() && m_settings.GetNumGenRepeatTimers() > 0)
+    if ((newTimer.GetType() == Timer::MANUAL_REPEATING || newTimer.GetType() == Timer::EPG_REPEATING) &&
+        m_settings.GetGenRepeatTimersEnabled() && m_settings.GetNumGenRepeatTimers() > 0)
     {
       GenerateChildManualRepeatingTimers(&timers, &newTimer);
     }
@@ -93,11 +91,11 @@ std::vector<Timer> Timers::LoadTimers() const
   return timers;
 }
 
-void Timers::GenerateChildManualRepeatingTimers(std::vector<Timer> *timers, Timer *timer) const
+void Timers::GenerateChildManualRepeatingTimers(std::vector<Timer>* timers, Timer* timer) const
 {
   int genTimerCount = 0;
   int weekdays = timer->GetWeekdays();
-  const time_t ONE_DAY = 24 * 60 * 60 ;
+  const time_t ONE_DAY = 24 * 60 * 60;
 
   if (m_settings.GetNumGenRepeatTimers() && weekdays != PVR_WEEKDAY_NONE)
   {
@@ -218,36 +216,33 @@ std::vector<AutoTimer> Timers::LoadAutoTimers() const
   return autoTimers;
 }
 
-bool Timers::IsAutoTimer(const PVR_TIMER &timer) const
+bool Timers::IsAutoTimer(const PVR_TIMER& timer) const
 {
   return timer.iTimerType == Timer::Type::EPG_AUTO_SEARCH;
 }
 
-void Timers::GetTimerTypes(std::vector<PVR_TIMER_TYPE> &types) const
+void Timers::GetTimerTypes(std::vector<PVR_TIMER_TYPE>& types) const
 {
-  struct TimerType
-    : PVR_TIMER_TYPE
+  struct TimerType : PVR_TIMER_TYPE
   {
-    TimerType(unsigned int id, unsigned int attributes,
-      const std::string &description = std::string(),
-      const std::vector<std::pair<int, std::string>> &groupValues
-        = std::vector<std::pair<int, std::string>>(),
-      const std::vector<std::pair<int, std::string>> &deDupValues
-        = std::vector<std::pair<int, std::string>>(),
-      int preventDuplicateEpisodesDefault
-        = AutoTimer::DeDup::DISABLED)
+    TimerType(unsigned int id,
+              unsigned int attributes,
+              const std::string& description = std::string(),
+              const std::vector<std::pair<int, std::string>>& groupValues = std::vector<std::pair<int, std::string>>(),
+              const std::vector<std::pair<int, std::string>>& deDupValues = std::vector<std::pair<int, std::string>>(),
+              int preventDuplicateEpisodesDefault = AutoTimer::DeDup::DISABLED)
     {
       int i;
       memset(this, 0, sizeof(PVR_TIMER_TYPE));
 
-      iId         = id;
+      iId = id;
       iAttributes = attributes;
       strncpy(strDescription, description.c_str(), sizeof(strDescription) - 1);
 
       if ((iRecordingGroupSize = groupValues.size()))
         iRecordingGroupDefault = groupValues[0].first;
       i = 0;
-      for (const auto &group : groupValues)
+      for (const auto& group : groupValues)
       {
         recordingGroup[i].iValue = group.first;
         strncpy(recordingGroup[i].strDescription, group.second.c_str(), sizeof(recordingGroup[i].strDescription) - 1);
@@ -257,7 +252,7 @@ void Timers::GetTimerTypes(std::vector<PVR_TIMER_TYPE> &types) const
       if ((iPreventDuplicateEpisodesSize = deDupValues.size()))
         iPreventDuplicateEpisodesDefault = preventDuplicateEpisodesDefault;
       i = 0;
-      for (const auto &deDup : deDupValues)
+      for (const auto& deDup : deDupValues)
       {
         preventDuplicateEpisodes[i].iValue = deDup.first;
         strncpy(preventDuplicateEpisodes[i].strDescription, deDup.second.c_str(), sizeof(preventDuplicateEpisodes[i].strDescription) - 1);
@@ -268,9 +263,9 @@ void Timers::GetTimerTypes(std::vector<PVR_TIMER_TYPE> &types) const
 
   /* PVR_Timer.iRecordingGroup values and presentation.*/
   std::vector<std::pair<int, std::string>> groupValues = {
-    { 0, LocalizedString(30410) }, //automatic
+      {0, LocalizedString(30410)}, //automatic
   };
-  for (const auto &recf : m_locations)
+  for (const auto& recf : m_locations)
     groupValues.emplace_back(groupValues.size(), recf);
 
   /* One-shot manual (time and channel based) */
@@ -433,7 +428,7 @@ int Timers::GetAutoTimerCount() const
   return m_autotimers.size();
 }
 
-void Timers::GetTimers(std::vector<PVR_TIMER> &timers) const
+void Timers::GetTimers(std::vector<PVR_TIMER>& timers) const
 {
   for (const auto& timer : m_timers)
   {
@@ -446,11 +441,12 @@ void Timers::GetTimers(std::vector<PVR_TIMER> &timers) const
   }
 }
 
-void Timers::GetAutoTimers(std::vector<PVR_TIMER> &timers) const
+void Timers::GetAutoTimers(std::vector<PVR_TIMER>& timers) const
 {
   for (const auto& autoTimer : m_autotimers)
   {
-    Logger::Log(LEVEL_DEBUG, "%s - Transfer timer '%s', ClientIndex '%d'", __FUNCTION__, autoTimer.GetTitle().c_str(), autoTimer.GetClientIndex());
+    Logger::Log(LEVEL_DEBUG, "%s - Transfer timer '%s', ClientIndex '%d'", __FUNCTION__, autoTimer.GetTitle().c_str(),
+                autoTimer.GetClientIndex());
     PVR_TIMER tag = {0};
 
     autoTimer.UpdateTo(tag);
@@ -459,17 +455,17 @@ void Timers::GetAutoTimers(std::vector<PVR_TIMER> &timers) const
   }
 }
 
-Timer *Timers::GetTimer(std::function<bool (const Timer&)> func)
+Timer* Timers::GetTimer(std::function<bool(const Timer&)> func)
 {
   return GetTimer<Timer>(func, m_timers);
 }
 
-AutoTimer *Timers::GetAutoTimer(std::function<bool (const AutoTimer&)> func)
+AutoTimer* Timers::GetAutoTimer(std::function<bool(const AutoTimer&)> func)
 {
   return GetTimer<AutoTimer>(func, m_autotimers);
 }
 
-PVR_ERROR Timers::AddTimer(const PVR_TIMER &timer)
+PVR_ERROR Timers::AddTimer(const PVR_TIMER& timer)
 {
   if (IsAutoTimer(timer))
     return AddAutoTimer(timer);
@@ -520,8 +516,7 @@ PVR_ERROR Timers::AddTimer(const PVR_TIMER &timer)
   unsigned int epgUid = timer.iEpgUid;
   bool foundEntry = false;
 
-  if (Settings::GetInstance().IsOpenWebIf() &&
-      (timer.iTimerType == Timer::EPG_ONCE || timer.iTimerType == Timer::MANUAL_ONCE))
+  if (Settings::GetInstance().IsOpenWebIf() && (timer.iTimerType == Timer::EPG_ONCE || timer.iTimerType == Timer::MANUAL_ONCE))
   {
     // We try to find the EPG Entry and use it's details
     EpgPartialEntry partialEntry = m_epg.LoadEPGEntryPartialDetails(serviceReference, timer.startTime);
@@ -574,7 +569,7 @@ PVR_ERROR Timers::AddTimer(const PVR_TIMER &timer)
   return PVR_ERROR_NO_ERROR;
 }
 
-PVR_ERROR Timers::AddAutoTimer(const PVR_TIMER &timer)
+PVR_ERROR Timers::AddAutoTimer(const PVR_TIMER& timer)
 {
   std::string strTmp = StringUtils::Format("autotimer/edit?");
 
@@ -690,7 +685,7 @@ PVR_ERROR Timers::AddAutoTimer(const PVR_TIMER &timer)
   return PVR_ERROR_NO_ERROR;
 }
 
-PVR_ERROR Timers::UpdateTimer(const PVR_TIMER &timer)
+PVR_ERROR Timers::UpdateTimer(const PVR_TIMER& timer)
 {
   if (IsAutoTimer(timer))
     return UpdateAutoTimer(timer);
@@ -773,7 +768,7 @@ std::string Timers::RemovePaddingTag(std::string tag)
   return regex_replace(tag, regex, replaceWith);
 }
 
-PVR_ERROR Timers::UpdateAutoTimer(const PVR_TIMER &timer)
+PVR_ERROR Timers::UpdateAutoTimer(const PVR_TIMER& timer)
 {
   const auto it = std::find_if(m_autotimers.cbegin(), m_autotimers.cend(), [&timer](const AutoTimer& autoTimer)
   {
@@ -840,8 +835,8 @@ PVR_ERROR Timers::UpdateAutoTimer(const PVR_TIMER &timer)
       }
     }
 
-    if (timer.iClientChannelUid != PVR_TIMER_ANY_CHANNEL && (timerToUpdate.GetAnyChannel() ||
-             (!timerToUpdate.GetAnyChannel() && timer.iClientChannelUid != timerToUpdate.GetChannelId())))
+    if (timer.iClientChannelUid != PVR_TIMER_ANY_CHANNEL &&
+        (timerToUpdate.GetAnyChannel() || (!timerToUpdate.GetAnyChannel() && timer.iClientChannelUid != timerToUpdate.GetChannelId())))
     {
       const std::string serviceReference = m_channels.GetChannel(timer.iClientChannelUid)->GetServiceReference();
 
@@ -909,7 +904,7 @@ PVR_ERROR Timers::UpdateAutoTimer(const PVR_TIMER &timer)
   return PVR_ERROR_SERVER_ERROR;
 }
 
-std::string Timers::BuildAddUpdateAutoTimerLimitGroupsParams(const std::shared_ptr<Channel> &channel)
+std::string Timers::BuildAddUpdateAutoTimerLimitGroupsParams(const std::shared_ptr<Channel>& channel)
 {
   std::string limitGroupParams;
 
@@ -962,7 +957,7 @@ std::string Timers::BuildAddUpdateAutoTimerIncludeParams(int weekdays)
   return includeParams;
 }
 
-PVR_ERROR Timers::DeleteTimer(const PVR_TIMER &timer)
+PVR_ERROR Timers::DeleteTimer(const PVR_TIMER& timer)
 {
   if (IsAutoTimer(timer))
     return DeleteAutoTimer(timer);
@@ -976,7 +971,9 @@ PVR_ERROR Timers::DeleteTimer(const PVR_TIMER &timer)
   {
     Timer timerToDelete = *it;
 
-    const std::string strTmp = StringUtils::Format("web/timerdelete?sRef=%s&begin=%d&end=%d", WebUtils::URLEncodeInline(timerToDelete.GetServiceReference()).c_str(), timerToDelete.GetRealStartTime(), timerToDelete.GetRealEndTime());
+    const std::string strTmp = StringUtils::Format("web/timerdelete?sRef=%s&begin=%d&end=%d",
+                                                   WebUtils::URLEncodeInline(timerToDelete.GetServiceReference()).c_str(),
+                                                   timerToDelete.GetRealStartTime(), timerToDelete.GetRealEndTime());
 
     std::string strResult;
     if (!WebUtils::SendSimpleCommand(strTmp, strResult))
@@ -1006,11 +1003,13 @@ PVR_ERROR Timers::DeleteAutoTimer(const PVR_TIMER &timer)
 
     //remove any child timers
     bool childTimerIsRecording = false;
-    for (const auto &childTimer : m_timers)
+    for (const auto& childTimer : m_timers)
     {
       if (childTimer.GetParentClientIndex() == timerToDelete.GetClientIndex())
       {
-        const std::string strTmp = StringUtils::Format("web/timerdelete?sRef=%s&begin=%d&end=%d", WebUtils::URLEncodeInline(childTimer.GetServiceReference()).c_str(), childTimer.GetRealStartTime(), childTimer.GetRealEndTime());
+        const std::string strTmp = StringUtils::Format("web/timerdelete?sRef=%s&begin=%d&end=%d",
+                                                       WebUtils::URLEncodeInline(childTimer.GetServiceReference()).c_str(),
+                                                       childTimer.GetRealStartTime(), childTimer.GetRealEndTime());
 
         std::string strResult;
         WebUtils::SendSimpleCommand(strTmp, strResult, true);
@@ -1081,8 +1080,8 @@ bool Timers::TimerUpdatesRegular()
   }
 
   //Update any timers
-  unsigned int iUpdated=0;
-  unsigned int iUnchanged=0;
+  unsigned int iUpdated = 0;
+  unsigned int iUnchanged = 0;
 
   for (auto& newTimer : newtimers)
   {
@@ -1090,7 +1089,7 @@ bool Timers::TimerUpdatesRegular()
     {
       if (existingTimer.Like(newTimer))
       {
-        if(existingTimer == newTimer)
+        if (existingTimer == newTimer)
         {
           existingTimer.SetUpdateState(UPDATE_STATE_FOUND);
           newTimer.SetUpdateState(UPDATE_STATE_FOUND);
@@ -1120,11 +1119,11 @@ bool Timers::TimerUpdatesRegular()
   iRemoved -= m_timers.size();
 
   //Add any new autotimers
-  unsigned int iNew=0;
+  unsigned int iNew = 0;
 
   for (auto& newTimer : newtimers)
   {
-    if(newTimer.GetUpdateState() == UPDATE_STATE_NEW)
+    if (newTimer.GetUpdateState() == UPDATE_STATE_NEW)
     {
       newTimer.SetClientIndex(m_clientIndexCounter);
       Logger::Log(LEVEL_DEBUG, "%s New timer: '%s', ClientIndex: '%d'", __FUNCTION__, newTimer.GetTitle().c_str(), m_clientIndexCounter);
@@ -1140,7 +1139,8 @@ bool Timers::TimerUpdatesRegular()
     for (auto& readonlyRepeatingOnceTimer : m_timers)
     {
       if ((repeatingTimer.GetType() == Timer::MANUAL_REPEATING || repeatingTimer.GetType() == Timer::EPG_REPEATING) &&
-          readonlyRepeatingOnceTimer.GetType() == Timer::READONLY_REPEATING_ONCE && readonlyRepeatingOnceTimer.IsChildOfParent(repeatingTimer))
+          readonlyRepeatingOnceTimer.GetType() == Timer::READONLY_REPEATING_ONCE &&
+          readonlyRepeatingOnceTimer.IsChildOfParent(repeatingTimer))
       {
         readonlyRepeatingOnceTimer.SetParentClientIndex(repeatingTimer.GetClientIndex());
         continue;
@@ -1166,8 +1166,8 @@ bool Timers::TimerUpdatesAuto()
   }
 
   //Update any autotimers
-  unsigned int iUpdated=0;
-  unsigned int iUnchanged=0;
+  unsigned int iUpdated = 0;
+  unsigned int iUnchanged = 0;
 
   for (auto& newAutoTimer : newautotimers)
   {
@@ -1175,7 +1175,7 @@ bool Timers::TimerUpdatesAuto()
     {
       if (existingAutoTimer.Like(newAutoTimer))
       {
-        if(existingAutoTimer == newAutoTimer)
+        if (existingAutoTimer == newAutoTimer)
         {
           existingAutoTimer.SetUpdateState(UPDATE_STATE_FOUND);
           newAutoTimer.SetUpdateState(UPDATE_STATE_FOUND);
@@ -1205,11 +1205,11 @@ bool Timers::TimerUpdatesAuto()
   iRemoved -= m_autotimers.size();
 
   //Add any new autotimers
-  unsigned int iNew=0;
+  unsigned int iNew = 0;
 
   for (auto& newAutoTimer : newautotimers)
   {
-    if(newAutoTimer.GetUpdateState() == UPDATE_STATE_NEW)
+    if (newAutoTimer.GetUpdateState() == UPDATE_STATE_NEW)
     {
       newAutoTimer.SetClientIndex(m_clientIndexCounter);
 
@@ -1229,8 +1229,7 @@ bool Timers::TimerUpdatesAuto()
     {
       const std::string autotimerTag = ConvertToAutoTimerTag(autoTimer.GetTitle());
 
-      if (timer.GetType() == Timer::EPG_AUTO_ONCE && timer.ContainsTag(TAG_FOR_AUTOTIMER)
-            && timer.ContainsTag(autotimerTag))
+      if (timer.GetType() == Timer::EPG_AUTO_ONCE && timer.ContainsTag(TAG_FOR_AUTOTIMER) && timer.ContainsTag(autotimerTag))
       {
         timer.SetParentClientIndex(autoTimer.GetClientIndex());
         continue;
@@ -1247,6 +1246,6 @@ void Timers::RunAutoTimerListCleanup()
 {
   const std::string strTmp = StringUtils::Format("web/timercleanup?cleanup=true");
   std::string strResult;
-  if(!WebUtils::SendSimpleCommand(strTmp, strResult))
+  if (!WebUtils::SendSimpleCommand(strTmp, strResult))
     Logger::Log(LEVEL_ERROR, "%s - AutomaticTimerlistCleanup failed!", __FUNCTION__);
 }

--- a/src/enigma2/Timers.h
+++ b/src/enigma2/Timers.h
@@ -1,5 +1,12 @@
 #pragma once
 
+#include "Epg.h"
+#include "data/AutoTimer.h"
+#include "data/Timer.h"
+#include "extract/EpgEntryExtractor.h"
+#include "tinyxml.h"
+#include "kodi/libXBMC_pvr.h"
+
 #include <atomic>
 #include <ctime>
 #include <functional>
@@ -7,44 +14,36 @@
 #include <string>
 #include <type_traits>
 
-#include "Epg.h"
-#include "data/AutoTimer.h"
-#include "data/Timer.h"
-#include "extract/EpgEntryExtractor.h"
-
-#include "kodi/libXBMC_pvr.h"
-#include "tinyxml.h"
-
 namespace enigma2
 {
   class Timers
   {
   public:
-    Timers(Channels &channels, ChannelGroups &channelGroups, std::vector<std::string> &locations, Epg &epg, enigma2::extract::EpgEntryExtractor &entryExtractor)
+    Timers(Channels& channels, ChannelGroups& channelGroups, std::vector<std::string>& locations, Epg& epg, enigma2::extract::EpgEntryExtractor& entryExtractor)
       : m_channels(channels), m_channelGroups(channelGroups), m_locations(locations), m_epg(epg), m_entryExtractor(entryExtractor)
     {
       m_clientIndexCounter = 1;
     };
 
-    void GetTimerTypes(std::vector<PVR_TIMER_TYPE> &types) const;
+    void GetTimerTypes(std::vector<PVR_TIMER_TYPE>& types) const;
 
     int GetTimerCount() const;
     int GetAutoTimerCount() const;
 
-    void GetTimers(std::vector<PVR_TIMER> &timers) const;
-    void GetAutoTimers(std::vector<PVR_TIMER> &timers) const;
+    void GetTimers(std::vector<PVR_TIMER>& timers) const;
+    void GetAutoTimers(std::vector<PVR_TIMER>& timers) const;
 
-    enigma2::data::Timer *GetTimer(std::function<bool (const enigma2::data::Timer&)> func);
-    enigma2::data::AutoTimer *GetAutoTimer(std::function<bool (const enigma2::data::AutoTimer&)> func);
+    enigma2::data::Timer* GetTimer(std::function<bool(const enigma2::data::Timer&)> func);
+    enigma2::data::AutoTimer* GetAutoTimer(std::function<bool(const enigma2::data::AutoTimer&)> func);
 
-    PVR_ERROR AddTimer(const PVR_TIMER &timer);
-    PVR_ERROR AddAutoTimer(const PVR_TIMER &timer);
+    PVR_ERROR AddTimer(const PVR_TIMER& timer);
+    PVR_ERROR AddAutoTimer(const PVR_TIMER& timer);
 
-    PVR_ERROR UpdateTimer(const PVR_TIMER &timer);
-    PVR_ERROR UpdateAutoTimer(const PVR_TIMER &timer);
+    PVR_ERROR UpdateTimer(const PVR_TIMER& timer);
+    PVR_ERROR UpdateAutoTimer(const PVR_TIMER& timer);
 
-    PVR_ERROR DeleteTimer(const PVR_TIMER &timer);
-    PVR_ERROR DeleteAutoTimer(const PVR_TIMER &timer);
+    PVR_ERROR DeleteTimer(const PVR_TIMER& timer);
+    PVR_ERROR DeleteAutoTimer(const PVR_TIMER& timer);
 
     void ClearTimers();
     bool TimerUpdates();
@@ -53,35 +52,34 @@ namespace enigma2
 
   private:
     //templates
-    template <typename T>
-    T *GetTimer(std::function<bool (const T&)> func,
-        std::vector<T> &timerlist);
+    template<typename T>
+    T* GetTimer(std::function<bool(const T&)> func, std::vector<T>& timerlist);
 
     // functions
     std::vector<enigma2::data::Timer> LoadTimers() const;
-    void GenerateChildManualRepeatingTimers(std::vector<enigma2::data::Timer> *timers, enigma2::data::Timer *timer) const;
+    void GenerateChildManualRepeatingTimers(std::vector<enigma2::data::Timer>* timers, enigma2::data::Timer* timer) const;
     static std::string ConvertToAutoTimerTag(std::string tag);
     static std::string RemovePaddingTag(std::string tag);
     std::vector<enigma2::data::AutoTimer> LoadAutoTimers() const;
-    bool IsAutoTimer(const PVR_TIMER &timer) const;
+    bool IsAutoTimer(const PVR_TIMER& timer) const;
     bool TimerUpdatesRegular();
     bool TimerUpdatesAuto();
-    std::string BuildAddUpdateAutoTimerLimitGroupsParams(const std::shared_ptr<data::Channel> &channel);
+    std::string BuildAddUpdateAutoTimerLimitGroupsParams(const std::shared_ptr<data::Channel>& channel);
     static std::string BuildAddUpdateAutoTimerIncludeParams(int weekdays);
 
     // members
     unsigned int m_clientIndexCounter;
     std::vector<std::atomic_bool*> m_timerChangeWatchers;
 
-    enigma2::extract::EpgEntryExtractor &m_entryExtractor;
+    enigma2::extract::EpgEntryExtractor& m_entryExtractor;
 
-    enigma2::Settings &m_settings = enigma2::Settings::GetInstance();
+    enigma2::Settings& m_settings = enigma2::Settings::GetInstance();
     std::vector<enigma2::data::Timer> m_timers;
     std::vector<enigma2::data::AutoTimer> m_autotimers;
 
-    Channels &m_channels;
-    ChannelGroups &m_channelGroups;
-    std::vector<std::string> &m_locations;
-    Epg &m_epg;
+    Channels& m_channels;
+    ChannelGroups& m_channelGroups;
+    std::vector<std::string>& m_locations;
+    Epg& m_epg;
   };
 } // namespace enigma2

--- a/src/enigma2/Timers.h
+++ b/src/enigma2/Timers.h
@@ -1,4 +1,25 @@
 #pragma once
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
 
 #include "Epg.h"
 #include "data/AutoTimer.h"

--- a/src/enigma2/TimeshiftBuffer.cpp
+++ b/src/enigma2/TimeshiftBuffer.cpp
@@ -1,3 +1,25 @@
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
 #include "TimeshiftBuffer.h"
 
 #include "../client.h"

--- a/src/enigma2/TimeshiftBuffer.cpp
+++ b/src/enigma2/TimeshiftBuffer.cpp
@@ -2,21 +2,18 @@
 
 #include "../client.h"
 #include "StreamReader.h"
-#include "utilities/Logger.h"
-
 #include "p8-platform/util/util.h"
+#include "utilities/Logger.h"
 
 using namespace ADDON;
 using namespace enigma2;
 using namespace enigma2::utilities;
 
-TimeshiftBuffer::TimeshiftBuffer(IStreamReader *m_streamReader,
-    const std::string &timeshiftBufferPath, const unsigned int readTimeout)
+TimeshiftBuffer::TimeshiftBuffer(IStreamReader* m_streamReader, const std::string& timeshiftBufferPath, const unsigned int readTimeout)
   : m_streamReader(m_streamReader)
 {
   m_bufferPath = timeshiftBufferPath + "/tsbuffer.ts";
-  m_readTimeout = (readTimeout) ? readTimeout
-      : DEFAULT_READ_TIMEOUT;
+  m_readTimeout = (readTimeout) ? readTimeout : DEFAULT_READ_TIMEOUT;
 
   m_filebufferWriteHandle = XBMC->OpenFileForWrite(m_bufferPath.c_str(), true);
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
@@ -33,7 +30,7 @@ TimeshiftBuffer::~TimeshiftBuffer(void)
   {
     // XBMC->TruncateFile doesn't work for unknown reasons
     XBMC->CloseFile(m_filebufferWriteHandle);
-    void *tmp;
+    void* tmp;
     if ((tmp = XBMC->OpenFileForWrite(m_bufferPath.c_str(), true)) != nullptr)
       XBMC->CloseFile(tmp);
   }
@@ -49,9 +46,7 @@ TimeshiftBuffer::~TimeshiftBuffer(void)
 
 bool TimeshiftBuffer::Start()
 {
-  if (m_streamReader == nullptr
-      || m_filebufferWriteHandle == nullptr
-      || m_filebufferReadHandle == nullptr)
+  if (m_streamReader == nullptr || m_filebufferWriteHandle == nullptr || m_filebufferReadHandle == nullptr)
     return false;
   if (m_running)
     return true;
@@ -101,14 +96,13 @@ int64_t TimeshiftBuffer::Length()
   return m_writePos;
 }
 
-ssize_t TimeshiftBuffer::ReadData(unsigned char *buffer, unsigned int size)
+ssize_t TimeshiftBuffer::ReadData(unsigned char* buffer, unsigned int size)
 {
   int64_t requiredLength = Position() + size;
 
   /* make sure we never read above the current write position */
   std::unique_lock<std::mutex> lock(m_mutex);
-  bool available = m_condition.wait_for(lock, std::chrono::seconds(m_readTimeout),
-    [&] { return Length() >= requiredLength; });
+  bool available = m_condition.wait_for(lock, std::chrono::seconds(m_readTimeout), [&] { return Length() >= requiredLength; });
 
   if (!available)
   {

--- a/src/enigma2/TimeshiftBuffer.h
+++ b/src/enigma2/TimeshiftBuffer.h
@@ -1,4 +1,25 @@
 #pragma once
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
 
 #include "IStreamReader.h"
 

--- a/src/enigma2/TimeshiftBuffer.h
+++ b/src/enigma2/TimeshiftBuffer.h
@@ -4,21 +4,19 @@
 
 #include <atomic>
 #include <condition_variable>
-#include <thread>
 #include <mutex>
+#include <thread>
 
 namespace enigma2
 {
-  class TimeshiftBuffer
-    : public IStreamReader
+  class TimeshiftBuffer : public IStreamReader
   {
   public:
-    TimeshiftBuffer(IStreamReader *strReader,
-        const std::string &m_timeshiftBufferPath, const unsigned int m_readTimeoutX);
+    TimeshiftBuffer(IStreamReader* strReader, const std::string& m_timeshiftBufferPath, const unsigned int m_readTimeoutX);
     ~TimeshiftBuffer(void);
 
     bool Start() override;
-    ssize_t ReadData(unsigned char *buffer, unsigned int size) override;
+    ssize_t ReadData(unsigned char* buffer, unsigned int size) override;
     int64_t Seek(long long position, int whence) override;
     int64_t Position() override;
     int64_t Length() override;
@@ -35,14 +33,14 @@ namespace enigma2
     static const int READ_WAITTIME = 50;
 
     std::string m_bufferPath;
-    IStreamReader *m_streamReader;
-    void *m_filebufferReadHandle;
-    void *m_filebufferWriteHandle;
+    IStreamReader* m_streamReader;
+    void* m_filebufferReadHandle;
+    void* m_filebufferWriteHandle;
     int m_readTimeout;
     std::time_t m_start = 0;
-    std::atomic<uint64_t> m_writePos = { 0 };
+    std::atomic<uint64_t> m_writePos = {0};
 
-    std::atomic<bool> m_running = { false };
+    std::atomic<bool> m_running = {false};
     std::thread m_inputThread;
     std::condition_variable m_condition;
     std::mutex m_mutex;

--- a/src/enigma2/data/AutoTimer.cpp
+++ b/src/enigma2/data/AutoTimer.cpp
@@ -27,6 +27,8 @@
 #include "p8-platform/util/StringUtils.h"
 #include "util/XMLUtils.h"
 
+#include <cstdlib>
+
 using namespace enigma2;
 using namespace enigma2::data;
 using namespace enigma2::utilities;
@@ -223,7 +225,7 @@ bool AutoTimer::UpdateFrom(TiXmlElement* autoTimerNode, Channels& channels)
       {
         if (where == "dayofweek")
         {
-          m_weekdays = m_weekdays |= (1 << atoi(includeVal.c_str()));
+          m_weekdays = m_weekdays |= (1 << std::atoi(includeVal.c_str()));
         }
       }
     }

--- a/src/enigma2/data/AutoTimer.cpp
+++ b/src/enigma2/data/AutoTimer.cpp
@@ -1,21 +1,20 @@
 #include "AutoTimer.h"
 
 #include "../utilities/LocalizedString.h"
-
 #include "inttypes.h"
-#include "util/XMLUtils.h"
 #include "p8-platform/util/StringUtils.h"
+#include "util/XMLUtils.h"
 
 using namespace enigma2;
 using namespace enigma2::data;
 using namespace enigma2::utilities;
 
-bool AutoTimer::Like(const AutoTimer &right) const
+bool AutoTimer::Like(const AutoTimer& right) const
 {
-  return m_backendId == right.m_backendId;;
+  return m_backendId == right.m_backendId;
 }
 
-bool AutoTimer::operator==(const AutoTimer &right) const
+bool AutoTimer::operator==(const AutoTimer& right) const
 {
   bool isEqual = (!m_title.compare(right.m_title));
   isEqual &= (m_startTime == right.m_startTime);
@@ -37,7 +36,7 @@ bool AutoTimer::operator==(const AutoTimer &right) const
   return isEqual;
 }
 
-void AutoTimer::UpdateFrom(const AutoTimer &right)
+void AutoTimer::UpdateFrom(const AutoTimer& right)
 {
   Timer::UpdateFrom(right);
 
@@ -53,37 +52,37 @@ void AutoTimer::UpdateFrom(const AutoTimer &right)
   m_tags = right.m_tags;
 }
 
-void AutoTimer::UpdateTo(PVR_TIMER &left) const
+void AutoTimer::UpdateTo(PVR_TIMER& left) const
 {
   strncpy(left.strTitle, m_title.c_str(), sizeof(left.strTitle));
   //strncpy(tag.strDirectory, "/", sizeof(tag.strDirectory));   // unused
   //strncpy(tag.strSummary, timer.strPlot.c_str(), sizeof(tag.strSummary));
   strncpy(left.strEpgSearchString, m_searchPhrase.c_str(), sizeof(left.strEpgSearchString));
-  left.iTimerType          = m_type;
+  left.iTimerType = m_type;
   if (m_anyChannel)
     left.iClientChannelUid = PVR_TIMER_ANY_CHANNEL;
   else
     left.iClientChannelUid = m_channelId;
-  left.startTime           = m_startTime;
-  left.endTime             = m_endTime;
-  left.state               = m_state;
-  left.iPriority           = 0;     // unused
-  left.iLifetime           = 0;     // unused
-  left.firstDay            = 0;     // unused
-  left.iWeekdays           = m_weekdays;
-  //right.iEpgUid             = timer.iEpgID;
-  left.iMarginStart        = 0;     // unused
-  left.iMarginEnd          = 0;     // unused
-  left.iGenreType          = 0;     // unused
-  left.iGenreSubType       = 0;     // unused
-  left.iClientIndex        = m_clientIndex;
-  left.bStartAnyTime       = m_startAnyTime;
-  left.bEndAnyTime         = m_endAnyTime;
-  left.bFullTextEpgSearch  = m_searchFulltext;
+  left.startTime = m_startTime;
+  left.endTime = m_endTime;
+  left.state = m_state;
+  left.iPriority = 0; // unused
+  left.iLifetime = 0; // unused
+  left.firstDay = 0; // unused
+  left.iWeekdays = m_weekdays;
+  //right.iEpgUid = timer.iEpgID;
+  left.iMarginStart = 0; // unused
+  left.iMarginEnd = 0; // unused
+  left.iGenreType = 0; // unused
+  left.iGenreSubType = 0; // unused
+  left.iClientIndex = m_clientIndex;
+  left.bStartAnyTime = m_startAnyTime;
+  left.bEndAnyTime = m_endAnyTime;
+  left.bFullTextEpgSearch = m_searchFulltext;
   left.iPreventDuplicateEpisodes = m_deDup;
 }
 
-bool AutoTimer::UpdateFrom(TiXmlElement* autoTimerNode, Channels &channels)
+bool AutoTimer::UpdateFrom(TiXmlElement* autoTimerNode, Channels& channels)
 {
   std::string strTmp;
   int iTmp;
@@ -150,7 +149,7 @@ bool AutoTimer::UpdateFrom(TiXmlElement* autoTimerNode, Channels &channels)
 
   if (serviceNode)
   {
-    const TiXmlElement *nextServiceNode = serviceNode->NextSiblingElement("e2service");
+    const TiXmlElement* nextServiceNode = serviceNode->NextSiblingElement("e2service");
 
     if (!nextServiceNode)
     {
@@ -257,8 +256,7 @@ bool AutoTimer::UpdateFrom(TiXmlElement* autoTimerNode, Channels &channels)
   return true;
 }
 
-void AutoTimer::ParseTime(const std::string &time, std::tm &timeinfo) const
+void AutoTimer::ParseTime(const std::string& time, std::tm& timeinfo) const
 {
-  std::sscanf(time.c_str(), "%02d:%02d", &timeinfo.tm_hour,
-      &timeinfo.tm_min);
+  std::sscanf(time.c_str(), "%02d:%02d", &timeinfo.tm_hour, &timeinfo.tm_min);
 }

--- a/src/enigma2/data/AutoTimer.cpp
+++ b/src/enigma2/data/AutoTimer.cpp
@@ -1,3 +1,25 @@
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
 #include "AutoTimer.h"
 
 #include "../utilities/LocalizedString.h"

--- a/src/enigma2/data/AutoTimer.h
+++ b/src/enigma2/data/AutoTimer.h
@@ -21,14 +21,13 @@
  *
  */
 
-#include <string>
-#include <ctime>
-#include <type_traits>
-
 #include "Timer.h"
-
-#include "kodi/libXBMC_pvr.h"
 #include "tinyxml.h"
+#include "kodi/libXBMC_pvr.h"
+
+#include <ctime>
+#include <string>
+#include <type_traits>
 
 namespace enigma2
 {
@@ -60,32 +59,30 @@ namespace enigma2
 
   namespace data
   {
-    class AutoTimer
-      : public Timer
+    class AutoTimer : public Timer
     {
     public:
-      enum DeDup
-        : unsigned int  // same type as PVR_TIMER_TYPE.iPreventDuplicateEpisodes
+      enum DeDup : unsigned int // same type as PVR_TIMER_TYPE.iPreventDuplicateEpisodes
       {
-        DISABLED                         = 0,
-        CHECK_TITLE                      = 1,
-        CHECK_TITLE_AND_SHORT_DESC       = 2,
-        CHECK_TITLE_AND_ALL_DESCS        = 3
+        DISABLED = 0,
+        CHECK_TITLE = 1,
+        CHECK_TITLE_AND_SHORT_DESC = 2,
+        CHECK_TITLE_AND_ALL_DESCS = 3
       };
 
       AutoTimer() = default;
 
       const std::string& GetSearchPhrase() const { return m_searchPhrase; }
-      void SetSearchPhrase(const std::string& value ) { m_searchPhrase = value; }
+      void SetSearchPhrase(const std::string& value) { m_searchPhrase = value; }
 
       const std::string& GetEncoding() const { return m_encoding; }
-      void SetEncoding(const std::string& value ) { m_encoding = value; }
+      void SetEncoding(const std::string& value) { m_encoding = value; }
 
       const std::string& GetSearchCase() const { return m_searchCase; }
-      void SetSearchCase(const std::string& value ) { m_searchCase = value; }
+      void SetSearchCase(const std::string& value) { m_searchCase = value; }
 
       const std::string& GetSearchType() const { return m_searchType; }
-      void SetSearchType(const std::string& value ) { m_searchType = value; }
+      void SetSearchType(const std::string& value) { m_searchType = value; }
 
       unsigned int GetBackendId() const { return m_backendId; }
       void SetBackendId(unsigned int value) { m_backendId = value; }
@@ -103,14 +100,14 @@ namespace enigma2
       void SetAnyChannel(bool value) { m_anyChannel = value; }
 
       std::underlying_type<DeDup>::type GetDeDup() const { return m_deDup; }
-      void SetDeDup(const std::underlying_type<DeDup>::type value ) { m_deDup = value; }
+      void SetDeDup(const std::underlying_type<DeDup>::type value) { m_deDup = value; }
 
-      bool Like(const AutoTimer &right) const;
-      bool operator==(const AutoTimer &right) const;
-      void UpdateFrom(const AutoTimer &right);
-      void UpdateTo(PVR_TIMER &right) const;
-      bool UpdateFrom(TiXmlElement* autoTimerNode, Channels &channels);
-      void ParseTime(const std::string &time, std::tm &timeinfo) const;
+      bool Like(const AutoTimer& right) const;
+      bool operator==(const AutoTimer& right) const;
+      void UpdateFrom(const AutoTimer& right);
+      void UpdateTo(PVR_TIMER& right) const;
+      bool UpdateFrom(TiXmlElement* autoTimerNode, Channels& channels);
+      void ParseTime(const std::string& time, std::tm& timeinfo) const;
 
     private:
       std::string m_searchPhrase;
@@ -120,7 +117,7 @@ namespace enigma2
       unsigned int m_backendId;
       bool m_searchFulltext = false;
       bool m_startAnyTime = false;
-      bool m_endAnyTime   = false;
+      bool m_endAnyTime = false;
       bool m_anyChannel = false;
       std::underlying_type<DeDup>::type m_deDup = DeDup::DISABLED;
     };

--- a/src/enigma2/data/AutoTimer.h
+++ b/src/enigma2/data/AutoTimer.h
@@ -1,6 +1,6 @@
 #pragma once
 /*
- *      Copyright (C) 2005-2015 Team XBMC
+ *      Copyright (C) 2005-2019 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify

--- a/src/enigma2/data/BaseChannel.h
+++ b/src/enigma2/data/BaseChannel.h
@@ -1,6 +1,6 @@
 #pragma once
 /*
- *      Copyright (C) 2005-2015 Team XBMC
+ *      Copyright (C) 2005-2019 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify

--- a/src/enigma2/data/BaseChannel.h
+++ b/src/enigma2/data/BaseChannel.h
@@ -21,12 +21,12 @@
  *
  */
 
+#include "tinyxml.h"
+#include "kodi/libXBMC_pvr.h"
+
 #include <memory>
 #include <string>
 #include <vector>
-
-#include "kodi/libXBMC_pvr.h"
-#include "tinyxml.h"
 
 namespace enigma2
 {
@@ -36,7 +36,7 @@ namespace enigma2
     {
     public:
       BaseChannel() = default;
-      BaseChannel(const BaseChannel &b) : m_radio(b.IsRadio()), m_uniqueId(b.GetUniqueId()),
+      BaseChannel(const BaseChannel& b) : m_radio(b.IsRadio()), m_uniqueId(b.GetUniqueId()),
         m_channelName(b.GetChannelName()), m_serviceReference(b.GetServiceReference()) {};
       ~BaseChannel() = default;
 
@@ -47,10 +47,10 @@ namespace enigma2
       void SetUniqueId(int value) { m_uniqueId = value; }
 
       const std::string& GetChannelName() const { return m_channelName; }
-      void SetChannelName(const std::string& value ) { m_channelName = value; }
+      void SetChannelName(const std::string& value) { m_channelName = value; }
 
       const std::string& GetServiceReference() const { return m_serviceReference; }
-      void SetServiceReference(const std::string& value ) { m_serviceReference = value; }
+      void SetServiceReference(const std::string& value) { m_serviceReference = value; }
 
     protected:
       bool m_radio;

--- a/src/enigma2/data/BaseEntry.cpp
+++ b/src/enigma2/data/BaseEntry.cpp
@@ -1,3 +1,25 @@
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
 #include "BaseEntry.h"
 
 #include "inttypes.h"

--- a/src/enigma2/data/BaseEntry.cpp
+++ b/src/enigma2/data/BaseEntry.cpp
@@ -15,8 +15,8 @@ void BaseEntry::ProcessPrependMode(PrependOutline prependOutlineMode)
     m_plotOutline.clear();
   }
   else if ((Settings::GetInstance().GetPrependOutline() == prependOutlineMode ||
-            Settings::GetInstance().GetPrependOutline() == PrependOutline::ALWAYS)
-            && !m_plotOutline.empty() && m_plotOutline != "N/A")
+            Settings::GetInstance().GetPrependOutline() == PrependOutline::ALWAYS) &&
+           !m_plotOutline.empty() && m_plotOutline != "N/A")
   {
     m_plot.insert(0, m_plotOutline + "\n");
     m_plotOutline.clear();

--- a/src/enigma2/data/BaseEntry.h
+++ b/src/enigma2/data/BaseEntry.h
@@ -1,6 +1,6 @@
 #pragma once
 /*
- *      Copyright (C) 2005-2015 Team XBMC
+ *      Copyright (C) 2005-2019 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify

--- a/src/enigma2/data/BaseEntry.h
+++ b/src/enigma2/data/BaseEntry.h
@@ -21,9 +21,9 @@
  *
  */
 
-#include <string>
-
 #include "../Settings.h"
+
+#include <string>
 
 namespace enigma2
 {
@@ -33,13 +33,13 @@ namespace enigma2
     {
     public:
       const std::string& GetTitle() const { return m_title; }
-      void SetTitle(const std::string& value ) { m_title = value; }
+      void SetTitle(const std::string& value) { m_title = value; }
 
       const std::string& GetPlotOutline() const { return m_plotOutline; }
-      void SetPlotOutline(const std::string& value ) { m_plotOutline = value; }
+      void SetPlotOutline(const std::string& value) { m_plotOutline = value; }
 
       const std::string& GetPlot() const { return m_plot; }
-      void SetPlot(const std::string& value ) { m_plot = value; }
+      void SetPlot(const std::string& value) { m_plot = value; }
 
       int GetGenreType() const { return m_genreType; }
       void SetGenreType(int value) { m_genreType = value; }
@@ -48,7 +48,7 @@ namespace enigma2
       void SetGenreSubType(int value) { m_genreSubType = value; }
 
       const std::string& GetGenreDescription() const { return m_genreDescription; }
-      void SetGenreDescription(const std::string& value ) { m_genreDescription = value; }
+      void SetGenreDescription(const std::string& value) { m_genreDescription = value; }
 
       int GetEpisodeNumber() const { return m_episodeNumber; }
       void SetEpisodeNumber(int value) { m_episodeNumber = value; }

--- a/src/enigma2/data/Channel.cpp
+++ b/src/enigma2/data/Channel.cpp
@@ -168,9 +168,9 @@ std::string Channel::CreateGenericServiceReference(const std::string& commonServ
   //Same as common service reference but starts with SERVICE_REF_GENERIC_PREFIX and ends with SERVICE_REF_GENERIC_POSTFIX
   std::regex startPrefixRegex("^\\d+:\\d+:\\d+:");
   std::string replaceWith = "";
-  std::string genericServiceReference = regex_replace(commonServiceReference, startPrefixRegex, replaceWith);
+  std::string genericServiceReference = std::regex_replace(commonServiceReference, startPrefixRegex, replaceWith);
   std::regex endPostfixRegex(":\\d+:\\d+:\\d+$");
-  genericServiceReference = regex_replace(genericServiceReference, endPostfixRegex, replaceWith);
+  genericServiceReference = std::regex_replace(genericServiceReference, endPostfixRegex, replaceWith);
   genericServiceReference = SERVICE_REF_GENERIC_PREFIX + genericServiceReference + SERVICE_REF_GENERIC_POSTFIX;
 
   return genericServiceReference;

--- a/src/enigma2/data/Channel.cpp
+++ b/src/enigma2/data/Channel.cpp
@@ -1,20 +1,19 @@
 #include "Channel.h"
 
-#include <regex>
-
-#include "ChannelGroup.h"
 #include "../Settings.h"
 #include "../utilities/WebUtils.h"
-
+#include "ChannelGroup.h"
 #include "inttypes.h"
-#include "util/XMLUtils.h"
 #include "p8-platform/util/StringUtils.h"
+#include "util/XMLUtils.h"
+
+#include <regex>
 
 using namespace enigma2;
 using namespace enigma2::data;
 using namespace enigma2::utilities;
 
-bool Channel::Like(const Channel &right) const
+bool Channel::Like(const Channel& right) const
 {
   bool isLike = (m_serviceReference == right.m_serviceReference);
   isLike &= (m_channelName == right.m_channelName);
@@ -22,7 +21,7 @@ bool Channel::Like(const Channel &right) const
   return isLike;
 }
 
-bool Channel::operator==(const Channel &right) const
+bool Channel::operator==(const Channel& right) const
 {
   bool isEqual = (m_serviceReference == right.m_serviceReference);
   isEqual &= (m_channelName == right.m_channelName);
@@ -36,7 +35,7 @@ bool Channel::operator==(const Channel &right) const
   return isEqual;
 }
 
-bool Channel::operator!=(const Channel &right) const
+bool Channel::operator!=(const Channel& right) const
 {
   return !(*this == right);
 }
@@ -101,7 +100,7 @@ bool Channel::UpdateFrom(TiXmlElement* channelNode)
   return true;
 }
 
-std::string Channel::NormaliseServiceReference(const std::string &serviceReference)
+std::string Channel::NormaliseServiceReference(const std::string& serviceReference)
 {
   if (Settings::GetInstance().UseStandardServiceReference())
     return CreateStandardServiceReference(serviceReference);
@@ -109,12 +108,12 @@ std::string Channel::NormaliseServiceReference(const std::string &serviceReferen
     return serviceReference;
 }
 
-std::string Channel::CreateStandardServiceReference(const std::string &serviceReference)
+std::string Channel::CreateStandardServiceReference(const std::string& serviceReference)
 {
   return CreateCommonServiceReference(serviceReference) + ":";
 }
 
-std::string Channel::CreateCommonServiceReference(const std::string &serviceReference)
+std::string Channel::CreateCommonServiceReference(const std::string& serviceReference)
 {
   //The common service reference contains only the first 10 groups of digits with colon's in between
   std::string commonServiceReference = serviceReference;
@@ -142,20 +141,20 @@ std::string Channel::CreateCommonServiceReference(const std::string &serviceRefe
   return commonServiceReference;
 }
 
-std::string Channel::CreateGenericServiceReference(const std::string &commonServiceReference)
+std::string Channel::CreateGenericServiceReference(const std::string& commonServiceReference)
 {
   //Same as common service reference but starts with SERVICE_REF_GENERIC_PREFIX and ends with SERVICE_REF_GENERIC_POSTFIX
-  std::regex startPrefixRegex ("^\\d+:\\d+:\\d+:");
+  std::regex startPrefixRegex("^\\d+:\\d+:\\d+:");
   std::string replaceWith = "";
   std::string genericServiceReference = regex_replace(commonServiceReference, startPrefixRegex, replaceWith);
-  std::regex endPostfixRegex (":\\d+:\\d+:\\d+$");
+  std::regex endPostfixRegex(":\\d+:\\d+:\\d+$");
   genericServiceReference = regex_replace(genericServiceReference, endPostfixRegex, replaceWith);
   genericServiceReference = SERVICE_REF_GENERIC_PREFIX + genericServiceReference + SERVICE_REF_GENERIC_POSTFIX;
 
   return genericServiceReference;
 }
 
-std::string Channel::CreateIconPath(const std::string &commonServiceReference)
+std::string Channel::CreateIconPath(const std::string& commonServiceReference)
 {
   std::string iconPath = commonServiceReference;
 
@@ -209,7 +208,7 @@ bool Channel::HasRadioServiceType()
   return radioServiceType == RADIO_SERVICE_TYPE;
 }
 
-void Channel::UpdateTo(PVR_CHANNEL &left) const
+void Channel::UpdateTo(PVR_CHANNEL& left) const
 {
   left.iUniqueId = m_uniqueId;
   left.bIsRadio = m_radio;
@@ -221,7 +220,7 @@ void Channel::UpdateTo(PVR_CHANNEL &left) const
   strncpy(left.strIconPath, m_iconPath.c_str(), sizeof(left.strIconPath));
 }
 
-void Channel::AddChannelGroup(std::shared_ptr<ChannelGroup> &channelGroup)
+void Channel::AddChannelGroup(std::shared_ptr<ChannelGroup>& channelGroup)
 {
   m_channelGroupList.emplace_back(channelGroup);
 }

--- a/src/enigma2/data/Channel.cpp
+++ b/src/enigma2/data/Channel.cpp
@@ -1,3 +1,25 @@
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
 #include "Channel.h"
 
 #include "../Settings.h"

--- a/src/enigma2/data/Channel.h
+++ b/src/enigma2/data/Channel.h
@@ -1,6 +1,6 @@
 #pragma once
 /*
- *      Copyright (C) 2005-2015 Team XBMC
+ *      Copyright (C) 2005-2019 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify

--- a/src/enigma2/data/Channel.h
+++ b/src/enigma2/data/Channel.h
@@ -21,14 +21,13 @@
  *
  */
 
+#include "BaseChannel.h"
+#include "tinyxml.h"
+#include "kodi/libXBMC_pvr.h"
+
 #include <memory>
 #include <string>
 #include <vector>
-
-#include "BaseChannel.h"
-
-#include "kodi/libXBMC_pvr.h"
-#include "tinyxml.h"
 
 namespace enigma2
 {
@@ -56,28 +55,28 @@ namespace enigma2
       void SetChannelNumber(int value) { m_channelNumber = value; }
 
       const std::string& GetStandardServiceReference() const { return m_standardServiceReference; }
-      void SetStandardServiceReference(const std::string& value ) { m_standardServiceReference = value; }
+      void SetStandardServiceReference(const std::string& value) { m_standardServiceReference = value; }
 
       const std::string& GetExtendedServiceReference() const { return m_extendedServiceReference; }
-      void SetExtendedServiceReference(const std::string& value ) { m_extendedServiceReference = value; }
+      void SetExtendedServiceReference(const std::string& value) { m_extendedServiceReference = value; }
 
       const std::string& GetGenericServiceReference() const { return m_genericServiceReference; }
-      void SetGenericServiceReference(const std::string& value ) { m_genericServiceReference = value; }
+      void SetGenericServiceReference(const std::string& value) { m_genericServiceReference = value; }
 
       const std::string& GetStreamURL() const { return m_streamURL; }
-      void SetStreamURL(const std::string& value ) { m_streamURL = value; }
+      void SetStreamURL(const std::string& value) { m_streamURL = value; }
 
       const std::string& GetM3uURL() const { return m_m3uURL; }
-      void SetM3uURL(const std::string& value ) { m_m3uURL = value; }
+      void SetM3uURL(const std::string& value) { m_m3uURL = value; }
 
       const std::string& GetIconPath() const { return m_iconPath; }
-      void SetIconPath(const std::string& value ) { m_iconPath = value; }
+      void SetIconPath(const std::string& value) { m_iconPath = value; }
 
       const std::string& GetProviderName() const { return m_providerName; }
-      void SetProviderlName(const std::string& value ) { m_providerName = value; }
+      void SetProviderlName(const std::string& value) { m_providerName = value; }
 
       const std::string& GetFuzzyChannelName() const { return m_fuzzyChannelName; }
-      void SetFuzzyChannelName(const std::string& value ) { m_fuzzyChannelName = value; }
+      void SetFuzzyChannelName(const std::string& value) { m_fuzzyChannelName = value; }
 
       int GetStreamProgramNumber() const { return m_streamProgramNumber; }
       void SetStreamProgramNumber(int value) { m_streamProgramNumber = value; }
@@ -88,22 +87,22 @@ namespace enigma2
       bool IsIptvStream() const { return m_isIptvStream; }
 
       bool UpdateFrom(TiXmlElement* channelNode);
-      void UpdateTo(PVR_CHANNEL &left) const;
+      void UpdateTo(PVR_CHANNEL& left) const;
 
-      void AddChannelGroup(std::shared_ptr<enigma2::data::ChannelGroup> &channelGroup);
+      void AddChannelGroup(std::shared_ptr<enigma2::data::ChannelGroup>& channelGroup);
       std::vector<std::shared_ptr<enigma2::data::ChannelGroup>> GetChannelGroupList() { return m_channelGroupList; };
 
-      bool Like(const Channel &right) const;
-      bool operator==(const Channel &right) const;
-      bool operator!=(const Channel &right) const;
+      bool Like(const Channel& right) const;
+      bool operator==(const Channel& right) const;
+      bool operator!=(const Channel& right) const;
 
-      static std::string NormaliseServiceReference(const std::string &serviceReference);
-      static std::string CreateStandardServiceReference(const std::string &serviceReference);
+      static std::string NormaliseServiceReference(const std::string& serviceReference);
+      static std::string CreateStandardServiceReference(const std::string& serviceReference);
 
     private:
-      static std::string CreateCommonServiceReference(const std::string &serviceReference);
-      std::string CreateGenericServiceReference(const std::string &commonServiceReference);
-      std::string CreateIconPath(const std::string &commonServiceReference);
+      static std::string CreateCommonServiceReference(const std::string& serviceReference);
+      std::string CreateGenericServiceReference(const std::string& commonServiceReference);
+      std::string CreateIconPath(const std::string& commonServiceReference);
       std::string ExtractIptvStreamURL();
       bool HasRadioServiceType();
 

--- a/src/enigma2/data/Channel.h
+++ b/src/enigma2/data/Channel.h
@@ -48,7 +48,8 @@ namespace enigma2
         m_extendedServiceReference(c.GetExtendedServiceReference()), m_genericServiceReference(c.GetGenericServiceReference()),
         m_streamURL(c.GetStreamURL()), m_m3uURL(c.GetM3uURL()), m_iconPath(c.GetIconPath()),
         m_providerName(c.GetProviderName()), m_fuzzyChannelName(c.GetFuzzyChannelName()),
-        m_streamProgramNumber(c.GetStreamProgramNumber()), m_usingDefaultChannelNumber(c.UsingDefaultChannelNumber()) {};
+        m_streamProgramNumber(c.GetStreamProgramNumber()), m_usingDefaultChannelNumber(c.UsingDefaultChannelNumber()),
+        m_isIptvStream(c.IsIptvStream()) {};
       ~Channel() = default;
 
       int GetChannelNumber() const { return m_channelNumber; }
@@ -84,6 +85,8 @@ namespace enigma2
       bool UsingDefaultChannelNumber() const { return m_usingDefaultChannelNumber; }
       void SetUsingDefaultChannelNumber(bool value) { m_usingDefaultChannelNumber = value; }
 
+      bool IsIptvStream() const { return m_isIptvStream; }
+
       bool UpdateFrom(TiXmlElement* channelNode);
       void UpdateTo(PVR_CHANNEL &left) const;
 
@@ -101,10 +104,12 @@ namespace enigma2
       static std::string CreateCommonServiceReference(const std::string &serviceReference);
       std::string CreateGenericServiceReference(const std::string &commonServiceReference);
       std::string CreateIconPath(const std::string &commonServiceReference);
+      std::string ExtractIptvStreamURL();
       bool HasRadioServiceType();
 
       int m_channelNumber;
       bool m_usingDefaultChannelNumber = true;
+      bool m_isIptvStream = false;
       std::string m_standardServiceReference;
       std::string m_extendedServiceReference;
       std::string m_genericServiceReference;

--- a/src/enigma2/data/ChannelGroup.cpp
+++ b/src/enigma2/data/ChannelGroup.cpp
@@ -1,14 +1,14 @@
 #include "ChannelGroup.h"
 
 #include "inttypes.h"
-#include "util/XMLUtils.h"
 #include "p8-platform/util/StringUtils.h"
+#include "util/XMLUtils.h"
 
 using namespace enigma2;
 using namespace enigma2::data;
 using namespace enigma2::utilities;
 
-bool ChannelGroup::Like(const ChannelGroup &right) const
+bool ChannelGroup::Like(const ChannelGroup& right) const
 {
   bool isLike = (m_serviceReference == right.m_serviceReference);
   isLike &= (m_groupName == right.m_groupName);
@@ -16,7 +16,7 @@ bool ChannelGroup::Like(const ChannelGroup &right) const
   return isLike;
 }
 
-bool ChannelGroup::operator==(const ChannelGroup &right) const
+bool ChannelGroup::operator==(const ChannelGroup& right) const
 {
   bool isEqual = (m_serviceReference == right.m_serviceReference);
   isEqual &= (m_groupName == right.m_groupName);
@@ -34,7 +34,7 @@ bool ChannelGroup::operator==(const ChannelGroup &right) const
   return isEqual;
 }
 
-bool ChannelGroup::operator!=(const ChannelGroup &right) const
+bool ChannelGroup::operator!=(const ChannelGroup& right) const
 {
   return !(*this == right);
 }
@@ -65,7 +65,7 @@ bool ChannelGroup::UpdateFrom(TiXmlElement* groupNode, bool radio)
   if (!radio && (Settings::GetInstance().GetTVChannelGroupMode() == ChannelGroupMode::SOME_GROUPS ||
                  Settings::GetInstance().GetTVChannelGroupMode() == ChannelGroupMode::CUSTOM_GROUPS))
   {
-    auto &customGroupNamelist = Settings::GetInstance().GetCustomTVChannelGroupNameList();
+    auto& customGroupNamelist = Settings::GetInstance().GetCustomTVChannelGroupNameList();
     auto it = std::find_if(customGroupNamelist.begin(), customGroupNamelist.end(),
       [&groupName](std::string& customGroupName) { return customGroupName == groupName; });
 
@@ -77,7 +77,7 @@ bool ChannelGroup::UpdateFrom(TiXmlElement* groupNode, bool radio)
   else if (radio && (Settings::GetInstance().GetRadioChannelGroupMode() == ChannelGroupMode::SOME_GROUPS ||
                      Settings::GetInstance().GetRadioChannelGroupMode() == ChannelGroupMode::CUSTOM_GROUPS))
   {
-    auto &customGroupNamelist = Settings::GetInstance().GetCustomRadioChannelGroupNameList();
+    auto& customGroupNamelist = Settings::GetInstance().GetCustomRadioChannelGroupNameList();
     auto it = std::find_if(customGroupNamelist.begin(), customGroupNamelist.end(),
       [&groupName](std::string& customGroupName) { return customGroupName == groupName; });
 
@@ -98,7 +98,7 @@ bool ChannelGroup::UpdateFrom(TiXmlElement* groupNode, bool radio)
   return true;
 }
 
-void ChannelGroup::UpdateTo(PVR_CHANNEL_GROUP &left) const
+void ChannelGroup::UpdateTo(PVR_CHANNEL_GROUP& left) const
 {
   left.bIsRadio = m_radio;
   left.iPosition = 0; // groups default order, unused

--- a/src/enigma2/data/ChannelGroup.cpp
+++ b/src/enigma2/data/ChannelGroup.cpp
@@ -1,3 +1,25 @@
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
 #include "ChannelGroup.h"
 
 #include "inttypes.h"

--- a/src/enigma2/data/ChannelGroup.h
+++ b/src/enigma2/data/ChannelGroup.h
@@ -21,15 +21,14 @@
  *
  */
 
+#include "Channel.h"
+#include "EpgEntry.h"
+#include "tinyxml.h"
+#include "kodi/libXBMC_pvr.h"
+
 #include <memory>
 #include <string>
 #include <vector>
-
-#include "Channel.h"
-#include "EpgEntry.h"
-
-#include "kodi/libXBMC_pvr.h"
-#include "tinyxml.h"
 
 namespace enigma2
 {
@@ -51,10 +50,10 @@ namespace enigma2
       void SetUniqueId(int value) { m_uniqueId = value; }
 
       const std::string& GetServiceReference() const { return m_serviceReference; }
-      void SetServiceReference(const std::string& value ) { m_serviceReference = value; }
+      void SetServiceReference(const std::string& value) { m_serviceReference = value; }
 
       const std::string& GetGroupName() const { return m_groupName; }
-      void SetGroupName(const std::string& value ) { m_groupName = value; }
+      void SetGroupName(const std::string& value) { m_groupName = value; }
 
       bool IsLastScannedGroup() const { return m_lastScannedGroup; }
       void SetLastScannedGroup(bool value) { m_lastScannedGroup = value; }
@@ -70,13 +69,13 @@ namespace enigma2
       void AddChannel(std::shared_ptr<enigma2::data::Channel> channel);
 
       bool UpdateFrom(TiXmlElement* groupNode, bool radio);
-      void UpdateTo(PVR_CHANNEL_GROUP &left) const;
+      void UpdateTo(PVR_CHANNEL_GROUP& left) const;
 
       std::vector<std::shared_ptr<enigma2::data::Channel>> GetChannelList() { return m_channelList; };
 
-      bool Like(const ChannelGroup &right) const;
-      bool operator==(const ChannelGroup &right) const;
-      bool operator!=(const ChannelGroup &right) const;
+      bool Like(const ChannelGroup& right) const;
+      bool operator==(const ChannelGroup& right) const;
+      bool operator!=(const ChannelGroup& right) const;
 
     private:
       bool m_radio;

--- a/src/enigma2/data/ChannelGroup.h
+++ b/src/enigma2/data/ChannelGroup.h
@@ -1,6 +1,6 @@
 #pragma once
 /*
- *      Copyright (C) 2005-2015 Team XBMC
+ *      Copyright (C) 2005-2019 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify

--- a/src/enigma2/data/EpgChannel.h
+++ b/src/enigma2/data/EpgChannel.h
@@ -1,6 +1,6 @@
 #pragma once
 /*
- *      Copyright (C) 2005-2015 Team XBMC
+ *      Copyright (C) 2005-2019 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify

--- a/src/enigma2/data/EpgChannel.h
+++ b/src/enigma2/data/EpgChannel.h
@@ -21,15 +21,14 @@
  *
  */
 
+#include "BaseChannel.h"
+#include "EpgEntry.h"
+#include "tinyxml.h"
+#include "kodi/libXBMC_pvr.h"
+
 #include <memory>
 #include <string>
 #include <vector>
-
-#include "BaseChannel.h"
-#include "EpgEntry.h"
-
-#include "kodi/libXBMC_pvr.h"
-#include "tinyxml.h"
 
 namespace enigma2
 {
@@ -40,9 +39,8 @@ namespace enigma2
     class EpgChannel : public BaseChannel
     {
     public:
-
       EpgChannel() = default;
-      EpgChannel(const EpgChannel &e) : BaseChannel(e) {};
+      EpgChannel(const EpgChannel& e) : BaseChannel(e){};
       ~EpgChannel() = default;
 
       bool RequiresInitialEpg() const { return m_requiresInitialEpg; }
@@ -51,7 +49,6 @@ namespace enigma2
       std::vector<EpgEntry>& GetInitialEPG() { return m_initialEPG; }
 
     private:
-
       bool m_requiresInitialEpg = true;
 
       std::vector<EpgEntry> m_initialEPG;

--- a/src/enigma2/data/EpgEntry.cpp
+++ b/src/enigma2/data/EpgEntry.cpp
@@ -1,3 +1,25 @@
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
 #include "EpgEntry.h"
 
 #include "inttypes.h"

--- a/src/enigma2/data/EpgEntry.cpp
+++ b/src/enigma2/data/EpgEntry.cpp
@@ -7,7 +7,7 @@ using namespace enigma2;
 using namespace enigma2::data;
 using namespace enigma2::utilities;
 
-void EpgEntry::UpdateTo(EPG_TAG &left) const
+void EpgEntry::UpdateTo(EPG_TAG& left) const
 {
   left.iUniqueBroadcastId  = m_epgId;
   left.strTitle            = m_title.c_str();
@@ -36,13 +36,13 @@ void EpgEntry::UpdateTo(EPG_TAG &left) const
   left.iFlags              = EPG_TAG_FLAG_UNDEFINED;
 }
 
-bool EpgEntry::UpdateFrom(TiXmlElement* eventNode, std::map<std::string, std::shared_ptr<EpgChannel>> &epgChannelsMap)
+bool EpgEntry::UpdateFrom(TiXmlElement* eventNode, std::map<std::string, std::shared_ptr<EpgChannel>>& epgChannelsMap)
 {
-  if(!XMLUtils::GetString(eventNode, "e2eventservicereference", m_serviceReference))
+  if (!XMLUtils::GetString(eventNode, "e2eventservicereference", m_serviceReference))
     return false;
 
   // Check whether the current element is not just a label or that it's not an empty record
-  if (m_serviceReference.compare(0,5,"1:64:") == 0)
+  if (m_serviceReference.compare(0, 5, "1:64:") == 0)
     return false;
 
   m_serviceReference = Channel::NormaliseServiceReference(m_serviceReference);
@@ -64,7 +64,7 @@ bool EpgEntry::UpdateFrom(TiXmlElement* eventNode, std::map<std::string, std::sh
   return UpdateFrom(eventNode, epgChannel, 0, 0);
 }
 
-bool EpgEntry::UpdateFrom(TiXmlElement* eventNode, const std::shared_ptr<EpgChannel> &epgChannel, time_t iStart, time_t iEnd)
+bool EpgEntry::UpdateFrom(TiXmlElement* eventNode, const std::shared_ptr<EpgChannel>& epgChannel, time_t iStart, time_t iEnd)
 {
   std::string strTmp;
 
@@ -94,7 +94,7 @@ bool EpgEntry::UpdateFrom(TiXmlElement* eventNode, const std::shared_ptr<EpgChan
   m_epgId = iTmp;
   m_channelId = epgChannel->GetUniqueId();
 
-  if(!XMLUtils::GetString(eventNode, "e2eventtitle", strTmp))
+  if (!XMLUtils::GetString(eventNode, "e2eventtitle", strTmp))
     return false;
 
   m_title = strTmp;

--- a/src/enigma2/data/EpgEntry.h
+++ b/src/enigma2/data/EpgEntry.h
@@ -21,14 +21,13 @@
  *
  */
 
-#include <map>
-#include <string>
-
 #include "BaseEntry.h"
 #include "EpgChannel.h"
-
-#include "kodi/libXBMC_pvr.h"
 #include "tinyxml.h"
+#include "kodi/libXBMC_pvr.h"
+
+#include <map>
+#include <string>
 
 namespace enigma2
 {
@@ -41,7 +40,7 @@ namespace enigma2
       void SetEpgId(int value) { m_epgId = value; }
 
       const std::string& GetServiceReference() const { return m_serviceReference; }
-      void SetServiceReference(const std::string& value ) { m_serviceReference = value; }
+      void SetServiceReference(const std::string& value) { m_serviceReference = value; }
 
       int GetChannelId() const { return m_channelId; }
       void SetChannelId(int value) { m_channelId = value; }
@@ -52,9 +51,9 @@ namespace enigma2
       time_t GetEndTime() const { return m_endTime; }
       void SetEndTime(time_t value) { m_endTime = value; }
 
-      void UpdateTo(EPG_TAG &left) const;
-      bool UpdateFrom(TiXmlElement* eventNode, std::map<std::string, std::shared_ptr<EpgChannel>> &m_epgChannelsMap);
-      bool UpdateFrom(TiXmlElement* eventNode, const std::shared_ptr<EpgChannel> &epgChannel, time_t iStart, time_t iEnd);
+      void UpdateTo(EPG_TAG& left) const;
+      bool UpdateFrom(TiXmlElement* eventNode, std::map<std::string, std::shared_ptr<EpgChannel>>& m_epgChannelsMap);
+      bool UpdateFrom(TiXmlElement* eventNode, const std::shared_ptr<EpgChannel>& epgChannel, time_t iStart, time_t iEnd);
 
     protected:
       unsigned int m_epgId;

--- a/src/enigma2/data/EpgEntry.h
+++ b/src/enigma2/data/EpgEntry.h
@@ -1,6 +1,6 @@
 #pragma once
 /*
- *      Copyleft (C) 2005-2015 Team XBMC
+ *      Copyleft (C) 2005-2019 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify

--- a/src/enigma2/data/EpgPartialEntry.h
+++ b/src/enigma2/data/EpgPartialEntry.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <string>
-
 #include "BaseEntry.h"
+
+#include <string>
 
 namespace enigma2
 {
@@ -10,14 +10,14 @@ namespace enigma2
   {
     class EpgPartialEntry : public BaseEntry
     {
-      public:
-        unsigned int GetEpgUid() const { return m_epgUid; }
-        void SetEpgUid(unsigned int value) { m_epgUid = value; }
+    public:
+      unsigned int GetEpgUid() const { return m_epgUid; }
+      void SetEpgUid(unsigned int value) { m_epgUid = value; }
 
-        bool EntryFound() const { return m_epgUid != 0; };
+      bool EntryFound() const { return m_epgUid != 0; };
 
-      private:
-        unsigned int m_epgUid = 0;
+    private:
+      unsigned int m_epgUid = 0;
     };
   } //namespace data
 } //namespace enigma2

--- a/src/enigma2/data/EpgPartialEntry.h
+++ b/src/enigma2/data/EpgPartialEntry.h
@@ -1,4 +1,25 @@
 #pragma once
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
 
 #include "BaseEntry.h"
 

--- a/src/enigma2/data/RecordingEntry.cpp
+++ b/src/enigma2/data/RecordingEntry.cpp
@@ -27,6 +27,8 @@
 #include "p8-platform/util/StringUtils.h"
 #include "util/XMLUtils.h"
 
+#include <cstdlib>
+
 using namespace enigma2;
 using namespace enigma2::data;
 using namespace enigma2::utilities;
@@ -149,8 +151,8 @@ long RecordingEntry::TimeStringToSeconds(const std::string& timeString)
 
   if (tokens.size() == 2)
   {
-    timeInSecs += atoi(tokens[0].c_str()) * 60;
-    timeInSecs += atoi(tokens[1].c_str());
+    timeInSecs += std::atoi(tokens[0].c_str()) * 60;
+    timeInSecs += std::atoi(tokens[1].c_str());
   }
 
   return timeInSecs;

--- a/src/enigma2/data/RecordingEntry.cpp
+++ b/src/enigma2/data/RecordingEntry.cpp
@@ -1,16 +1,15 @@
 #include "RecordingEntry.h"
 
 #include "../utilities/WebUtils.h"
-
 #include "inttypes.h"
-#include "util/XMLUtils.h"
 #include "p8-platform/util/StringUtils.h"
+#include "util/XMLUtils.h"
 
 using namespace enigma2;
 using namespace enigma2::data;
 using namespace enigma2::utilities;
 
-bool RecordingEntry::UpdateFrom(TiXmlElement* recordingNode, const std::string &directory, bool deleted, Channels &channels)
+bool RecordingEntry::UpdateFrom(TiXmlElement* recordingNode, const std::string& directory, bool deleted, Channels& channels)
 {
   std::string strTmp;
   int iTmp;
@@ -107,7 +106,7 @@ bool RecordingEntry::UpdateFrom(TiXmlElement* recordingNode, const std::string &
   return true;
 }
 
-long RecordingEntry::TimeStringToSeconds(const std::string &timeString)
+long RecordingEntry::TimeStringToSeconds(const std::string& timeString)
 {
   std::vector<std::string> tokens;
 
@@ -135,7 +134,7 @@ long RecordingEntry::TimeStringToSeconds(const std::string &timeString)
   return timeInSecs;
 }
 
-void RecordingEntry::UpdateTo(PVR_RECORDING &left, Channels &channels, bool isInRecordingFolder)
+void RecordingEntry::UpdateTo(PVR_RECORDING& left, Channels& channels, bool isInRecordingFolder)
 {
   std::string strTmp;
   strncpy(left.strRecordingId, m_recordingId.c_str(), sizeof(left.strRecordingId));
@@ -147,7 +146,7 @@ void RecordingEntry::UpdateTo(PVR_RECORDING &left, Channels &channels, bool isIn
 
   if (!Settings::GetInstance().GetKeepRecordingsFolders())
   {
-    if(isInRecordingFolder)
+    if (isInRecordingFolder)
       strTmp = StringUtils::Format("/%s/", m_title.c_str());
     else
       strTmp = StringUtils::Format("/");
@@ -181,7 +180,7 @@ void RecordingEntry::UpdateTo(PVR_RECORDING &left, Channels &channels, bool isIn
   strncpy(left.strGenreDescription, m_genreDescription.c_str(), sizeof(left.strGenreDescription));
 }
 
-std::shared_ptr<Channel> RecordingEntry::FindChannel(Channels &channels) const
+std::shared_ptr<Channel> RecordingEntry::FindChannel(Channels& channels) const
 {
   std::shared_ptr<Channel> channel = GetChannelFromChannelReferenceTag(channels);
 
@@ -220,7 +219,7 @@ std::shared_ptr<Channel> RecordingEntry::FindChannel(Channels &channels) const
   return channel;
 }
 
-std::shared_ptr<Channel> RecordingEntry::GetChannelFromChannelReferenceTag(Channels &channels) const
+std::shared_ptr<Channel> RecordingEntry::GetChannelFromChannelReferenceTag(Channels& channels) const
 {
   std::string channelServiceReference;
 
@@ -235,13 +234,12 @@ std::shared_ptr<Channel> RecordingEntry::GetChannelFromChannelReferenceTag(Chann
   return channels.GetChannel(channelServiceReference);
 }
 
-std::shared_ptr<Channel> RecordingEntry::GetChannelFromChannelNameSearch(Channels &channels) const
+std::shared_ptr<Channel> RecordingEntry::GetChannelFromChannelNameSearch(Channels& channels) const
 {
   //search for channel name using exact match
   for (const auto& channel : channels.GetChannelsList())
   {
-    if (m_channelName == channel->GetChannelName() &&
-        (!m_haveChannelType || (channel->IsRadio() == m_radio)))
+    if (m_channelName == channel->GetChannelName() && (!m_haveChannelType || (channel->IsRadio() == m_radio)))
     {
       return channel;
     }
@@ -250,7 +248,7 @@ std::shared_ptr<Channel> RecordingEntry::GetChannelFromChannelNameSearch(Channel
   return nullptr;
 }
 
-std::shared_ptr<Channel> RecordingEntry::GetChannelFromChannelNameFuzzySearch(Channels &channels) const
+std::shared_ptr<Channel> RecordingEntry::GetChannelFromChannelNameFuzzySearch(Channels& channels) const
 {
   std::string fuzzyRecordingChannelName;
 
@@ -260,8 +258,7 @@ std::shared_ptr<Channel> RecordingEntry::GetChannelFromChannelNameFuzzySearch(Ch
     fuzzyRecordingChannelName = m_channelName;
     fuzzyRecordingChannelName.erase(remove_if(fuzzyRecordingChannelName.begin(), fuzzyRecordingChannelName.end(), isspace), fuzzyRecordingChannelName.end());
 
-    if (fuzzyRecordingChannelName == channel->GetFuzzyChannelName() &&
-        (!m_haveChannelType || (channel->IsRadio() == m_radio)))
+    if (fuzzyRecordingChannelName == channel->GetFuzzyChannelName() && (!m_haveChannelType || (channel->IsRadio() == m_radio)))
     {
       return channel;
     }

--- a/src/enigma2/data/RecordingEntry.cpp
+++ b/src/enigma2/data/RecordingEntry.cpp
@@ -1,3 +1,25 @@
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
 #include "RecordingEntry.h"
 
 #include "../utilities/WebUtils.h"

--- a/src/enigma2/data/RecordingEntry.h
+++ b/src/enigma2/data/RecordingEntry.h
@@ -1,6 +1,6 @@
 #pragma once
 /*
- *      Copyright (C) 2005-2015 Team XBMC
+ *      Copyright (C) 2005-2019 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify

--- a/src/enigma2/data/RecordingEntry.h
+++ b/src/enigma2/data/RecordingEntry.h
@@ -21,15 +21,14 @@
  *
  */
 
-#include <string>
-
+#include "../Channels.h"
 #include "BaseEntry.h"
 #include "Channel.h"
 #include "Tags.h"
-#include "../Channels.h"
-
-#include "kodi/libXBMC_pvr.h"
 #include "tinyxml.h"
+#include "kodi/libXBMC_pvr.h"
+
+#include <string>
 namespace enigma2
 {
   namespace data
@@ -42,7 +41,7 @@ namespace enigma2
     {
     public:
       const std::string& GetRecordingId() const { return m_recordingId; }
-      void SetRecordingId(const std::string& value ) { m_recordingId = value; }
+      void SetRecordingId(const std::string& value) { m_recordingId = value; }
 
       time_t GetStartTime() const { return m_startTime; }
       void SetStartTime(time_t value) { m_startTime = value; }
@@ -60,22 +59,22 @@ namespace enigma2
       void SetNextSyncTime(time_t value) { m_nextSyncTime = value; }
 
       const std::string& GetStreamURL() const { return m_streamURL; }
-      void SetStreamURL(const std::string& value ) { m_streamURL = value; }
+      void SetStreamURL(const std::string& value) { m_streamURL = value; }
 
       const std::string& GetEdlURL() const { return m_edlURL; }
-      void SetEdlURL(const std::string& value ) { m_edlURL = value; }
+      void SetEdlURL(const std::string& value) { m_edlURL = value; }
 
       const std::string& GetChannelName() const { return m_channelName; }
-      void SetChannelName(const std::string& value ) { m_channelName = value; }
+      void SetChannelName(const std::string& value) { m_channelName = value; }
 
       int GetChannelUniqueId() const { return m_channelUniqueId; }
       void SetChannelUniqueId(int value) { m_channelUniqueId = value; }
 
       const std::string& GetDirectory() const { return m_directory; }
-      void SetDirectory(const std::string& value ) { m_directory = value; }
+      void SetDirectory(const std::string& value) { m_directory = value; }
 
       const std::string& GetIconPath() const { return m_iconPath; }
-      void SetIconPath(const std::string& value ) { m_iconPath = value; }
+      void SetIconPath(const std::string& value) { m_iconPath = value; }
 
       int GetStreamProgramNumber() const { return m_streamProgramNumber; }
       void SetStreamProgramNumber(int value) { m_streamProgramNumber = value; }
@@ -88,16 +87,16 @@ namespace enigma2
       bool IsDeleted() const { return m_deleted; }
       void SetDeleted(bool value) { m_deleted = value; }
 
-      bool UpdateFrom(TiXmlElement* recordingNode, const std::string &directory, bool deleted, enigma2::Channels &channels);
-      void UpdateTo(PVR_RECORDING &left, Channels &channels, bool isInRecordingFolder);
+      bool UpdateFrom(TiXmlElement* recordingNode, const std::string& directory, bool deleted, enigma2::Channels& channels);
+      void UpdateTo(PVR_RECORDING& left, Channels& channels, bool isInRecordingFolder);
 
     private:
-      long TimeStringToSeconds(const std::string &timeString);
+      long TimeStringToSeconds(const std::string& timeString);
 
-      std::shared_ptr<Channel> FindChannel(enigma2::Channels &channels) const;
-      std::shared_ptr<Channel> GetChannelFromChannelReferenceTag(enigma2::Channels &channels) const;
-      std::shared_ptr<Channel> GetChannelFromChannelNameSearch(enigma2::Channels &channels) const;
-      std::shared_ptr<Channel> GetChannelFromChannelNameFuzzySearch(enigma2::Channels &channels) const;
+      std::shared_ptr<Channel> FindChannel(enigma2::Channels& channels) const;
+      std::shared_ptr<Channel> GetChannelFromChannelReferenceTag(enigma2::Channels& channels) const;
+      std::shared_ptr<Channel> GetChannelFromChannelNameSearch(enigma2::Channels& channels) const;
+      std::shared_ptr<Channel> GetChannelFromChannelNameFuzzySearch(enigma2::Channels& channels) const;
 
       std::string m_recordingId;
       time_t m_startTime;

--- a/src/enigma2/data/Tags.h
+++ b/src/enigma2/data/Tags.h
@@ -1,6 +1,6 @@
 #pragma once
 /*
- *      Copyright (C) 2005-2015 Team XBMC
+ *      Copyright (C) 2005-2019 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify

--- a/src/enigma2/data/Tags.h
+++ b/src/enigma2/data/Tags.h
@@ -50,7 +50,7 @@ namespace enigma2
       {
         std::regex regex("^.* ?" + tag + " ?.*$");
 
-        return (regex_match(m_tags, regex));
+        return (std::regex_match(m_tags, regex));
       }
 
       void AddTag(const std::string& tagName, const std::string& tagValue = "", bool replaceUnderscores = false)
@@ -98,7 +98,7 @@ namespace enigma2
         std::regex regex(" *" + tagName + "=?[^\\s-]*");
         std::string replaceWith = "";
 
-        m_tags = regex_replace(m_tags, regex, replaceWith);
+        m_tags = std::regex_replace(m_tags, regex, replaceWith);
       }
 
     protected:

--- a/src/enigma2/data/Tags.h
+++ b/src/enigma2/data/Tags.h
@@ -21,10 +21,10 @@
  *
  */
 
-#include <string>
-#include <regex>
-
 #include "p8-platform/util/StringUtils.h"
+
+#include <regex>
+#include <string>
 
 namespace enigma2
 {
@@ -44,16 +44,16 @@ namespace enigma2
       Tags(const std::string& tags) : m_tags(tags) {};
 
       const std::string& GetTags() const { return m_tags; }
-      void SetTags(const std::string& value ) { m_tags = value; }
+      void SetTags(const std::string& value) { m_tags = value; }
 
-      bool ContainsTag(const std::string &tag) const
+      bool ContainsTag(const std::string& tag) const
       {
         std::regex regex("^.* ?" + tag + " ?.*$");
 
         return (regex_match(m_tags, regex));
       }
 
-      void AddTag(const std::string &tagName, const std::string &tagValue = "", bool replaceUnderscores = false)
+      void AddTag(const std::string& tagName, const std::string& tagValue = "", bool replaceUnderscores = false)
       {
         RemoveTag(tagName);
 
@@ -71,7 +71,7 @@ namespace enigma2
         }
       }
 
-      std::string ReadTagValue(const std::string &tagName, bool replaceUnderscores = false) const
+      std::string ReadTagValue(const std::string& tagName, bool replaceUnderscores = false) const
       {
         std::string tagValue;
 
@@ -93,7 +93,7 @@ namespace enigma2
         return tagValue;
       }
 
-      void RemoveTag(const std::string &tagName)
+      void RemoveTag(const std::string& tagName)
       {
         std::regex regex(" *" + tagName + "=?[^\\s-]*");
         std::string replaceWith = "";

--- a/src/enigma2/data/Timer.cpp
+++ b/src/enigma2/data/Timer.cpp
@@ -1,18 +1,17 @@
 #include "Timer.h"
 
-#include <regex>
-
 #include "../utilities/LocalizedString.h"
-
 #include "inttypes.h"
-#include "util/XMLUtils.h"
 #include "p8-platform/util/StringUtils.h"
+#include "util/XMLUtils.h"
+
+#include <regex>
 
 using namespace enigma2;
 using namespace enigma2::data;
 using namespace enigma2::utilities;
 
-bool Timer::Like(const Timer &right) const
+bool Timer::Like(const Timer& right) const
 {
   bool isLike = (m_startTime == right.m_startTime);
   isLike &= (m_endTime == right.m_endTime);
@@ -23,7 +22,7 @@ bool Timer::Like(const Timer &right) const
   return isLike;
 }
 
-bool Timer::operator==(const Timer &right) const
+bool Timer::operator==(const Timer& right) const
 {
   bool isEqual = (m_startTime == right.m_startTime);
   isEqual &= (m_endTime == right.m_endTime);
@@ -49,7 +48,7 @@ bool Timer::operator==(const Timer &right) const
   return isEqual;
 }
 
-void Timer::UpdateFrom(const Timer &right)
+void Timer::UpdateFrom(const Timer& right)
 {
   m_title = right.m_title;
   m_plot = right.m_plot;
@@ -74,36 +73,35 @@ void Timer::UpdateFrom(const Timer &right)
   m_year = right.m_year;
 }
 
-void Timer::UpdateTo(PVR_TIMER &left) const
+void Timer::UpdateTo(PVR_TIMER& left) const
 {
   strncpy(left.strTitle, m_title.c_str(), sizeof(left.strTitle));
-  strncpy(left.strDirectory, "/", sizeof(left.strDirectory));   // unused
+  strncpy(left.strDirectory, "/", sizeof(left.strDirectory)); // unused
   strncpy(left.strSummary, m_plot.c_str(), sizeof(left.strSummary));
-  left.iTimerType         = m_type;
-  left.iClientChannelUid   = m_channelId;
-  left.startTime           = m_startTime;
-  left.endTime             = m_endTime;
-  left.state               = m_state;
-  left.iPriority           = 0;     // unused
-  left.iLifetime           = 0;     // unused
-  left.firstDay            = 0;     // unused
-  left.iWeekdays           = m_weekdays;
-  left.iEpgUid             = m_epgId;
-  left.iMarginStart        = m_paddingStartMins;
-  left.iMarginEnd          = m_paddingEndMins;
-  left.iGenreType          = 0;     // unused
-  left.iGenreSubType       = 0;     // unused
-  left.iClientIndex        = m_clientIndex;
-  left.iParentClientIndex  = m_parentClientIndex;
+  left.iTimerType = m_type;
+  left.iClientChannelUid = m_channelId;
+  left.startTime = m_startTime;
+  left.endTime = m_endTime;
+  left.state = m_state;
+  left.iPriority = 0; // unused
+  left.iLifetime = 0; // unused
+  left.firstDay = 0; // unused
+  left.iWeekdays = m_weekdays;
+  left.iEpgUid = m_epgId;
+  left.iMarginStart = m_paddingStartMins;
+  left.iMarginEnd = m_paddingEndMins;
+  left.iGenreType = 0; // unused
+  left.iGenreSubType = 0; // unused
+  left.iClientIndex = m_clientIndex;
+  left.iParentClientIndex = m_parentClientIndex;
 }
 
 bool Timer::IsScheduled() const
 {
-  return m_state == PVR_TIMER_STATE_SCHEDULED
-      || m_state == PVR_TIMER_STATE_RECORDING;
+  return m_state == PVR_TIMER_STATE_SCHEDULED || m_state == PVR_TIMER_STATE_RECORDING;
 }
 
-bool Timer::IsRunning(std::time_t *now, std::string *channelName, std::time_t startTime) const
+bool Timer::IsRunning(std::time_t* now, std::string* channelName, std::time_t startTime) const
 {
   if (!IsScheduled())
     return false;
@@ -116,7 +114,7 @@ bool Timer::IsRunning(std::time_t *now, std::string *channelName, std::time_t st
   return true;
 }
 
-bool Timer::IsChildOfParent(const Timer &parent) const
+bool Timer::IsChildOfParent(const Timer& parent) const
 {
   time_t time;
   std::tm timeinfo;
@@ -155,7 +153,7 @@ bool Timer::IsChildOfParent(const Timer &parent) const
   return isChild;
 }
 
-bool Timer::UpdateFrom(TiXmlElement* timerNode, Channels &channels)
+bool Timer::UpdateFrom(TiXmlElement* timerNode, Channels& channels)
 {
   std::string strTmp;
 

--- a/src/enigma2/data/Timer.cpp
+++ b/src/enigma2/data/Timer.cpp
@@ -1,3 +1,25 @@
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
 #include "Timer.h"
 
 #include "../utilities/LocalizedString.h"

--- a/src/enigma2/data/Timer.h
+++ b/src/enigma2/data/Timer.h
@@ -21,17 +21,16 @@
  *
  */
 
-#include <string>
-#include <ctime>
-#include <type_traits>
-
-#include "BaseEntry.h"
-#include "Tags.h"
 #include "../Channels.h"
 #include "../utilities/UpdateState.h"
-
-#include "kodi/libXBMC_pvr.h"
+#include "BaseEntry.h"
+#include "Tags.h"
 #include "tinyxml.h"
+#include "kodi/libXBMC_pvr.h"
+
+#include <ctime>
+#include <string>
+#include <type_traits>
 
 namespace enigma2
 {
@@ -65,16 +64,16 @@ namespace enigma2
       }
 
       Type GetType() const { return m_type; }
-      void SetType(const Type value ) { m_type = value; }
+      void SetType(const Type value) { m_type = value; }
 
       const std::string& GetServiceReference() const { return m_serviceReference; }
-      void SetServiceReference(const std::string& value ) { m_serviceReference = value; }
+      void SetServiceReference(const std::string& value) { m_serviceReference = value; }
 
       int GetChannelId() const { return m_channelId; }
       void SetChannelId(int value) { m_channelId = value; }
 
       const std::string& GetChannelName() const { return m_channelName; }
-      void SetChannelName(const std::string& value ) { m_channelName = value; }
+      void SetChannelName(const std::string& value) { m_channelName = value; }
 
       time_t GetStartTime() const { return m_startTime; }
       void SetStartTime(time_t value) { m_startTime = value; }
@@ -110,14 +109,14 @@ namespace enigma2
       void SetPaddingEndMins(int value) { m_paddingEndMins = value; }
 
       bool IsScheduled() const;
-      bool IsRunning(std::time_t *now, std::string *channelName, std::time_t startTime) const;
-      bool IsChildOfParent(const Timer &parent) const;
+      bool IsRunning(std::time_t* now, std::string* channelName, std::time_t startTime) const;
+      bool IsChildOfParent(const Timer& parent) const;
 
-      bool Like(const Timer &right) const;
-      bool operator==(const Timer &right) const;
-      void UpdateFrom(const Timer &right);
-      void UpdateTo(PVR_TIMER &right) const;
-      bool UpdateFrom(TiXmlElement* timerNode, Channels &channels);
+      bool Like(const Timer& right) const;
+      bool operator==(const Timer& right) const;
+      void UpdateFrom(const Timer& right);
+      void UpdateTo(PVR_TIMER& right) const;
+      bool UpdateFrom(TiXmlElement* timerNode, Channels& channels);
 
     protected:
       Type m_type = Type::MANUAL_ONCE;

--- a/src/enigma2/data/Timer.h
+++ b/src/enigma2/data/Timer.h
@@ -1,6 +1,6 @@
 #pragma once
 /*
- *      Copyright (C) 2005-2015 Team XBMC
+ *      Copyright (C) 2005-2019 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify

--- a/src/enigma2/extract/EpgEntryExtractor.cpp
+++ b/src/enigma2/extract/EpgEntryExtractor.cpp
@@ -1,3 +1,25 @@
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
 #include "EpgEntryExtractor.h"
 
 #include "../utilities/FileUtils.h"

--- a/src/enigma2/extract/EpgEntryExtractor.cpp
+++ b/src/enigma2/extract/EpgEntryExtractor.cpp
@@ -1,9 +1,9 @@
 #include "EpgEntryExtractor.h"
 
+#include "../utilities/FileUtils.h"
 #include "GenreIdMapper.h"
 #include "GenreRytecTextMapper.h"
 #include "ShowInfoExtractor.h"
-#include "../utilities/FileUtils.h"
 
 using namespace enigma2;
 using namespace enigma2::data;
@@ -31,11 +31,9 @@ EpgEntryExtractor::EpgEntryExtractor()
   }
 }
 
-EpgEntryExtractor::~EpgEntryExtractor(void)
-{
-}
+EpgEntryExtractor::~EpgEntryExtractor(void) {}
 
-void EpgEntryExtractor::ExtractFromEntry(BaseEntry &entry)
+void EpgEntryExtractor::ExtractFromEntry(BaseEntry& entry)
 {
   for (auto& extractor : m_extractors)
   {
@@ -44,7 +42,4 @@ void EpgEntryExtractor::ExtractFromEntry(BaseEntry &entry)
   }
 }
 
-bool EpgEntryExtractor::IsEnabled()
-{
-  return m_anyExtractorEnabled;
-}
+bool EpgEntryExtractor::IsEnabled() { return m_anyExtractorEnabled; }

--- a/src/enigma2/extract/EpgEntryExtractor.h
+++ b/src/enigma2/extract/EpgEntryExtractor.h
@@ -1,10 +1,10 @@
 #pragma once
 
+#include "IExtractor.h"
+
 #include <memory>
 #include <string>
 #include <vector>
-
-#include "IExtractor.h"
 
 namespace enigma2
 {
@@ -15,14 +15,13 @@ namespace enigma2
     static const std::string SHOW_INFO_DIR = "/showInfo";
     static const std::string SHOW_INFO_ADDON_DATA_BASE_DIR = ADDON_DATA_BASE_DIR + SHOW_INFO_DIR;
 
-    class EpgEntryExtractor
-      : public IExtractor
+    class EpgEntryExtractor : public IExtractor
     {
     public:
       EpgEntryExtractor();
       ~EpgEntryExtractor(void);
 
-      void ExtractFromEntry(enigma2::data::BaseEntry &entry);
+      void ExtractFromEntry(enigma2::data::BaseEntry& entry);
       bool IsEnabled();
 
     private:

--- a/src/enigma2/extract/EpgEntryExtractor.h
+++ b/src/enigma2/extract/EpgEntryExtractor.h
@@ -1,4 +1,25 @@
 #pragma once
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
 
 #include "IExtractor.h"
 

--- a/src/enigma2/extract/EpisodeSeasonPattern.h
+++ b/src/enigma2/extract/EpisodeSeasonPattern.h
@@ -8,7 +8,7 @@ namespace enigma2
   {
     struct EpisodeSeasonPattern
     {
-      EpisodeSeasonPattern(const std::string &masterPattern, const std::string &seasonPattern, const std::string &episodePattern)
+      EpisodeSeasonPattern(const std::string& masterPattern, const std::string& seasonPattern, const std::string& episodePattern)
       {
         m_masterRegex = std::regex(masterPattern);
         m_seasonRegex = std::regex(seasonPattern);
@@ -16,7 +16,7 @@ namespace enigma2
         m_hasSeasonRegex = true;
       }
 
-      EpisodeSeasonPattern(const std::string &masterPattern, const std::string &episodePattern)
+      EpisodeSeasonPattern(const std::string& masterPattern, const std::string& episodePattern)
       {
         m_masterRegex = std::regex(masterPattern);
         m_episodeRegex = std::regex(episodePattern);

--- a/src/enigma2/extract/EpisodeSeasonPattern.h
+++ b/src/enigma2/extract/EpisodeSeasonPattern.h
@@ -1,4 +1,25 @@
 #pragma once
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
 
 #include <regex>
 

--- a/src/enigma2/extract/GenreIdMapper.cpp
+++ b/src/enigma2/extract/GenreIdMapper.cpp
@@ -28,6 +28,8 @@
 #include "kodi/libXBMC_pvr.h"
 #include "util/XMLUtils.h"
 
+#include <cstdlib>
+
 using namespace enigma2;
 using namespace enigma2::data;
 using namespace enigma2::extract;
@@ -155,8 +157,8 @@ bool GenreIdMapper::LoadIdToIdGenreFile(const std::string& xmlFile, std::map<int
     const std::string sourceIdString = pNode->Attribute("sourceId");
     const std::string targetIdString = pNode->GetText();
 
-    int sourceId = strtol(sourceIdString.c_str(), nullptr, 16);
-    int targetId = strtol(targetIdString.c_str(), nullptr, 16);
+    int sourceId = std::strtol(sourceIdString.c_str(), nullptr, 16);
+    int targetId = std::strtol(targetIdString.c_str(), nullptr, 16);
 
     map.insert({sourceId, targetId});
 

--- a/src/enigma2/extract/GenreIdMapper.cpp
+++ b/src/enigma2/extract/GenreIdMapper.cpp
@@ -1,3 +1,25 @@
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
 #include "GenreIdMapper.h"
 
 #include "../utilities/FileUtils.h"

--- a/src/enigma2/extract/GenreIdMapper.cpp
+++ b/src/enigma2/extract/GenreIdMapper.cpp
@@ -2,8 +2,8 @@
 
 #include "../utilities/FileUtils.h"
 
-#include "kodi/libXBMC_pvr.h"
 #include "tinyxml.h"
+#include "kodi/libXBMC_pvr.h"
 #include "util/XMLUtils.h"
 
 using namespace enigma2;
@@ -11,17 +11,14 @@ using namespace enigma2::data;
 using namespace enigma2::extract;
 using namespace enigma2::utilities;
 
-GenreIdMapper::GenreIdMapper()
-  : IExtractor()
+GenreIdMapper::GenreIdMapper() : IExtractor()
 {
   LoadGenreIdMapFile();
 }
 
-GenreIdMapper::~GenreIdMapper(void)
-{
-}
+GenreIdMapper::~GenreIdMapper(void) {}
 
-void GenreIdMapper::ExtractFromEntry(BaseEntry &entry)
+void GenreIdMapper::ExtractFromEntry(BaseEntry& entry)
 {
   if (entry.GetGenreType() != 0)
   {
@@ -71,7 +68,7 @@ void GenreIdMapper::LoadGenreIdMapFile()
     Logger::Log(LEVEL_ERROR, "%s Could not load genre id to dvb id file: %s", __FUNCTION__, Settings::GetInstance().GetMapGenreIdsFile().c_str());
 }
 
-bool GenreIdMapper::LoadIdToIdGenreFile(const std::string &xmlFile, std::map<int, int> &map)
+bool GenreIdMapper::LoadIdToIdGenreFile(const std::string& xmlFile, std::map<int, int>& map)
 {
   map.clear();
 

--- a/src/enigma2/extract/GenreIdMapper.h
+++ b/src/enigma2/extract/GenreIdMapper.h
@@ -1,4 +1,25 @@
 #pragma once
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
 
 #include "IExtractor.h"
 

--- a/src/enigma2/extract/GenreIdMapper.h
+++ b/src/enigma2/extract/GenreIdMapper.h
@@ -9,14 +9,13 @@ namespace enigma2
 {
   namespace extract
   {
-    class GenreIdMapper
-      : public IExtractor
+    class GenreIdMapper : public IExtractor
     {
     public:
       GenreIdMapper();
       ~GenreIdMapper();
 
-      void ExtractFromEntry(enigma2::data::BaseEntry &entry);
+      void ExtractFromEntry(enigma2::data::BaseEntry& entry);
       bool IsEnabled();
 
     private:
@@ -26,7 +25,7 @@ namespace enigma2
       int LookupGenreIdInMap(const int genreId);
 
       void LoadGenreIdMapFile();
-      bool LoadIdToIdGenreFile(const std::string &xmlFile, std::map<int, int> &map);
+      bool LoadIdToIdGenreFile(const std::string& xmlFile, std::map<int, int>& map);
       void CreateGenreAddonDataDirectories();
 
       std::map<int, int> m_genreIdToDvbIdMap;

--- a/src/enigma2/extract/GenreRytecTextMapper.cpp
+++ b/src/enigma2/extract/GenreRytecTextMapper.cpp
@@ -2,8 +2,8 @@
 
 #include "../utilities/FileUtils.h"
 
-#include "kodi/libXBMC_pvr.h"
 #include "tinyxml.h"
+#include "kodi/libXBMC_pvr.h"
 #include "util/XMLUtils.h"
 
 using namespace enigma2;
@@ -11,8 +11,7 @@ using namespace enigma2::data;
 using namespace enigma2::extract;
 using namespace enigma2::utilities;
 
-GenreRytecTextMapper::GenreRytecTextMapper()
-  : IExtractor()
+GenreRytecTextMapper::GenreRytecTextMapper() : IExtractor()
 {
   LoadGenreTextMappingFiles();
 
@@ -25,11 +24,9 @@ GenreRytecTextMapper::GenreRytecTextMapper()
   m_genreMajorPattern = std::regex(GENRE_MAJOR_PATTERN);
 }
 
-GenreRytecTextMapper::~GenreRytecTextMapper(void)
-{
-}
+GenreRytecTextMapper::~GenreRytecTextMapper(void) {}
 
-void GenreRytecTextMapper::ExtractFromEntry(BaseEntry &entry)
+void GenreRytecTextMapper::ExtractFromEntry(BaseEntry& entry)
 {
   if (entry.GetGenreType() == 0)
   {
@@ -71,7 +68,7 @@ int GenreRytecTextMapper::GetGenreSubTypeFromCombined(int combinedGenreType)
   return combinedGenreType & 0x0F;
 }
 
-int GenreRytecTextMapper::GetGenreTypeFromText(const std::string &genreText, const std::string &showName)
+int GenreRytecTextMapper::GetGenreTypeFromText(const std::string& genreText, const std::string& showName)
 {
   int genreType = LookupGenreValueInMaps(genreText);
 
@@ -94,7 +91,7 @@ int GenreRytecTextMapper::GetGenreTypeFromText(const std::string &genreText, con
   return genreType;
 }
 
-int GenreRytecTextMapper::LookupGenreValueInMaps(const std::string &genreText)
+int GenreRytecTextMapper::LookupGenreValueInMaps(const std::string& genreText)
 {
   int genreType = EPG_EVENT_CONTENTMASK_UNDEFINED;
 
@@ -124,7 +121,7 @@ void GenreRytecTextMapper::LoadGenreTextMappingFiles()
     Logger::Log(LEVEL_ERROR, "%s Could not load genre id to dvb id file: %s", __FUNCTION__, Settings::GetInstance().GetMapRytecTextGenresFile().c_str());
 }
 
-bool GenreRytecTextMapper::LoadTextToIdGenreFile(const std::string &xmlFile, std::map<std::string, int> &map)
+bool GenreRytecTextMapper::LoadTextToIdGenreFile(const std::string& xmlFile, std::map<std::string, int>& map)
 {
   map.clear();
 

--- a/src/enigma2/extract/GenreRytecTextMapper.cpp
+++ b/src/enigma2/extract/GenreRytecTextMapper.cpp
@@ -1,3 +1,25 @@
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
 #include "GenreRytecTextMapper.h"
 
 #include "../utilities/FileUtils.h"

--- a/src/enigma2/extract/GenreRytecTextMapper.cpp
+++ b/src/enigma2/extract/GenreRytecTextMapper.cpp
@@ -28,6 +28,8 @@
 #include "kodi/libXBMC_pvr.h"
 #include "util/XMLUtils.h"
 
+#include <cstdlib>
+
 using namespace enigma2;
 using namespace enigma2::data;
 using namespace enigma2::extract;
@@ -208,7 +210,7 @@ bool GenreRytecTextMapper::LoadTextToIdGenreFile(const std::string& xmlFile, std
     const std::string targetIdString = pNode->Attribute("targetId");
     const std::string textMapping = pNode->GetText();
 
-    int targetId = strtol(targetIdString.c_str(), nullptr, 16);
+    int targetId = std::strtol(targetIdString.c_str(), nullptr, 16);
 
     map.insert({textMapping, targetId});
 

--- a/src/enigma2/extract/GenreRytecTextMapper.h
+++ b/src/enigma2/extract/GenreRytecTextMapper.h
@@ -16,25 +16,24 @@ namespace enigma2
 
     static const std::string GENRE_KODI_DVB_FILEPATH = "special://userdata/addon_data/pvr.vuplus/genres/kodiDvbGenres.xml";
 
-    class GenreRytecTextMapper
-      : public IExtractor
+    class GenreRytecTextMapper : public IExtractor
     {
     public:
       GenreRytecTextMapper();
       ~GenreRytecTextMapper();
 
-      void ExtractFromEntry(enigma2::data::BaseEntry &entry);
+      void ExtractFromEntry(enigma2::data::BaseEntry& entry);
       bool IsEnabled();
 
     private:
       static int GetGenreTypeFromCombined(int combinedGenreType);
       static int GetGenreSubTypeFromCombined(int combinedGenreType);
 
-      int GetGenreTypeFromText(const std::string &genreText, const std::string &showName);
-      int LookupGenreValueInMaps(const std::string &genreText);
+      int GetGenreTypeFromText(const std::string& genreText, const std::string& showName);
+      int LookupGenreValueInMaps(const std::string& genreText);
 
       void LoadGenreTextMappingFiles();
-      bool LoadTextToIdGenreFile(const std::string &xmlFile, std::map<std::string, int> &map);
+      bool LoadTextToIdGenreFile(const std::string& xmlFile, std::map<std::string, int>& map);
       void CreateGenreAddonDataDirectories();
 
       std::regex m_genrePattern;

--- a/src/enigma2/extract/GenreRytecTextMapper.h
+++ b/src/enigma2/extract/GenreRytecTextMapper.h
@@ -1,4 +1,25 @@
 #pragma once
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
 
 #include "IExtractor.h"
 

--- a/src/enigma2/extract/IExtractor.h
+++ b/src/enigma2/extract/IExtractor.h
@@ -44,7 +44,7 @@ namespace enigma2
         std::string matchText = "";
         std::smatch match;
 
-        if (regex_match(text, match, pattern))
+        if (std::regex_match(text, match, pattern))
         {
           if (match.size() == 2)
           {

--- a/src/enigma2/extract/IExtractor.h
+++ b/src/enigma2/extract/IExtractor.h
@@ -1,4 +1,25 @@
 #pragma once
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
 
 #include "../Settings.h"
 #include "../data/BaseEntry.h"

--- a/src/enigma2/extract/IExtractor.h
+++ b/src/enigma2/extract/IExtractor.h
@@ -14,11 +14,11 @@ namespace enigma2
     public:
       IExtractor() = default;
       virtual ~IExtractor() = default;
-      virtual void ExtractFromEntry(enigma2::data::BaseEntry &entry) = 0;
+      virtual void ExtractFromEntry(enigma2::data::BaseEntry& entry) = 0;
       virtual bool IsEnabled() = 0;
 
     protected:
-      static std::string GetMatchTextFromString(const std::string &text, const std::regex &pattern)
+      static std::string GetMatchTextFromString(const std::string& text, const std::regex& pattern)
       {
         std::string matchText = "";
         std::smatch match;
@@ -35,7 +35,7 @@ namespace enigma2
         return matchText;
       };
 
-      static std::string GetMatchedText(const std::string &firstText, const std::string &secondText, const std::regex &pattern)
+      static std::string GetMatchedText(const std::string& firstText, const std::string& secondText, const std::regex& pattern)
       {
         std::string matchedText = GetMatchTextFromString(firstText, pattern);
 
@@ -45,7 +45,7 @@ namespace enigma2
         return matchedText;
       }
 
-      enigma2::Settings &m_settings = Settings::GetInstance();
+      enigma2::Settings& m_settings = Settings::GetInstance();
     };
   } //namespace extract
 } //namespace enigma2

--- a/src/enigma2/extract/ShowInfoExtractor.cpp
+++ b/src/enigma2/extract/ShowInfoExtractor.cpp
@@ -1,3 +1,25 @@
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
 #include "ShowInfoExtractor.h"
 
 #include "../utilities/FileUtils.h"

--- a/src/enigma2/extract/ShowInfoExtractor.cpp
+++ b/src/enigma2/extract/ShowInfoExtractor.cpp
@@ -26,6 +26,8 @@
 #include "tinyxml.h"
 #include "util/XMLUtils.h"
 
+#include <cstdlib>
+
 using namespace enigma2;
 using namespace enigma2::data;
 using namespace enigma2::extract;
@@ -52,7 +54,7 @@ void ShowInfoExtractor::ExtractFromEntry(BaseEntry& entry)
         const std::string seasonText = GetMatchTextFromString(masterText, patternSet.m_seasonRegex);
         if (!seasonText.empty())
         {
-          entry.SetSeasonNumber(atoi(seasonText.c_str()));
+          entry.SetSeasonNumber(std::atoi(seasonText.c_str()));
         }
       }
 
@@ -61,7 +63,7 @@ void ShowInfoExtractor::ExtractFromEntry(BaseEntry& entry)
         const std::string episodeText = GetMatchTextFromString(masterText, patternSet.m_episodeRegex);
         if (!episodeText.empty())
         {
-          entry.SetEpisodeNumber(atoi(episodeText.c_str()));
+          entry.SetEpisodeNumber(std::atoi(episodeText.c_str()));
         }
       }
     }
@@ -77,7 +79,7 @@ void ShowInfoExtractor::ExtractFromEntry(BaseEntry& entry)
 
     if (!yearText.empty() && entry.GetYear() == 0)
     {
-      entry.SetYear(atoi(yearText.c_str()));
+      entry.SetYear(std::atoi(yearText.c_str()));
     }
 
     if (entry.GetYear() != 0)

--- a/src/enigma2/extract/ShowInfoExtractor.cpp
+++ b/src/enigma2/extract/ShowInfoExtractor.cpp
@@ -1,7 +1,6 @@
 #include "ShowInfoExtractor.h"
 
 #include "../utilities/FileUtils.h"
-
 #include "tinyxml.h"
 #include "util/XMLUtils.h"
 
@@ -10,18 +9,15 @@ using namespace enigma2::data;
 using namespace enigma2::extract;
 using namespace enigma2::utilities;
 
-ShowInfoExtractor::ShowInfoExtractor()
-  : IExtractor()
+ShowInfoExtractor::ShowInfoExtractor() : IExtractor()
 {
   if (!LoadShowInfoPatternsFile(Settings::GetInstance().GetExtractShowInfoFile(), m_episodeSeasonPatterns, m_yearPatterns))
     Logger::Log(LEVEL_ERROR, "%s Could not load show info patterns file: %s", __FUNCTION__, Settings::GetInstance().GetExtractShowInfoFile().c_str());
 }
 
-ShowInfoExtractor::~ShowInfoExtractor(void)
-{
-}
+ShowInfoExtractor::~ShowInfoExtractor(void) {}
 
-void ShowInfoExtractor::ExtractFromEntry(BaseEntry &entry)
+void ShowInfoExtractor::ExtractFromEntry(BaseEntry& entry)
 {
   for (const auto& patternSet : m_episodeSeasonPatterns)
   {
@@ -72,7 +68,7 @@ bool ShowInfoExtractor::IsEnabled()
   return Settings::GetInstance().GetExtractShowInfo();
 }
 
-bool ShowInfoExtractor::LoadShowInfoPatternsFile(const std::string &xmlFile, std::vector<EpisodeSeasonPattern> &episodeSeasonPatterns, std::vector<std::regex> yearPatterns)
+bool ShowInfoExtractor::LoadShowInfoPatternsFile(const std::string& xmlFile, std::vector<EpisodeSeasonPattern>& episodeSeasonPatterns, std::vector<std::regex> yearPatterns)
 {
   episodeSeasonPatterns.clear();
   yearPatterns.clear();

--- a/src/enigma2/extract/ShowInfoExtractor.h
+++ b/src/enigma2/extract/ShowInfoExtractor.h
@@ -1,12 +1,11 @@
 #pragma once
 
+#include "EpisodeSeasonPattern.h"
 #include "IExtractor.h"
 
 #include <regex>
 #include <string>
 #include <vector>
-
-#include "EpisodeSeasonPattern.h"
 
 namespace enigma2
 {
@@ -32,18 +31,17 @@ namespace enigma2
     // (2018E25)
     static const std::string GET_YEAR_EPISODE_PATTERN = "^.*\\(([12][0-9][0-9][0-9])[eE][pP]?\\.?[0-9]+/?[0-9]*\\)[^]*$";
 
-    class ShowInfoExtractor
-      : public IExtractor
+    class ShowInfoExtractor : public IExtractor
     {
     public:
       ShowInfoExtractor();
       ~ShowInfoExtractor(void);
 
-      void ExtractFromEntry(enigma2::data::BaseEntry &entry);
+      void ExtractFromEntry(enigma2::data::BaseEntry& entry);
       bool IsEnabled();
 
     private:
-      bool LoadShowInfoPatternsFile(const std::string &xmlFile, std::vector<EpisodeSeasonPattern> &episodeSeasonPatterns, std::vector<std::regex> yearPatterns);
+      bool LoadShowInfoPatternsFile(const std::string& xmlFile, std::vector<EpisodeSeasonPattern>& episodeSeasonPatterns, std::vector<std::regex> yearPatterns);
 
       std::vector<EpisodeSeasonPattern> m_episodeSeasonPatterns;
       std::vector<std::regex> m_yearPatterns;

--- a/src/enigma2/extract/ShowInfoExtractor.h
+++ b/src/enigma2/extract/ShowInfoExtractor.h
@@ -1,4 +1,25 @@
 #pragma once
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
 
 #include "EpisodeSeasonPattern.h"
 #include "IExtractor.h"

--- a/src/enigma2/utilities/CurlFile.cpp
+++ b/src/enigma2/utilities/CurlFile.cpp
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2005-2015 Team Kodi
+ *      Copyright (C) 2005-2019 Team Kodi
  *      http://kodi.tv
  *
  *  This Program is free software; you can redistribute it and/or modify

--- a/src/enigma2/utilities/CurlFile.cpp
+++ b/src/enigma2/utilities/CurlFile.cpp
@@ -21,14 +21,14 @@
 
 #include "CurlFile.h"
 
-#include <cstdarg>
-
-#include "Logger.h"
 #include "../Settings.h"
+#include "Logger.h"
+
+#include <cstdarg>
 
 using namespace enigma2::utilities;
 
-bool CurlFile::Get(const std::string &strURL, std::string &strResult)
+bool CurlFile::Get(const std::string& strURL, std::string& strResult)
 {
   void* fileHandle = XBMC->OpenFile(strURL.c_str(), 0);
   if (fileHandle)
@@ -42,9 +42,9 @@ bool CurlFile::Get(const std::string &strURL, std::string &strResult)
   return false;
 }
 
-bool CurlFile::Post(const std::string &strURL, std::string &strResult)
+bool CurlFile::Post(const std::string& strURL, std::string& strResult)
 {
-  void *fileHandle = XBMC->CURLCreate(strURL.c_str());
+  void* fileHandle = XBMC->CURLCreate(strURL.c_str());
 
   if (!fileHandle)
   {
@@ -72,9 +72,9 @@ bool CurlFile::Post(const std::string &strURL, std::string &strResult)
   return false;
 }
 
-bool CurlFile::Check(const std::string &strURL)
+bool CurlFile::Check(const std::string& strURL)
 {
-  void *fileHandle = XBMC->CURLCreate(strURL.c_str());
+  void* fileHandle = XBMC->CURLCreate(strURL.c_str());
 
   if (!fileHandle)
   {
@@ -82,8 +82,8 @@ bool CurlFile::Check(const std::string &strURL)
     return false;
   }
 
-  XBMC->CURLAddOption(fileHandle, XFILE::CURL_OPTION_PROTOCOL,
-    "connection-timeout", std::to_string(Settings::GetInstance().GetConnectioncCheckTimeoutSecs()).c_str());
+  XBMC->CURLAddOption(fileHandle, XFILE::CURL_OPTION_PROTOCOL, "connection-timeout",
+                      std::to_string(Settings::GetInstance().GetConnectioncCheckTimeoutSecs()).c_str());
 
   if (!XBMC->CURLOpen(fileHandle, XFILE::READ_NO_CACHE))
   {

--- a/src/enigma2/utilities/CurlFile.h
+++ b/src/enigma2/utilities/CurlFile.h
@@ -21,9 +21,9 @@
  *
  */
 
-#include <string>
-
 #include "../../client.h"
+
+#include <string>
 
 namespace enigma2
 {
@@ -35,9 +35,9 @@ namespace enigma2
       CurlFile(void) {};
       ~CurlFile(void) {};
 
-      bool Get(const std::string &strURL, std::string &strResult);
-      bool Post(const std::string &strURL, std::string &strResult);
-      bool Check(const std::string &strURL);
+      bool Get(const std::string& strURL, std::string& strResult);
+      bool Post(const std::string& strURL, std::string& strResult);
+      bool Check(const std::string& strURL);
     };
-  }
-}
+  } // namespace utilities
+} // namespace enigma2

--- a/src/enigma2/utilities/CurlFile.h
+++ b/src/enigma2/utilities/CurlFile.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
- *      Copyright (C) 2005-2015 Team Kodi
+ *      Copyright (C) 2005-2019 Team Kodi
  *      http://kodi.tv
  *
  *  This Program is free software; you can redistribute it and/or modify

--- a/src/enigma2/utilities/DeviceInfo.h
+++ b/src/enigma2/utilities/DeviceInfo.h
@@ -10,8 +10,8 @@ namespace enigma2
     {
     public:
       DeviceInfo() = default;
-      DeviceInfo(const std::string &serverName, const std::string &enigmaVersion, const std::string &imageVersion, const std::string &distroName,
-        const std::string &webIfVersion, unsigned int webIfVersionAsNum)
+      DeviceInfo(const std::string& serverName, const std::string& enigmaVersion, const std::string& imageVersion, const std::string& distroName,
+        const std::string& webIfVersion, unsigned int webIfVersionAsNum)
         : m_serverName(serverName), m_enigmaVersion(enigmaVersion), m_imageVersion(imageVersion), m_distroName(distroName),
           m_webIfVersion(webIfVersion), m_webIfVersionAsNum(webIfVersionAsNum) {};
 

--- a/src/enigma2/utilities/DeviceInfo.h
+++ b/src/enigma2/utilities/DeviceInfo.h
@@ -1,4 +1,25 @@
 #pragma once
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
 
 #include <regex>
 

--- a/src/enigma2/utilities/DeviceSettings.h
+++ b/src/enigma2/utilities/DeviceSettings.h
@@ -1,4 +1,25 @@
 #pragma once
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
 
 #include <regex>
 

--- a/src/enigma2/utilities/FileUtils.cpp
+++ b/src/enigma2/utilities/FileUtils.cpp
@@ -21,20 +21,20 @@
 
 #include "FileUtils.h"
 
-#include "Logger.h"
 #include "../../client.h"
+#include "Logger.h"
 
 #include <kodi/kodi_vfs_types.h>
 
 using namespace enigma2;
 using namespace enigma2::utilities;
 
-bool FileUtils::FileExists(const std::string &file)
+bool FileUtils::FileExists(const std::string& file)
 {
   return XBMC->FileExists(file.c_str(), false);
 }
 
-bool FileUtils::CopyFile(const std::string &sourceFile, const std::string &targetFile)
+bool FileUtils::CopyFile(const std::string& sourceFile, const std::string& targetFile)
 {
   bool copySuccessful = true;
 
@@ -70,7 +70,7 @@ bool FileUtils::CopyFile(const std::string &sourceFile, const std::string &targe
   return copySuccessful;
 }
 
-bool FileUtils::WriteStringToFile(const std::string &fileContents, const std::string &targetFile)
+bool FileUtils::WriteStringToFile(const std::string& fileContents, const std::string& targetFile)
 {
   bool writeSuccessful = true;
 
@@ -92,12 +92,12 @@ bool FileUtils::WriteStringToFile(const std::string &fileContents, const std::st
   return writeSuccessful;
 }
 
-std::string FileUtils::ReadXmlFileToString(const std::string &sourceFile)
+std::string FileUtils::ReadXmlFileToString(const std::string& sourceFile)
 {
   return ReadFileToString(sourceFile) + "\n";
 }
 
-std::string FileUtils::ReadFileToString(const std::string &sourceFile)
+std::string FileUtils::ReadFileToString(const std::string& sourceFile)
 {
   std::string fileContents;
 
@@ -119,7 +119,7 @@ std::string FileUtils::ReadFileToString(const std::string &sourceFile)
   return fileContents;
 }
 
-std::string FileUtils::ReadFileContents(void *fileHandle)
+std::string FileUtils::ReadFileContents(void* fileHandle)
 {
   std::string fileContents;
 
@@ -133,7 +133,7 @@ std::string FileUtils::ReadFileContents(void *fileHandle)
   return fileContents;
 }
 
-bool FileUtils::CopyDirectory(const std::string &sourceDir, const std::string &targetDir, bool recursiveCopy)
+bool FileUtils::CopyDirectory(const std::string& sourceDir, const std::string& targetDir, bool recursiveCopy)
 {
   bool copySuccessful = true;
 
@@ -166,7 +166,7 @@ bool FileUtils::CopyDirectory(const std::string &sourceDir, const std::string &t
   return copySuccessful;
 }
 
-std::vector<std::string> FileUtils::GetFilesInDirectory(const std::string &dir)
+std::vector<std::string> FileUtils::GetFilesInDirectory(const std::string& dir)
 {
   std::vector<std::string> files;
 

--- a/src/enigma2/utilities/FileUtils.cpp
+++ b/src/enigma2/utilities/FileUtils.cpp
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2005-2015 Team Kodi
+ *      Copyright (C) 2005-2019 Team Kodi
  *      http://kodi.tv
  *
  *  This Program is free software; you can redistribute it and/or modify

--- a/src/enigma2/utilities/FileUtils.h
+++ b/src/enigma2/utilities/FileUtils.h
@@ -31,18 +31,17 @@ namespace enigma2
     class FileUtils
     {
     public:
-
-      static bool FileExists(const std::string &file);
-      static bool CopyFile(const std::string &sourceFile, const std::string &targetFile);
-      static bool WriteStringToFile(const std::string &fileContents, const std::string &targetFile);
-      static std::string ReadFileToString(const std::string &sourceFile);
-      static std::string ReadXmlFileToString(const std::string &sourceFile);
-      static bool CopyDirectory(const std::string &sourceDir, const std::string &targetDir, bool recursiveCopy);
-      static std::vector<std::string> GetFilesInDirectory(const std::string &dir);
+      static bool FileExists(const std::string& file);
+      static bool CopyFile(const std::string& sourceFile, const std::string& targetFile);
+      static bool WriteStringToFile(const std::string& fileContents, const std::string& targetFile);
+      static std::string ReadFileToString(const std::string& sourceFile);
+      static std::string ReadXmlFileToString(const std::string& sourceFile);
+      static bool CopyDirectory(const std::string& sourceDir, const std::string& targetDir, bool recursiveCopy);
+      static std::vector<std::string> GetFilesInDirectory(const std::string& dir);
       static std::string GetResourceDataPath();
 
     private:
-      static std::string ReadFileContents(void *fileHandle);
+      static std::string ReadFileContents(void* fileHandle);
     };
-  }
-}
+  } // namespace utilities
+} // namespace enigma2

--- a/src/enigma2/utilities/FileUtils.h
+++ b/src/enigma2/utilities/FileUtils.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
- *      Copyright (C) 2005-2015 Team Kodi
+ *      Copyright (C) 2005-2019 Team Kodi
  *      http://kodi.tv
  *
  *  This Program is free software; you can redistribute it and/or modify

--- a/src/enigma2/utilities/LocalizedString.h
+++ b/src/enigma2/utilities/LocalizedString.h
@@ -16,7 +16,7 @@ namespace enigma2
 
     bool Load(int id)
     {
-      char *str;
+      char* str;
       if ((str = XBMC->GetLocalizedString(id)))
       {
         m_localizedString = str;
@@ -46,7 +46,7 @@ namespace enigma2
   private:
     LocalizedString() = delete;
     LocalizedString(const LocalizedString&) = delete;
-    LocalizedString &operator =(const LocalizedString&) = delete;
+    LocalizedString& operator=(const LocalizedString&) = delete;
 
     std::string m_localizedString;
   };

--- a/src/enigma2/utilities/LocalizedString.h
+++ b/src/enigma2/utilities/LocalizedString.h
@@ -1,4 +1,25 @@
 #pragma once
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
 
 #include "../../client.h"
 

--- a/src/enigma2/utilities/Logger.cpp
+++ b/src/enigma2/utilities/Logger.cpp
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2005-2015 Team Kodi
+ *      Copyright (C) 2005-2019 Team Kodi
  *      http://kodi.tv
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -30,7 +30,6 @@ Logger::Logger()
   // Use an empty implementation by default
   SetImplementation([](LogLevel level, const char* message)
   {
-
   });
 }
 

--- a/src/enigma2/utilities/Logger.cpp
+++ b/src/enigma2/utilities/Logger.cpp
@@ -28,21 +28,21 @@ using namespace enigma2::utilities;
 Logger::Logger()
 {
   // Use an empty implementation by default
-  SetImplementation([](LogLevel level, const char *message)
+  SetImplementation([](LogLevel level, const char* message)
   {
 
   });
 }
 
-Logger &Logger::GetInstance()
+Logger& Logger::GetInstance()
 {
   static Logger instance;
   return instance;
 }
 
-void Logger::Log(LogLevel level, const char *message, ...)
+void Logger::Log(LogLevel level, const char* message, ...)
 {
-  auto &logger = GetInstance();
+  auto& logger = GetInstance();
 
   char buffer[MESSAGE_BUFFER_SIZE];
   std::string logMessage = message;
@@ -65,7 +65,7 @@ void Logger::SetImplementation(LoggerImplementation implementation)
   m_implementation = implementation;
 }
 
-void Logger::SetPrefix(const std::string &prefix)
+void Logger::SetPrefix(const std::string& prefix)
 {
   m_prefix = prefix;
 }

--- a/src/enigma2/utilities/Logger.h
+++ b/src/enigma2/utilities/Logger.h
@@ -21,8 +21,8 @@
  *
  */
 
-#include <string>
 #include <functional>
+#include <string>
 
 namespace enigma2
 {
@@ -43,7 +43,7 @@ namespace enigma2
     /**
      * Short-hand for a function that acts as the logger implementation
      */
-    typedef std::function<void(LogLevel level, const char *message)> LoggerImplementation;
+    typedef std::function<void(LogLevel level, const char* message)> LoggerImplementation;
 
     /**
      * The logger class. It is a singleton that by default comes with no
@@ -53,12 +53,11 @@ namespace enigma2
     class Logger
     {
     public:
-
       /**
        * Returns the singleton instance
        * @return
        */
-      static Logger &GetInstance();
+      static Logger& GetInstance();
 
       /**
        * Logs the specified message using the specified log level
@@ -66,7 +65,7 @@ namespace enigma2
        * @param message the log message
        * @param ... parameters for the log message
        */
-      static void Log(LogLevel level, const char *message, ...);
+      static void Log(LogLevel level, const char* message, ...);
 
       /**
        * Configures the logger to use the specified implementation
@@ -78,7 +77,7 @@ namespace enigma2
        * Sets the prefix to use in log messages
        * @param prefix
        */
-      void SetPrefix(const std::string &prefix);
+      void SetPrefix(const std::string& prefix);
 
     private:
       static const unsigned int MESSAGE_BUFFER_SIZE = 16384;
@@ -94,7 +93,6 @@ namespace enigma2
        * The log message prefix
        */
       std::string m_prefix;
-
     };
-  }
-}
+  } // namespace utilities
+} // namespace enigma2

--- a/src/enigma2/utilities/Logger.h
+++ b/src/enigma2/utilities/Logger.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
- *      Copyright (C) 2005-2015 Team Kodi
+ *      Copyright (C) 2005-2019 Team Kodi
  *      http://kodi.tv
  *
  *  This Program is free software; you can redistribute it and/or modify

--- a/src/enigma2/utilities/SignalStatus.h
+++ b/src/enigma2/utilities/SignalStatus.h
@@ -1,4 +1,25 @@
 #pragma once
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
 
 #include <string>
 

--- a/src/enigma2/utilities/StreamStatus.h
+++ b/src/enigma2/utilities/StreamStatus.h
@@ -1,4 +1,25 @@
 #pragma once
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
 
 #include <string>
 

--- a/src/enigma2/utilities/Tuner.h
+++ b/src/enigma2/utilities/Tuner.h
@@ -8,8 +8,8 @@ namespace enigma2
   {
     struct Tuner
     {
-      Tuner(int tunerNumber, const std::string &tunerName, const std::string &tunerModel)
-        : m_tunerNumber(tunerNumber), m_tunerName(tunerName), m_tunerModel(tunerModel) {};
+      Tuner(int tunerNumber, const std::string& tunerName, const std::string& tunerModel)
+        : m_tunerNumber(tunerNumber), m_tunerName(tunerName), m_tunerModel(tunerModel){};
 
       int m_tunerNumber;
       std::string m_tunerName;

--- a/src/enigma2/utilities/Tuner.h
+++ b/src/enigma2/utilities/Tuner.h
@@ -1,4 +1,25 @@
 #pragma once
+/*
+ *      Copyright (C) 2005-2019 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+ *  MA 02110-1335, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
 
 #include <string>
 

--- a/src/enigma2/utilities/UpdateState.h
+++ b/src/enigma2/utilities/UpdateState.h
@@ -21,9 +21,9 @@
  *
  */
 
-#include <string>
-
 #include "../data/BaseEntry.h"
+
+#include <string>
 
 namespace enigma2
 {
@@ -31,10 +31,10 @@ namespace enigma2
   {
     typedef enum UPDATE_STATE
     {
-        UPDATE_STATE_NONE,
-        UPDATE_STATE_FOUND,
-        UPDATE_STATE_UPDATED,
-        UPDATE_STATE_NEW
+      UPDATE_STATE_NONE,
+      UPDATE_STATE_FOUND,
+      UPDATE_STATE_UPDATED,
+      UPDATE_STATE_NEW
     } UPDATE_STATE;
-  } //namespace data
+  } // namespace utilities
 } //namespace enigma2

--- a/src/enigma2/utilities/UpdateState.h
+++ b/src/enigma2/utilities/UpdateState.h
@@ -1,6 +1,6 @@
 #pragma once
 /*
- *      Copyright (C) 2005-2015 Team XBMC
+ *      Copyright (C) 2005-2019 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify

--- a/src/enigma2/utilities/WebUtils.cpp
+++ b/src/enigma2/utilities/WebUtils.cpp
@@ -21,13 +21,12 @@
 
 #include "WebUtils.h"
 
+#include "../Settings.h"
 #include "CurlFile.h"
 #include "Logger.h"
-#include "../Settings.h"
-
+#include "p8-platform/util/StringUtils.h"
 #include "tinyxml.h"
 #include "util/XMLUtils.h"
-#include "p8-platform/util/StringUtils.h"
 
 using namespace enigma2;
 using namespace enigma2::utilities;
@@ -56,14 +55,14 @@ const char SAFE[256] =
     /* F */ 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0
 };
 
-std::string WebUtils::URLEncodeInline(const std::string &sSrc)
+std::string WebUtils::URLEncodeInline(const std::string& sSrc)
 {
   const char DEC2HEX[16 + 1] = "0123456789ABCDEF";
-  const unsigned char * pSrc = (const unsigned char *)sSrc.c_str();
+  const unsigned char* pSrc = (const unsigned char*)sSrc.c_str();
   const int SRC_LEN = sSrc.length();
-  unsigned char * const pStart = new unsigned char[SRC_LEN * 3];
-  unsigned char * pEnd = pStart;
-  const unsigned char * const SRC_END = pSrc + SRC_LEN;
+  unsigned char* const pStart = new unsigned char[SRC_LEN * 3];
+  unsigned char* pEnd = pStart;
+  const unsigned char* const SRC_END = pSrc + SRC_LEN;
 
   for (; pSrc < SRC_END; ++pSrc)
   {
@@ -78,8 +77,8 @@ std::string WebUtils::URLEncodeInline(const std::string &sSrc)
     }
   }
 
-  std::string sResult((char *)pStart, (char *)pEnd);
-  delete [] pStart;
+  std::string sResult((char*)pStart, (char*)pEnd);
+  delete[] pStart;
   return sResult;
 }
 
@@ -88,7 +87,7 @@ bool WebUtils::CheckHttp(const std::string& url)
   Logger::Log(LEVEL_TRACE, "%s Check webAPI with URL: '%s'", __FUNCTION__, url.c_str());
 
   CurlFile http;
-  if(!http.Check(url))
+  if (!http.Check(url))
   {
     Logger::Log(LEVEL_TRACE, "%s - Could not open webAPI.", __FUNCTION__);
     return false;
@@ -106,7 +105,7 @@ std::string WebUtils::GetHttp(const std::string& url)
   std::string strTmp;
 
   CurlFile http;
-  if(!http.Get(url, strTmp))
+  if (!http.Get(url, strTmp))
   {
     Logger::Log(LEVEL_ERROR, "%s - Could not open webAPI.", __FUNCTION__);
     return "";
@@ -136,7 +135,7 @@ std::string WebUtils::PostHttpJson(const std::string& url)
   std::string strTmp;
 
   CurlFile http;
-  if(!http.Post(url, strTmp))
+  if (!http.Post(url, strTmp))
   {
     Logger::Log(LEVEL_ERROR, "%s - Could not open webAPI.", __FUNCTION__);
     return "";
@@ -249,10 +248,10 @@ bool WebUtils::SendSimpleJsonPostCommand(const std::string& strCommandURL, std::
   return true;
 }
 
-std::string& WebUtils::Escape(std::string &s, const std::string from, const std::string to)
+std::string& WebUtils::Escape(std::string& s, const std::string from, const std::string to)
 {
   std::string::size_type pos = -1;
-  while ( (pos = s.find(from, pos+1) ) != std::string::npos)
+  while ((pos = s.find(from, pos + 1)) != std::string::npos)
     s.erase(pos, from.length()).insert(pos, to);
 
   return s;

--- a/src/enigma2/utilities/WebUtils.cpp
+++ b/src/enigma2/utilities/WebUtils.cpp
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2005-2015 Team Kodi
+ *      Copyright (C) 2005-2019 Team Kodi
  *      http://kodi.tv
  *
  *  This Program is free software; you can redistribute it and/or modify

--- a/src/enigma2/utilities/WebUtils.h
+++ b/src/enigma2/utilities/WebUtils.h
@@ -30,16 +30,15 @@ namespace enigma2
     class WebUtils
     {
     public:
-
-      static std::string URLEncodeInline(const std::string &sStr);
+      static std::string URLEncodeInline(const std::string& sStr);
       static bool CheckHttp(const std::string& url);
       static std::string GetHttp(const std::string& url);
       static std::string GetHttpXML(const std::string& url);
       static std::string PostHttpJson(const std::string& url);
-      static bool SendSimpleCommand(const std::string& strCommandURL, std::string& strResultText, bool bIgnoreResult=false);
-      static bool SendSimpleJsonCommand(const std::string& strCommandURL, std::string& strResultText, bool bIgnoreResult=false);
-      static bool SendSimpleJsonPostCommand(const std::string& strCommandURL, std::string& strResultText, bool bIgnoreResult=false);
-      static std::string& Escape(std::string &s, const std::string from, const std::string to);
+      static bool SendSimpleCommand(const std::string& strCommandURL, std::string& strResultText, bool bIgnoreResult = false);
+      static bool SendSimpleJsonCommand(const std::string& strCommandURL, std::string& strResultText, bool bIgnoreResult = false);
+      static bool SendSimpleJsonPostCommand(const std::string& strCommandURL, std::string& strResultText, bool bIgnoreResult = false);
+      static std::string& Escape(std::string& s, const std::string from, const std::string to);
     };
-  }
-}
+  } // namespace utilities
+} // namespace enigma2

--- a/src/enigma2/utilities/WebUtils.h
+++ b/src/enigma2/utilities/WebUtils.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
- *      Copyright (C) 2005-2015 Team Kodi
+ *      Copyright (C) 2005-2019 Team Kodi
  *      http://kodi.tv
  *
  *  This Program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
v4.7.0
- Added: Support for IPTV Streams configured on E2 device (no timeshifting)
- Added: Reload instead of reconnecting when channel/group changes are detected
- Added: Use truly unique IDs for channels so EPG changes are correctly reflected
- Fixed: Only get drive space for devices that have an HDD
- Fixed: use correct function to lookup group when adding
- Added: update README.md to show appveyor/travis badges per branch
- Added: Update OSX build script
- Added: update badge status for travis/appveyor
- Added: add copyright notices to files
- Fixed: Fix default path for genre text mapping file