### PR TITLE
Change version to 4.5.1 related to Kodi API update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,7 @@ matrix:
       sudo: required
       compiler: clang
     - os: osx
-      osx_image: xcode9
-    - os: osx
-      osx_image: xcode9.4
+      osx_image: xcode10.2
 
 #
 # The addon source is automatically checked out in $TRAVIS_BUILD_DIR,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,7 @@
+cmake_minimum_required(VERSION 3.5)
 project(pvr.vuplus)
 
-cmake_minimum_required(VERSION 2.6)
-
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
-
-enable_language(CXX)
 
 find_package(Kodi REQUIRED)
 find_package(kodiplatform REQUIRED)

--- a/FindTinyXML.cmake
+++ b/FindTinyXML.cmake
@@ -6,22 +6,19 @@
 #   TINYXML_LIBRARIES    - List of libraries when using TinyXML.
 #
 
+find_package(PkgConfig)
 if(PKG_CONFIG_FOUND)
-  pkg_check_modules (TINYXML tinyxml)
-  list(APPEND TINYXML_INCLUDE_DIRS ${TINYXML_INCLUDEDIR})
-endif()
-if(NOT TINYXML_FOUND)
-  find_path( TINYXML_INCLUDE_DIRS "tinyxml.h"
-             PATH_SUFFIXES "tinyxml")
-
-  find_library( TINYXML_LIBRARIES
-                NAMES "tinyxml"
-                PATH_SUFFIXES "tinyxml")
+  pkg_check_modules(PC_TINYXML tinyxml QUIET)
 endif()
 
-# handle the QUIETLY and REQUIRED arguments and set TINYXML_FOUND to TRUE if
-# all listed variables are TRUE
+find_path(TINYXML_INCLUDE_DIRS NAMES tinyxml.h
+                               PATHS ${PC_TINYXML_INCLUDEDIR}
+                               PATH_SUFFIXES tinyxml)
+find_library(TINYXML_LIBRARIES NAMES tinyxml
+                               PATHS ${PC_TINYXML_LIBDIR}
+                               PATH_SUFFIXES tinyxml)
+
 include("FindPackageHandleStandardArgs")
-find_package_handle_standard_args(TinyXML DEFAULT_MSG TINYXML_INCLUDE_DIRS TINYXML_LIBRARIES)
+find_package_handle_standard_args(TinyXML REQUIRED_VARS TINYXML_INCLUDE_DIRS TINYXML_LIBRARIES)
 
 mark_as_advanced(TINYXML_INCLUDE_DIRS TINYXML_LIBRARIES)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,33 @@
+version: BuildNr.{build}
+
+image: Visual Studio 2017
+
+shallow_clone: true
+
+clone_folder: c:\projects\pvr.vuplus
+
+environment:
+  app_id: pvr.vuplus
+
+  matrix:
+    - GENERATOR: "Visual Studio 15"
+      CONFIG: Release
+    - GENERATOR: "Visual Studio 15 Win64"
+      CONFIG: Release
+    - GENERATOR: "Visual Studio 15 Win64"
+      CONFIG: Release
+      WINSTORE: -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION="10.0.17763.0"
+    - GENERATOR: "Visual Studio 15 ARM"
+      CONFIG: Release
+      WINSTORE: -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION="10.0.17763.0"
+
+build_script:
+  - cd ..
+  - git clone --branch master --depth=1 https://github.com/xbmc/xbmc.git
+  - cd %app_id%
+  - mkdir build
+  - cd build
+  - mkdir -p definition\%app_id%
+  - echo %app_id% %APPVEYOR_BUILD_FOLDER% %APPVEYOR_REPO_COMMIT% > definition\%app_id%\%app_id%.txt
+  - cmake -T host=x64 -G "%GENERATOR%" %WINSTORE% -DADDONS_TO_BUILD=%app_id% -DCMAKE_BUILD_TYPE=%CONFIG% -DADDONS_DEFINITION_DIR=%APPVEYOR_BUILD_FOLDER%/build/definition -DADDON_SRC_PREFIX=../.. -DCMAKE_INSTALL_PREFIX=../../xbmc/addons -DPACKAGE_ZIP=1 ../../xbmc/cmake/addons
+  - cmake --build . --config %CONFIG% --target %app_id%

--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="4.5.0"
+  version="4.5.1"
   name="Enigma2 Client"
   provider-name="Joerg Dembski and Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>
@@ -175,6 +175,12 @@
     <disclaimer lang="zh_TW">這是測試版軟體！其原創作者並無法對於以下情況負責，包含：錄影失敗，不正確的定時設定，多餘時數，或任何產生的其它不良影響...</disclaimer>
     <platform>@PLATFORM@</platform>
     <news>
+v4.5.1
+- Update: Kodi VFS API 1.0.3
+- Update: Build sytem version
+- Added: AppVeyor for Windows related build tests
+- Fixed: Build depends search way
+
 v4.5.0
 - Added: Allow creation of epg based repeating timer rules if autotimers are not available
 

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,3 +1,9 @@
+v4.5.1
+- Update: Kodi VFS API 1.0.3
+- Update: Build sytem version
+- Added: AppVeyor for Windows related build tests
+- Fixed: Build depends search way
+
 v4.5.0
 - Added: Allow creation of epg-based repeating timer rules if autotimers are not available
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -34,7 +34,7 @@
 
 #include "p8-platform/util/util.h"
 #include <p8-platform/util/StringUtils.h>
-#include "xbmc_pvr_dll.h"
+#include "kodi/xbmc_pvr_dll.h"
 
 using namespace ADDON;
 using namespace enigma2;

--- a/src/client.h
+++ b/src/client.h
@@ -21,8 +21,8 @@
  *
  */
 
-#include "libXBMC_addon.h"
-#include "libXBMC_pvr.h"
+#include "kodi/libXBMC_addon.h"
+#include "kodi/libXBMC_pvr.h"
 
 extern ADDON::CHelper_libXBMC_addon *XBMC;
 extern CHelper_libXBMC_pvr *PVR;

--- a/src/enigma2/Admin.h
+++ b/src/enigma2/Admin.h
@@ -31,7 +31,7 @@
 #include "utilities/StreamStatus.h"
 #include "utilities/Tuner.h"
 
-#include "libXBMC_pvr.h"
+#include "kodi/libXBMC_pvr.h"
 
 namespace enigma2
 {

--- a/src/enigma2/ChannelGroups.h
+++ b/src/enigma2/ChannelGroups.h
@@ -29,7 +29,7 @@
 #include "data/Channel.h"
 #include "data/ChannelGroup.h"
 
-#include "libXBMC_pvr.h"
+#include "kodi/libXBMC_pvr.h"
 
 namespace enigma2
 {

--- a/src/enigma2/Channels.h
+++ b/src/enigma2/Channels.h
@@ -29,7 +29,7 @@
 #include "ChannelGroups.h"
 #include "data/Channel.h"
 
-#include "libXBMC_pvr.h"
+#include "kodi/libXBMC_pvr.h"
 
 namespace enigma2
 {

--- a/src/enigma2/ConnectionManager.h
+++ b/src/enigma2/ConnectionManager.h
@@ -23,7 +23,7 @@
 
 #include <string>
 
-#include "libXBMC_pvr.h"
+#include "kodi/libXBMC_pvr.h"
 
 #include "p8-platform/threads/mutex.h"
 #include "p8-platform/threads/threads.h"

--- a/src/enigma2/Epg.h
+++ b/src/enigma2/Epg.h
@@ -32,7 +32,7 @@
 #include "data/EpgChannel.h"
 #include "extract/EpgEntryExtractor.h"
 
-#include "libXBMC_pvr.h"
+#include "kodi/libXBMC_pvr.h"
 
 #include "p8-platform/threads/threads.h"
 

--- a/src/enigma2/IStreamReader.h
+++ b/src/enigma2/IStreamReader.h
@@ -2,7 +2,7 @@
 
 #include <ctime>
 
-#include "libXBMC_addon.h"
+#include "kodi/libXBMC_addon.h"
 
 namespace enigma2
 {

--- a/src/enigma2/RecordingReader.h
+++ b/src/enigma2/RecordingReader.h
@@ -3,7 +3,7 @@
 #include <ctime>
 #include <string>
 
-#include "libXBMC_addon.h"
+#include "kodi/libXBMC_addon.h"
 
 namespace enigma2
 {

--- a/src/enigma2/Recordings.h
+++ b/src/enigma2/Recordings.h
@@ -30,7 +30,7 @@
 #include "data/RecordingEntry.h"
 #include "extract/EpgEntryExtractor.h"
 
-#include "libXBMC_pvr.h"
+#include "kodi/libXBMC_pvr.h"
 
 namespace enigma2
 {

--- a/src/enigma2/Settings.h
+++ b/src/enigma2/Settings.h
@@ -8,7 +8,7 @@
 #include "utilities/DeviceSettings.h"
 
 #include <p8-platform/util/StringUtils.h>
-#include "xbmc_addon_types.h"
+#include "kodi/xbmc_addon_types.h"
 
 class Vu;
 

--- a/src/enigma2/Timers.h
+++ b/src/enigma2/Timers.h
@@ -12,7 +12,7 @@
 #include "data/Timer.h"
 #include "extract/EpgEntryExtractor.h"
 
-#include "libXBMC_pvr.h"
+#include "kodi/libXBMC_pvr.h"
 #include "tinyxml.h"
 
 namespace enigma2

--- a/src/enigma2/data/AutoTimer.h
+++ b/src/enigma2/data/AutoTimer.h
@@ -27,7 +27,7 @@
 
 #include "Timer.h"
 
-#include "libXBMC_pvr.h"
+#include "kodi/libXBMC_pvr.h"
 #include "tinyxml.h"
 
 namespace enigma2

--- a/src/enigma2/data/BaseChannel.h
+++ b/src/enigma2/data/BaseChannel.h
@@ -25,7 +25,7 @@
 #include <string>
 #include <vector>
 
-#include "libXBMC_pvr.h"
+#include "kodi/libXBMC_pvr.h"
 #include "tinyxml.h"
 
 namespace enigma2

--- a/src/enigma2/data/Channel.h
+++ b/src/enigma2/data/Channel.h
@@ -27,7 +27,7 @@
 
 #include "BaseChannel.h"
 
-#include "libXBMC_pvr.h"
+#include "kodi/libXBMC_pvr.h"
 #include "tinyxml.h"
 
 namespace enigma2

--- a/src/enigma2/data/ChannelGroup.h
+++ b/src/enigma2/data/ChannelGroup.h
@@ -28,7 +28,7 @@
 #include "Channel.h"
 #include "EpgEntry.h"
 
-#include "libXBMC_pvr.h"
+#include "kodi/libXBMC_pvr.h"
 #include "tinyxml.h"
 
 namespace enigma2

--- a/src/enigma2/data/EpgChannel.h
+++ b/src/enigma2/data/EpgChannel.h
@@ -28,7 +28,7 @@
 #include "BaseChannel.h"
 #include "EpgEntry.h"
 
-#include "libXBMC_pvr.h"
+#include "kodi/libXBMC_pvr.h"
 #include "tinyxml.h"
 
 namespace enigma2

--- a/src/enigma2/data/EpgEntry.h
+++ b/src/enigma2/data/EpgEntry.h
@@ -27,7 +27,7 @@
 #include "BaseEntry.h"
 #include "EpgChannel.h"
 
-#include "libXBMC_pvr.h"
+#include "kodi/libXBMC_pvr.h"
 #include "tinyxml.h"
 
 namespace enigma2

--- a/src/enigma2/data/RecordingEntry.h
+++ b/src/enigma2/data/RecordingEntry.h
@@ -28,7 +28,7 @@
 #include "Tags.h"
 #include "../Channels.h"
 
-#include "libXBMC_pvr.h"
+#include "kodi/libXBMC_pvr.h"
 #include "tinyxml.h"
 namespace enigma2
 {

--- a/src/enigma2/data/Timer.h
+++ b/src/enigma2/data/Timer.h
@@ -30,7 +30,7 @@
 #include "../Channels.h"
 #include "../utilities/UpdateState.h"
 
-#include "libXBMC_pvr.h"
+#include "kodi/libXBMC_pvr.h"
 #include "tinyxml.h"
 
 namespace enigma2

--- a/src/enigma2/extract/GenreIdMapper.cpp
+++ b/src/enigma2/extract/GenreIdMapper.cpp
@@ -2,7 +2,7 @@
 
 #include "../utilities/FileUtils.h"
 
-#include "libXBMC_pvr.h"
+#include "kodi/libXBMC_pvr.h"
 #include "tinyxml.h"
 #include "util/XMLUtils.h"
 

--- a/src/enigma2/extract/GenreRytecTextMapper.cpp
+++ b/src/enigma2/extract/GenreRytecTextMapper.cpp
@@ -2,7 +2,7 @@
 
 #include "../utilities/FileUtils.h"
 
-#include "libXBMC_pvr.h"
+#include "kodi/libXBMC_pvr.h"
 #include "tinyxml.h"
 #include "util/XMLUtils.h"
 

--- a/src/enigma2/utilities/FileUtils.cpp
+++ b/src/enigma2/utilities/FileUtils.cpp
@@ -24,7 +24,7 @@
 #include "Logger.h"
 #include "../../client.h"
 
-#include <kodi_vfs_types.h>
+#include <kodi/kodi_vfs_types.h>
 
 using namespace enigma2;
 using namespace enigma2::utilities;


### PR DESCRIPTION
Further is on .travis.yml the xcode changed to 10.2 to have equal with
Kodi itself.

This version change is related to xbmc/xbmc#16431 and xbmc/xbmc#16452
(it use `#include <kodi_vfs_types.h>`)

How do you see it, with version 4.6.0 OK?
Is not actually a change in the code.

As another question, does it make sense to add "appveyor.yml" here as well?

**EDIT:** Maybe better to make 4.5.1? There  is for me mostly a fix.