### PR TITLE
Support group (bouquet) channel order from the backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Within this tab options that refer to EPG data can be set. Excluding logging mis
 
 Information on customising the extraction and mapper configs can be found in the next section of the README.
 
-* **Extract season, episode and year info where possible**: Check the description fields in the EPG data and attempt to extract season, episode and year info where possible.
+* **Extract season, episode and year info where possible**: Check the description fields in the EPG data and attempt to extract season, episode and year info where possible. In addtion can also extract properties like new, live and premiere info.
 * **Extract show info file**: The config used to extract season, episode and year information. The default file is `English-ShowInfo.xml`.
 * **Enable genre ID mappings**: If the genre IDs sent with EPG data from your set-top box are not using the DVB standard, map from these to the DVB standard IDs. Sky UK for instance uses OpenTV, in that case without this option set the genre colouring and text would be incorrect in Kodi.
 * **Genre ID mappings file**: The config used to map set-top box EPG genre IDs to DVB standard IDs. The default file is `Sky-UK.xml`.

--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="4.7.0"
+  version="4.8.0"
   name="Enigma2 Client"
   provider-name="Joerg Dembski and Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>
@@ -71,7 +71,7 @@
     <description lang="de_DE">VU+ -Oberfläche; Unterstützt Live TV &amp; Aufnahmen, EPG und Timer.</description>
     <description lang="el_GR">Frontend για το VU+. Υποστηρίζει ροές Live TV &amp; Εγγραφές, EPG, Χρονοδιακόπτες.</description>
     <description lang="en_AU">VU+ frontend; supporting streaming of Live TV &amp; Recordings, EPG, Timers.</description>
-    <description lang="en_GB">Enigma2 frontend - supporting streaming of Live TV &amp; Recordings, EPG, Timers, Autotimers.&#10;    &#10;For documentation visit: https://github.com/kodi-pvr/pvr.vuplus/blob/master/README.md&#10;    </description>
+    <description lang="en_GB">Enigma2 frontend - supporting streaming of Live TV &amp; Recordings, EPG, Timers, Autotimers.&#10;    &#10;For documentation visit: https://github.com/kodi-pvr/pvr.vuplus/blob/Matrix/README.md&#10;    </description>
     <description lang="en_NZ">VU+ frontend; supporting streaming of Live TV &amp; Recordings, EPG, Timers.</description>
     <description lang="en_US">VU+ frontend; supporting streaming of Live TV &amp; Recordings, EPG, Timers.</description>
     <description lang="es_AR">VU+ frontend; soporta TV en vivo, grabaciones, guía de programación (GEP) y temporizadores.</description>
@@ -175,6 +175,17 @@
     <disclaimer lang="zh_TW">這是測試版軟體！其原創作者並無法對於以下情況負責，包含：錄影失敗，不正確的定時設定，多餘時數，或任何產生的其它不良影響...</disclaimer>
     <platform>@PLATFORM@</platform>
     <news>
+v4.8.0
+- Added: Support group (bouquet) channel order from the backend
+- Added: Extract new/live/premiere as part of show info from EPG
+- Fixed: Fix possible runtime error assigning nullptr to string
+- Fixed: Preserve recordings and timer lists if connection lost
+- Update: Remove p8-platform dependency on Threads, Mutex, Condition, Util and OS
+- Update: README Location
+- Fixed: Fix long kodi shutdown delay if shutodwn happens before addon fully starts
+- Update: Update regex to static/const (perf benefit)
+- Update: Update show info regex's
+
 v4.7.0
 - Added: Support for IPTV Streams configured on E2 device (no timeshifting)
 - Added: Reload instead of reconnecting when channel/group changes are detected

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,3 +1,14 @@
+v4.8.0
+- Added: Support group (bouquet) channel order from the backend
+- Added: Extract new/live/premiere as part of show info from EPG
+- Fixed: Fix possible runtime error assigning nullptr to string
+- Fixed: Preserve recordings and timer lists if connection lost
+- Update: Remove p8-platform dependency on Threads, Mutex, Condition, Util and OS
+- Update: README Location
+- Fixed: Fix long kodi shutdown delay if shutodwn happens before addon fully starts
+- Update: Update regex to static/const (perf benefit)
+- Update: Update show info regex's
+
 v4.7.0
 - Added: Support for IPTV Streams configured on E2 device (no timeshifting)
 - Added: Reload instead of reconnecting when channel/group changes are detected

--- a/pvr.vuplus/resources/data/showInfo/English-ShowInfo.xml
+++ b/pvr.vuplus/resources/data/showInfo/English-ShowInfo.xml
@@ -24,7 +24,7 @@ If you have changes either create a PR containing the changes or an issue with d
   <seasonEpisodes>
     <!-- (S4E37) (S04E37) (S2 Ep3/6) (S2 Ep7) (S2 Ep 3) -->
     <seasonEpisode>
-      <master pattern="(?:^|.* )\(?([sS]\.?[0-9]+ ?[eE][pP]?\.? ?[0-9]+/?[0-9]*)\)?[^]*$"/>
+      <master pattern="(?:^|.* )\(?([sS]\.?[0-9]+,? ?/?[eE][pP]?\.? ?[0-9]+/?[0-9]*)\)?[^]*$"/>
       <season pattern="^.*[sS]\.?([0-9][0-9]*).*$"/>
       <episode pattern="^.*[eE][pP]?\.? ?([0-9][0-9]*).*$"/>
     </seasonEpisode>

--- a/pvr.vuplus/resources/data/showInfo/English-ShowInfo.xml
+++ b/pvr.vuplus/resources/data/showInfo/English-ShowInfo.xml
@@ -11,6 +11,10 @@
  - This element must have a pattern attrbute.
  - There is no limit to the number of <year> elements but there must be at least one.
 
+<textProperty> elements
+ - This element must have a type attribute. Supported types currently are: 'new', 'live' or 'premiere'.
+ - This element must have a titlePattern attrbute and/or a descPattern attribute. If either match the entry will be marked as it's type.
+
 If you are creating yoru own patterns make a copy of this file in the same directory so it's not overwritten.
 
 NOTE: IF YOU MODIFY THIS FILE IT WILL BE OVERWRITTEN NEXT TIME THE ADDON IS STARTED
@@ -50,4 +54,10 @@ If you have changes either create a PR containing the changes or an issue with d
     <!-- (2018E25) -->
     <year pattern="^.*\(([12][0-9][0-9][0-9])[eE][pP]?\.?[0-9]+/?[0-9]*\)[^]*$"/>
   </years>
+  <textProperties>
+    <!-- New: -->
+    <textProperty type="new" titlePattern="^ *New:[^]*$"/>
+    <textProperty type="live" titlePattern="^ *Live:[^]*$"/>
+    <textProperty type="premiere" titlePattern="^ *Premiere:[^]*$"/>
+  </textProperties>
 </showInfo>

--- a/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
@@ -1079,7 +1079,7 @@ msgstr ""
 
 #help: EPG - extractshowinfoenabled
 msgctxt "#30661"
-msgid "Check the description fields in the EPG data and attempt to extract season, episode and year info where possible."
+msgid "Check the description fields in the EPG data and attempt to extract season, episode and year info where possible. In addtion can also extract properties like new, live and premiere info."
 msgstr ""
 
 #help: EPG - extractshowinfofile

--- a/src/Enigma2.cpp
+++ b/src/Enigma2.cpp
@@ -65,7 +65,7 @@ Enigma2::~Enigma2()
 
 void Enigma2::ConnectionLost()
 {
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
 
   Logger::Log(LEVEL_NOTICE, "%s Lost connection with Enigma2 device...", __FUNCTION__);
 
@@ -79,7 +79,7 @@ void Enigma2::ConnectionLost()
 
 void Enigma2::ConnectionEstablished()
 {
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
 
   Logger::Log(LEVEL_DEBUG, "%s Removing internal channels and groups lists...", __FUNCTION__);
   m_channels.ClearChannels();
@@ -168,7 +168,7 @@ void Enigma2::OnWake()
 
 bool Enigma2::Start()
 {
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
 
   connectionManager->Start();
 
@@ -213,7 +213,7 @@ void* Enigma2::Process()
       updateTimer = 0;
 
       // Trigger Timer and Recording updates according to the addon settings
-      CLockObject lock(m_mutex);
+      std::lock_guard<std::mutex> lock(m_mutex);
       // We need to check this again in case StopThread is called (in destroying Enigma2) during the sleep, otherwise TimerUpdates could be called after the object is released
       if (!IsStopped() && m_isConnected)
       {
@@ -236,7 +236,7 @@ void* Enigma2::Process()
     if (lastUpdateHour != timeInfo.tm_hour && timeInfo.tm_hour == m_settings.GetChannelAndGroupUpdateHour())
     {
       // Trigger Channel and Group updates according to the addon settings
-      CLockObject lock(m_mutex);
+      std::lock_guard<std::mutex> lock(m_mutex);
       // We need to check this again in case StopThread is called (in destroying Enigma2) during the sleep, otherwise TimerUpdates could be called after the object is released
       if (!IsStopped() && m_isConnected)
       {
@@ -250,8 +250,8 @@ void* Enigma2::Process()
     lastUpdateHour = timeInfo.tm_hour;
   }
 
-  //CLockObject lock(m_mutex);
-  m_started.Broadcast();
+  //std::lock_guard<std::mutex> lock(m_mutex);
+  //m_started.Broadcast();
 
   return nullptr;
 }
@@ -337,7 +337,7 @@ void Enigma2::ReloadChannelsGroupsAndEPG()
 
 void Enigma2::SendPowerstate()
 {
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
 
   m_admin.SendPowerstate();
 }
@@ -370,7 +370,7 @@ PVR_ERROR Enigma2::GetChannelGroups(ADDON_HANDLE handle, bool radio)
 {
   std::vector<PVR_CHANNEL_GROUP> channelGroups;
   {
-    CLockObject lock(m_mutex);
+    std::lock_guard<std::mutex> lock(m_mutex);
     m_channelGroups.GetChannelGroups(channelGroups, radio);
   }
 
@@ -386,7 +386,7 @@ PVR_ERROR Enigma2::GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL
 {
   std::vector<PVR_CHANNEL_GROUP_MEMBER> channelGroupMembers;
   {
-    CLockObject lock(m_mutex);
+    std::lock_guard<std::mutex> lock(m_mutex);
     m_channelGroups.GetChannelGroupMembers(channelGroupMembers, group.strGroupName);
   }
 
@@ -411,7 +411,7 @@ PVR_ERROR Enigma2::GetChannels(ADDON_HANDLE handle, bool bRadio)
 {
   std::vector<PVR_CHANNEL> channels;
   {
-    CLockObject lock(m_mutex);
+    std::lock_guard<std::mutex> lock(m_mutex);
     m_channels.GetChannels(channels, bRadio);
   }
 
@@ -435,7 +435,7 @@ PVR_ERROR Enigma2::GetEPGForChannel(ADDON_HANDLE handle, int iChannelUid, time_t
   //Have a lock while getting the channel. Then we don't have to worry about a disconnection while retrieving the EPG data.
   std::shared_ptr<Channel> myChannel;
   {
-    CLockObject lock(m_mutex);
+    std::lock_guard<std::mutex> lock(m_mutex);
 
     if (!m_channels.IsValid(iChannelUid))
     {
@@ -462,7 +462,7 @@ PVR_ERROR Enigma2::GetEPGForChannel(ADDON_HANDLE handle, int iChannelUid, time_t
 bool Enigma2::OpenLiveStream(const PVR_CHANNEL& channelinfo)
 {
   Logger::Log(LEVEL_DEBUG, "%s: channel=%u", __FUNCTION__, channelinfo.iUniqueId);
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
 
   if (channelinfo.iUniqueId != m_currentChannel)
   {
@@ -486,7 +486,7 @@ bool Enigma2::OpenLiveStream(const PVR_CHANNEL& channelinfo)
 
 void Enigma2::CloseLiveStream(void)
 {
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   m_currentChannel = -1;
 }
 
@@ -549,7 +549,7 @@ PVR_ERROR Enigma2::GetRecordings(ADDON_HANDLE handle, bool deleted)
 
   std::vector<PVR_RECORDING> recordings;
   {
-    CLockObject lock(m_mutex);
+    std::lock_guard<std::mutex> lock(m_mutex);
     m_recordings.GetRecordings(recordings, deleted);
   }
 
@@ -580,7 +580,7 @@ PVR_ERROR Enigma2::GetRecordingEdl(const PVR_RECORDING& recinfo, PVR_EDL_ENTRY e
 {
   std::vector<PVR_EDL_ENTRY> edlEntries;
   {
-    CLockObject lock(m_mutex);
+    std::lock_guard<std::mutex> lock(m_mutex);
     m_recordings.GetRecordingEdl(recinfo.strRecordingId, edlEntries);
   }
 
@@ -606,7 +606,7 @@ PVR_ERROR Enigma2::GetRecordingEdl(const PVR_RECORDING& recinfo, PVR_EDL_ENTRY e
 
 RecordingReader* Enigma2::OpenRecordedStream(const PVR_RECORDING& recinfo)
 {
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   std::time_t now = std::time(nullptr), start = 0, end = 0;
   std::string channelName = recinfo.strChannelName;
   auto timer = m_timers.GetTimer([&](const Timer &timer)
@@ -634,25 +634,25 @@ int Enigma2::GetRecordingStreamProgramNumber(const PVR_RECORDING& recording)
 
 PVR_ERROR Enigma2::RenameRecording(const PVR_RECORDING& recording)
 {
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   return m_recordings.RenameRecording(recording);
 }
 
 PVR_ERROR Enigma2::SetRecordingPlayCount(const PVR_RECORDING& recording, int count)
 {
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   return m_recordings.SetRecordingPlayCount(recording, count);
 }
 
 PVR_ERROR Enigma2::SetRecordingLastPlayedPosition(const PVR_RECORDING& recording, int lastPlayedPosition)
 {
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   return m_recordings.SetRecordingLastPlayedPosition(recording, lastPlayedPosition);
 }
 
 int Enigma2::GetRecordingLastPlayedPosition(const PVR_RECORDING& recording)
 {
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   return m_recordings.GetRecordingLastPlayedPosition(recording);
 }
 
@@ -664,7 +664,7 @@ void Enigma2::GetTimerTypes(PVR_TIMER_TYPE types[], int* size)
 {
   std::vector<PVR_TIMER_TYPE> timerTypes;
   {
-    CLockObject lock(m_mutex);
+    std::lock_guard<std::mutex> lock(m_mutex);
     m_timers.GetTimerTypes(timerTypes);
   }
 
@@ -677,7 +677,7 @@ void Enigma2::GetTimerTypes(PVR_TIMER_TYPE types[], int* size)
 
 int Enigma2::GetTimersAmount()
 {
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   return m_timers.GetTimerCount();
 }
 
@@ -685,7 +685,7 @@ PVR_ERROR Enigma2::GetTimers(ADDON_HANDLE handle)
 {
   std::vector<PVR_TIMER> timers;
   {
-    CLockObject lock(m_mutex);
+    std::lock_guard<std::mutex> lock(m_mutex);
     m_timers.GetTimers(timers);
     m_timers.GetAutoTimers(timers);
   }

--- a/src/Enigma2.cpp
+++ b/src/Enigma2.cpp
@@ -36,7 +36,7 @@
 #include <stdlib.h>
 #include <string>
 
-#include <p8-platform/util/StringUtils.h>
+#include <util/StringUtils.h>
 
 using namespace ADDON;
 using namespace P8PLATFORM;
@@ -332,7 +332,7 @@ void Enigma2::ReloadChannelsGroupsAndEPG()
   for (const auto& myChannel : m_channels.GetChannelsList())
     PVR->TriggerEpgUpdate(myChannel->GetUniqueId());
 
-  PVR->TriggerRecordingUpdate();  
+  PVR->TriggerRecordingUpdate();
 }
 
 void Enigma2::SendPowerstate()

--- a/src/Enigma2.cpp
+++ b/src/Enigma2.cpp
@@ -27,16 +27,17 @@
 #include "enigma2/utilities/LocalizedString.h"
 #include "enigma2/utilities/Logger.h"
 #include "enigma2/utilities/WebUtils.h"
-#include "util/XMLUtils.h"
 
 #include <algorithm>
+#include <cstdlib>
+#include <ctime>
 #include <fstream>
 #include <iostream>
 #include <regex>
-#include <stdlib.h>
 #include <string>
 
-#include <util/StringUtils.h>
+#include <kodi/util/XMLUtils.h>
+#include <p8-platform/util/StringUtils.h>
 
 using namespace ADDON;
 using namespace enigma2;

--- a/src/Enigma2.cpp
+++ b/src/Enigma2.cpp
@@ -198,14 +198,14 @@ void Enigma2::Process()
   m_epg.TriggerEpgUpdatesForChannels();
 
   unsigned int updateTimer = 0;
-  time_t lastUpdateTimeSeconds = time(nullptr);
+  time_t lastUpdateTimeSeconds = std::time(nullptr);
   int lastUpdateHour = m_settings.GetChannelAndGroupUpdateHour(); //ignore if we start during same hour
 
   while (m_running && m_isConnected)
   {
     std::this_thread::sleep_for(std::chrono::milliseconds(PROCESS_LOOP_WAIT_SECS * 1000));
 
-    time_t currentUpdateTimeSeconds = time(nullptr);
+    time_t currentUpdateTimeSeconds = std::time(nullptr);
     std::tm timeInfo = *std::localtime(&currentUpdateTimeSeconds);
     updateTimer += static_cast<unsigned int>(currentUpdateTimeSeconds - lastUpdateTimeSeconds);
     lastUpdateTimeSeconds = currentUpdateTimeSeconds;
@@ -731,7 +731,7 @@ PVR_ERROR Enigma2::GetTunerSignal(PVR_SIGNAL_STATUS& signalStatus)
     strncpy(signalStatus.strServiceName, channel->GetChannelName().c_str(), sizeof(signalStatus.strServiceName) - 1);
     strncpy(signalStatus.strProviderName, channel->GetProviderName().c_str(), sizeof(signalStatus.strProviderName) - 1);
 
-    time_t now = time(nullptr);
+    time_t now = std::time(nullptr);
     if ((now - m_lastSignalStatusUpdateSeconds) >= POLL_INTERVAL_SECONDS)
     {
       Logger::Log(LEVEL_DEBUG, "%s - Calling backend for Signal Status after interval of %d seconds", __FUNCTION__, POLL_INTERVAL_SECONDS);

--- a/src/Enigma2.cpp
+++ b/src/Enigma2.cpp
@@ -183,7 +183,7 @@ void Enigma2::Process()
 
   // Wait for the initial EPG update to complete
   int totalWaitSecs = 0;
-  while (totalWaitSecs < INITIAL_EPG_WAIT_SECS)
+  while (m_running && totalWaitSecs < INITIAL_EPG_WAIT_SECS)
   {
     totalWaitSecs += INITIAL_EPG_STEP_SECS;
 

--- a/src/Enigma2.h
+++ b/src/Enigma2.h
@@ -43,7 +43,6 @@
 #include <atomic>
 #include <mutex>
 #include <thread>
-#include <time.h>
 
 #include <tinyxml.h>
 

--- a/src/Enigma2.h
+++ b/src/Enigma2.h
@@ -41,6 +41,7 @@
 #include "enigma2/utilities/SignalStatus.h"
 
 #include <atomic>
+#include <mutex>
 #include <time.h>
 
 #include <p8-platform/threads/threads.h>
@@ -141,6 +142,5 @@ private:
   enigma2::utilities::SignalStatus m_signalStatus;
   enigma2::ConnectionManager* connectionManager;
 
-  mutable P8PLATFORM::CMutex m_mutex;
-  P8PLATFORM::CCondition<bool> m_started;
+  mutable std::mutex m_mutex;
 };

--- a/src/Enigma2.h
+++ b/src/Enigma2.h
@@ -42,9 +42,9 @@
 
 #include <atomic>
 #include <mutex>
+#include <thread>
 #include <time.h>
 
-#include <p8-platform/threads/threads.h>
 #include <tinyxml.h>
 
 // The windows build defines this but it breaks nlohmann/json.hpp's reference to std::snprintf
@@ -52,7 +52,7 @@
 #undef snprintf
 #endif
 
-class Enigma2 : public P8PLATFORM::CThread, public enigma2::IConnectionListener
+class Enigma2 : public enigma2::IConnectionListener
 {
 public:
   Enigma2(PVR_PROPERTIES* pvrProps);
@@ -110,7 +110,7 @@ public:
   PVR_ERROR GetTunerSignal(PVR_SIGNAL_STATUS& signalStatus);
 
 protected:
-  void* Process() override;
+  void Process();
 
 private:
   static const int INITIAL_EPG_WAIT_SECS = 60;
@@ -142,5 +142,7 @@ private:
   enigma2::utilities::SignalStatus m_signalStatus;
   enigma2::ConnectionManager* connectionManager;
 
+  std::atomic<bool> m_running = {false};
+  std::thread m_thread;
   mutable std::mutex m_mutex;
 };

--- a/src/Enigma2.h
+++ b/src/Enigma2.h
@@ -39,11 +39,12 @@
 #include "enigma2/data/RecordingEntry.h"
 #include "enigma2/extract/EpgEntryExtractor.h"
 #include "enigma2/utilities/SignalStatus.h"
-#include "p8-platform/threads/threads.h"
-#include "tinyxml.h"
 
 #include <atomic>
 #include <time.h>
+
+#include <p8-platform/threads/threads.h>
+#include <tinyxml.h>
 
 // The windows build defines this but it breaks nlohmann/json.hpp's reference to std::snprintf
 #if defined(snprintf)

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -33,7 +33,6 @@
 #include <stdlib.h>
 
 #include <kodi/xbmc_pvr_dll.h>
-#include <p8-platform/util/util.h>
 #include <util/StringUtils.h>
 
 using namespace ADDON;
@@ -52,6 +51,15 @@ CHelper_libXBMC_addon* XBMC = nullptr;
 CHelper_libXBMC_pvr* PVR = nullptr;
 Enigma2* enigma = nullptr;
 
+template<typename T> void SafeDelete(T*& p)
+{
+  if (p)
+  {
+    delete p;
+    p = nullptr;
+  }
+}
+
 extern "C"
 {
 
@@ -69,7 +77,7 @@ ADDON_STATUS ADDON_Create(void* hdl, void* props)
   XBMC = new CHelper_libXBMC_addon;
   if (!XBMC->RegisterMe(hdl))
   {
-    SAFE_DELETE(XBMC);
+    SafeDelete(XBMC);
     m_currentStatus = ADDON_STATUS_PERMANENT_FAILURE;
     return m_currentStatus;
   }
@@ -77,8 +85,8 @@ ADDON_STATUS ADDON_Create(void* hdl, void* props)
   PVR = new CHelper_libXBMC_pvr;
   if (!PVR->RegisterMe(hdl))
   {
-    SAFE_DELETE(PVR);
-    SAFE_DELETE(XBMC);
+    SafeDelete(PVR);
+    SafeDelete(XBMC);
     m_currentStatus = ADDON_STATUS_PERMANENT_FAILURE;
     return m_currentStatus;
   }
@@ -152,9 +160,9 @@ void ADDON_Destroy()
     enigma->SendPowerstate();
   }
 
-  SAFE_DELETE(enigma);
-  SAFE_DELETE(PVR);
-  SAFE_DELETE(XBMC);
+  SafeDelete(enigma);
+  SafeDelete(PVR);
+  SafeDelete(XBMC);
 
   m_currentStatus = ADDON_STATUS_UNKNOWN;
 }
@@ -413,7 +421,7 @@ void CloseLiveStream(void)
 {
   if (enigma)
     enigma->CloseLiveStream();
-  SAFE_DELETE(streamReader);
+  SafeDelete(streamReader);
 }
 
 bool IsRealTimeStream()
@@ -628,7 +636,7 @@ PVR_ERROR GetRecordingStreamProperties(const PVR_RECORDING* recording, PVR_NAMED
 bool OpenRecordedStream(const PVR_RECORDING& recording)
 {
   if (recordingReader)
-    SAFE_DELETE(recordingReader);
+    SafeDelete(recordingReader);
 
   if (!enigma || !enigma->IsConnected())
     return false;
@@ -640,7 +648,7 @@ bool OpenRecordedStream(const PVR_RECORDING& recording)
 void CloseRecordedStream(void)
 {
   if (recordingReader)
-    SAFE_DELETE(recordingReader);
+    SafeDelete(recordingReader);
 }
 
 int ReadRecordedStream(unsigned char* buffer, unsigned int size)

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -29,12 +29,12 @@
 #include "enigma2/TimeshiftBuffer.h"
 #include "enigma2/utilities/LocalizedString.h"
 #include "enigma2/utilities/Logger.h"
-#include "p8-platform/util/util.h"
-#include "kodi/xbmc_pvr_dll.h"
 
 #include <stdlib.h>
 
-#include <p8-platform/util/StringUtils.h>
+#include <kodi/xbmc_pvr_dll.h>
+#include <p8-platform/util/util.h>
+#include <util/StringUtils.h>
 
 using namespace ADDON;
 using namespace enigma2;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -30,10 +30,10 @@
 #include "enigma2/utilities/LocalizedString.h"
 #include "enigma2/utilities/Logger.h"
 
-#include <stdlib.h>
+#include <cstdlib>
 
 #include <kodi/xbmc_pvr_dll.h>
-#include <util/StringUtils.h>
+#include <p8-platform/util/StringUtils.h>
 
 using namespace ADDON;
 using namespace enigma2;

--- a/src/client.h
+++ b/src/client.h
@@ -21,8 +21,8 @@
  *
  */
 
-#include "kodi/libXBMC_addon.h"
-#include "kodi/libXBMC_pvr.h"
+#include <kodi/libXBMC_addon.h>
+#include <kodi/libXBMC_pvr.h>
 
 extern ADDON::CHelper_libXBMC_addon* XBMC;
 extern CHelper_libXBMC_pvr* PVR;

--- a/src/enigma2/Admin.cpp
+++ b/src/enigma2/Admin.cpp
@@ -24,8 +24,6 @@
 
 #include "../Enigma2.h"
 #include "../client.h"
-#include "p8-platform/util/StringUtils.h"
-#include "util/XMLUtils.h"
 #include "utilities/FileUtils.h"
 #include "utilities/LocalizedString.h"
 #include "utilities/Logger.h"
@@ -35,6 +33,8 @@
 #include <regex>
 
 #include <nlohmann/json.hpp>
+#include <util/StringUtils.h>
+#include <util/XMLUtils.h>
 
 using namespace enigma2;
 using namespace enigma2::data;

--- a/src/enigma2/Admin.cpp
+++ b/src/enigma2/Admin.cpp
@@ -32,9 +32,9 @@
 #include <cstdlib>
 #include <regex>
 
+#include <kodi/util/XMLUtils.h>
 #include <nlohmann/json.hpp>
-#include <util/StringUtils.h>
-#include <util/XMLUtils.h>
+#include <p8-platform/util/StringUtils.h>
 
 using namespace enigma2;
 using namespace enigma2::data;

--- a/src/enigma2/Admin.cpp
+++ b/src/enigma2/Admin.cpp
@@ -247,12 +247,12 @@ unsigned int Admin::ParseWebIfVersion(const std::string& webIfVersion)
 {
   unsigned int webIfVersionAsNum = 0;
 
-  std::regex regex("^.*[0-9]+\\.[0-9]+\\.[0-9].*$");
+  static const std::regex regex("^.*[0-9]+\\.[0-9]+\\.[0-9].*$");
   if (std::regex_match(webIfVersion, regex))
   {
     int count = 0;
     unsigned int versionPart = 0;
-    std::regex pattern("([0-9]+)");
+    static const std::regex pattern("([0-9]+)");
     for (auto i = std::sregex_iterator(webIfVersion.begin(), webIfVersion.end(), pattern); i != std::sregex_iterator(); ++i)
     {
         switch (count)
@@ -584,8 +584,8 @@ long long Admin::GetKbFromString(const std::string& stringInMbGbTb) const
   std::string replaceWith = "";
   for (const std::string& size : sizes)
   {
-    std::regex regexSize("^.* " + size);
-    std::regex regexReplaceSize(" " + size);
+    const std::regex regexSize("^.* " + size);
+    const std::regex regexReplaceSize(" " + size);
 
     if (std::regex_match(stringInMbGbTb, regexSize))
     {
@@ -654,7 +654,7 @@ bool Admin::GetTunerSignal(SignalStatus& signalStatus, const std::shared_ptr<dat
     return false;
   }
 
-  std::regex regexReplacePercent(" %");
+  static const std::regex regexReplacePercent(" %");
   std::string regexReplace = "";
 
   // For some reason the iSNR and iSignal values need to multiplied by 655!

--- a/src/enigma2/Admin.h
+++ b/src/enigma2/Admin.h
@@ -22,7 +22,6 @@
  */
 
 #include "data/Channel.h"
-#include "kodi/libXBMC_pvr.h"
 #include "utilities/DeviceInfo.h"
 #include "utilities/DeviceSettings.h"
 #include "utilities/SignalStatus.h"
@@ -31,6 +30,8 @@
 
 #include <string>
 #include <vector>
+
+#include <kodi/libXBMC_pvr.h>
 
 namespace enigma2
 {

--- a/src/enigma2/ChannelGroups.cpp
+++ b/src/enigma2/ChannelGroups.cpp
@@ -24,8 +24,6 @@
 
 #include "../Enigma2.h"
 #include "../client.h"
-#include "p8-platform/util/StringUtils.h"
-#include "util/XMLUtils.h"
 #include "utilities/FileUtils.h"
 #include "utilities/LocalizedString.h"
 #include "utilities/Logger.h"
@@ -34,6 +32,8 @@
 #include <regex>
 
 #include <nlohmann/json.hpp>
+#include <util/StringUtils.h>
+#include <util/XMLUtils.h>
 
 using namespace enigma2;
 using namespace enigma2::data;

--- a/src/enigma2/ChannelGroups.cpp
+++ b/src/enigma2/ChannelGroups.cpp
@@ -76,7 +76,7 @@ PVR_ERROR ChannelGroups::GetChannelGroupMembers(std::vector<PVR_CHANNEL_GROUP_ME
     Logger::Log(LEVEL_DEBUG, "%s - Starting to get ChannelGroupsMembers for PVR for group: %s", __FUNCTION__, groupName.c_str());
   }
 
-  int channelNumberInGroup = 1;
+  int channelOrder = 1;
 
   for (const auto& channel : channelGroup->GetChannelList())
   {
@@ -84,13 +84,14 @@ PVR_ERROR ChannelGroups::GetChannelGroupMembers(std::vector<PVR_CHANNEL_GROUP_ME
 
     strncpy(tag.strGroupName, groupName.c_str(), sizeof(tag.strGroupName));
     tag.iChannelUniqueId = channel->GetUniqueId();
-    tag.iChannelNumber = channelNumberInGroup; //Keep the channels in list order as per the groups on the STB
+    tag.iChannelNumber = 0; // The addon or kodi-pvr do not currently support group specific channel numbers
+    tag.iOrder = channelOrder; //Keep the channels in list order as per the groups on the STB
 
-    Logger::Log(LEVEL_DEBUG, "%s - add channel %s (%d) to group '%s' channel number %d", __FUNCTION__, channel->GetChannelName().c_str(), tag.iChannelUniqueId, groupName.c_str(), channel->GetChannelNumber());
+    Logger::Log(LEVEL_DEBUG, "%s - add channel %s (%d) to group '%s' with channel order %d", __FUNCTION__, channel->GetChannelName().c_str(), tag.iChannelUniqueId, groupName.c_str(), channelOrder);
 
     channelGroupMembers.emplace_back(tag);
 
-    channelNumberInGroup++;
+    channelOrder++;
   }
 
   Logger::Log(LEVEL_DEBUG, "%s - Finished getting ChannelGroupsMembers for PVR for group: %s", __FUNCTION__, groupName.c_str());

--- a/src/enigma2/ChannelGroups.cpp
+++ b/src/enigma2/ChannelGroups.cpp
@@ -31,9 +31,9 @@
 
 #include <regex>
 
+#include <kodi/util/XMLUtils.h>
 #include <nlohmann/json.hpp>
-#include <util/StringUtils.h>
-#include <util/XMLUtils.h>
+#include <p8-platform/util/StringUtils.h>
 
 using namespace enigma2;
 using namespace enigma2::data;

--- a/src/enigma2/ChannelGroups.h
+++ b/src/enigma2/ChannelGroups.h
@@ -23,12 +23,13 @@
 
 #include "data/Channel.h"
 #include "data/ChannelGroup.h"
-#include "kodi/libXBMC_pvr.h"
 
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
+
+#include <kodi/libXBMC_pvr.h>
 
 namespace enigma2
 {

--- a/src/enigma2/Channels.cpp
+++ b/src/enigma2/Channels.cpp
@@ -31,9 +31,9 @@
 
 #include <regex>
 
+#include <kodi/util/XMLUtils.h>
 #include <nlohmann/json.hpp>
-#include <util/StringUtils.h>
-#include <util/XMLUtils.h>
+#include <p8-platform/util/StringUtils.h>
 
 using namespace enigma2;
 using namespace enigma2::data;

--- a/src/enigma2/Channels.cpp
+++ b/src/enigma2/Channels.cpp
@@ -61,17 +61,23 @@ int GenerateChannelUniqueId(const std::string& channelName, const std::string& e
 
 void Channels::GetChannels(std::vector<PVR_CHANNEL>& kodiChannels, bool bRadio) const
 {
+  int channelOrder = 1;
+
   for (const auto& channel : m_channels)
   {
     if (channel->IsRadio() == bRadio)
     {
-      Logger::Log(LEVEL_DEBUG, "%s - Transfer channel '%s', ChannelIndex '%d'", __FUNCTION__, channel->GetChannelName().c_str(),
-                  channel->GetUniqueId());
       PVR_CHANNEL kodiChannel = {0};
 
       channel->UpdateTo(kodiChannel);
+      kodiChannel.iOrder = channelOrder; //Keep the channels in list order as per the load order on the STB
+
+      Logger::Log(LEVEL_DEBUG, "%s - Transfer channel '%s', ChannelIndex '%d', Order '%d''", __FUNCTION__, channel->GetChannelName().c_str(),
+                  channel->GetUniqueId(), channelOrder);
 
       kodiChannels.emplace_back(kodiChannel);
+
+      channelOrder++;
     }
   }
 }

--- a/src/enigma2/Channels.cpp
+++ b/src/enigma2/Channels.cpp
@@ -26,14 +26,14 @@
 #include "../client.h"
 #include "Admin.h"
 #include "ChannelGroups.h"
-#include "p8-platform/util/StringUtils.h"
-#include "util/XMLUtils.h"
 #include "utilities/Logger.h"
 #include "utilities/WebUtils.h"
 
 #include <regex>
 
 #include <nlohmann/json.hpp>
+#include <util/StringUtils.h>
+#include <util/XMLUtils.h>
 
 using namespace enigma2;
 using namespace enigma2::data;

--- a/src/enigma2/Channels.h
+++ b/src/enigma2/Channels.h
@@ -23,12 +23,13 @@
 
 #include "ChannelGroups.h"
 #include "data/Channel.h"
-#include "kodi/libXBMC_pvr.h"
 
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
+
+#include <kodi/libXBMC_pvr.h>
 
 namespace enigma2
 {

--- a/src/enigma2/ConnectionManager.cpp
+++ b/src/enigma2/ConnectionManager.cpp
@@ -64,7 +64,7 @@ void ConnectionManager::Stop()
 
 void ConnectionManager::OnSleep()
 {
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
 
   Logger::Log(LogLevel::LEVEL_DEBUG, "%s going to sleep", __FUNCTION__);
 
@@ -73,7 +73,7 @@ void ConnectionManager::OnSleep()
 
 void ConnectionManager::OnWake()
 {
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
 
   Logger::Log(LogLevel::LEVEL_DEBUG, "%s Waking up", __FUNCTION__);
 
@@ -86,7 +86,7 @@ void ConnectionManager::SetState(PVR_CONNECTION_STATE state)
   PVR_CONNECTION_STATE newState(PVR_CONNECTION_STATE_UNKNOWN);
 
   {
-    CLockObject lock(m_mutex);
+    std::lock_guard<std::mutex> lock(m_mutex);
 
     /* No notification if no state change or while suspended. */
     if (m_state != state && !m_suspended)
@@ -119,7 +119,7 @@ void ConnectionManager::SetState(PVR_CONNECTION_STATE state)
 
 void ConnectionManager::Disconnect()
 {
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
 
   m_connectionListener.ConnectionLost();
 }

--- a/src/enigma2/ConnectionManager.cpp
+++ b/src/enigma2/ConnectionManager.cpp
@@ -27,7 +27,6 @@
 #include "utilities/Logger.h"
 #include "utilities/WebUtils.h"
 
-#include <p8-platform/os.h>
 #include <util/StringUtils.h>
 
 using namespace P8PLATFORM;

--- a/src/enigma2/ConnectionManager.cpp
+++ b/src/enigma2/ConnectionManager.cpp
@@ -24,10 +24,11 @@
 #include "../client.h"
 #include "IConnectionListener.h"
 #include "Settings.h"
-#include "p8-platform/os.h"
-#include "p8-platform/util/StringUtils.h"
 #include "utilities/Logger.h"
 #include "utilities/WebUtils.h"
+
+#include <p8-platform/os.h>
+#include <util/StringUtils.h>
 
 using namespace P8PLATFORM;
 using namespace enigma2;

--- a/src/enigma2/ConnectionManager.cpp
+++ b/src/enigma2/ConnectionManager.cpp
@@ -29,7 +29,7 @@
 
 #include <chrono>
 
-#include <util/StringUtils.h>
+#include <p8-platform/util/StringUtils.h>
 
 using namespace enigma2;
 using namespace enigma2::utilities;

--- a/src/enigma2/ConnectionManager.h
+++ b/src/enigma2/ConnectionManager.h
@@ -22,11 +22,12 @@
  *
  */
 
+#include <atomic>
 #include <mutex>
 #include <string>
+#include <thread>
 
 #include <kodi/libXBMC_pvr.h>
-#include <p8-platform/threads/threads.h>
 
 namespace enigma2
 {
@@ -35,11 +36,11 @@ namespace enigma2
 
   class IConnectionListener;
 
-  class ConnectionManager : public P8PLATFORM::CThread
+  class ConnectionManager
   {
   public:
     ConnectionManager(IConnectionListener& connectionListener);
-    ~ConnectionManager() override;
+    ~ConnectionManager();
 
     void Start();
     void Stop();
@@ -50,11 +51,13 @@ namespace enigma2
     void OnWake();
 
   private:
-    void* Process() override;
+    void Process();
     void SetState(PVR_CONNECTION_STATE state);
     void SteppedSleep(int intervalMs);
 
     IConnectionListener& m_connectionListener;
+    std::atomic<bool> m_running = {false};
+    std::thread m_thread;
     mutable std::mutex m_mutex;
     bool m_suspended;
     PVR_CONNECTION_STATE m_state;

--- a/src/enigma2/ConnectionManager.h
+++ b/src/enigma2/ConnectionManager.h
@@ -22,10 +22,10 @@
  *
  */
 
+#include <mutex>
 #include <string>
 
 #include <kodi/libXBMC_pvr.h>
-#include <p8-platform/threads/mutex.h>
 #include <p8-platform/threads/threads.h>
 
 namespace enigma2
@@ -55,7 +55,7 @@ namespace enigma2
     void SteppedSleep(int intervalMs);
 
     IConnectionListener& m_connectionListener;
-    mutable P8PLATFORM::CMutex m_mutex;
+    mutable std::mutex m_mutex;
     bool m_suspended;
     PVR_CONNECTION_STATE m_state;
   };

--- a/src/enigma2/ConnectionManager.h
+++ b/src/enigma2/ConnectionManager.h
@@ -22,11 +22,11 @@
  *
  */
 
-#include "kodi/libXBMC_pvr.h"
-#include "p8-platform/threads/mutex.h"
-#include "p8-platform/threads/threads.h"
-
 #include <string>
+
+#include <kodi/libXBMC_pvr.h>
+#include <p8-platform/threads/mutex.h>
+#include <p8-platform/threads/threads.h>
 
 namespace enigma2
 {

--- a/src/enigma2/Epg.cpp
+++ b/src/enigma2/Epg.cpp
@@ -550,7 +550,7 @@ bool Epg::LoadInitialEPGForGroup(const std::shared_ptr<ChannelGroup> group)
 void Epg::UpdateTimerEPGFallbackEntries(const std::vector<enigma2::data::EpgEntry>& timerBasedEntries)
 {
   std::lock_guard<std::mutex> lock(m_mutex);
-  time_t now = time(nullptr);
+  time_t now = std::time(nullptr);
   time_t until = now + m_epgMaxDaysSeconds;
 
   m_timerBasedEntries.clear();

--- a/src/enigma2/Epg.cpp
+++ b/src/enigma2/Epg.cpp
@@ -31,9 +31,9 @@
 #include <cmath>
 #include <regex>
 
+#include <kodi/util/XMLUtils.h>
 #include <nlohmann/json.hpp>
-#include <util/StringUtils.h>
-#include <util/XMLUtils.h>
+#include <p8-platform/util/StringUtils.h>
 
 using namespace enigma2;
 using namespace enigma2::data;

--- a/src/enigma2/Epg.cpp
+++ b/src/enigma2/Epg.cpp
@@ -550,7 +550,7 @@ bool Epg::LoadInitialEPGForGroup(const std::shared_ptr<ChannelGroup> group)
 
 void Epg::UpdateTimerEPGFallbackEntries(const std::vector<enigma2::data::EpgEntry>& timerBasedEntries)
 {
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   time_t now = time(nullptr);
   time_t until = now + m_epgMaxDaysSeconds;
 
@@ -567,7 +567,7 @@ int Epg::TransferTimerBasedEntries(ADDON_HANDLE handle, int epgChannelId)
 {
   int numTransferred = 0;
 
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   for (auto& timerBasedEntry : m_timerBasedEntries)
   {
     if (epgChannelId == timerBasedEntry.GetChannelId())

--- a/src/enigma2/Epg.cpp
+++ b/src/enigma2/Epg.cpp
@@ -39,7 +39,6 @@ using namespace enigma2;
 using namespace enigma2::data;
 using namespace enigma2::extract;
 using namespace enigma2::utilities;
-using namespace P8PLATFORM;
 using json = nlohmann::json;
 
 Epg::Epg(enigma2::extract::EpgEntryExtractor& entryExtractor, int epgMaxDays)

--- a/src/enigma2/Epg.cpp
+++ b/src/enigma2/Epg.cpp
@@ -24,8 +24,6 @@
 
 #include "../Enigma2.h"
 #include "../client.h"
-#include "p8-platform/util/StringUtils.h"
-#include "util/XMLUtils.h"
 #include "utilities/Logger.h"
 #include "utilities/WebUtils.h"
 
@@ -34,6 +32,8 @@
 #include <regex>
 
 #include <nlohmann/json.hpp>
+#include <util/StringUtils.h>
+#include <util/XMLUtils.h>
 
 using namespace enigma2;
 using namespace enigma2::data;

--- a/src/enigma2/Epg.h
+++ b/src/enigma2/Epg.h
@@ -34,7 +34,6 @@
 #include <vector>
 
 #include <kodi/libXBMC_pvr.h>
-#include <p8-platform/threads/threads.h>
 
 namespace enigma2
 {

--- a/src/enigma2/Epg.h
+++ b/src/enigma2/Epg.h
@@ -29,6 +29,7 @@
 
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -79,6 +80,6 @@ namespace enigma2
 
     std::vector<data::EpgEntry> m_timerBasedEntries;
 
-    mutable P8PLATFORM::CMutex m_mutex;
+    mutable std::mutex m_mutex;
   };
 } //namespace enigma2

--- a/src/enigma2/Epg.h
+++ b/src/enigma2/Epg.h
@@ -26,13 +26,14 @@
 #include "data/EpgChannel.h"
 #include "data/EpgPartialEntry.h"
 #include "extract/EpgEntryExtractor.h"
-#include "kodi/libXBMC_pvr.h"
-#include "p8-platform/threads/threads.h"
 
 #include <map>
 #include <memory>
 #include <string>
 #include <vector>
+
+#include <kodi/libXBMC_pvr.h>
+#include <p8-platform/threads/threads.h>
 
 namespace enigma2
 {

--- a/src/enigma2/IStreamReader.h
+++ b/src/enigma2/IStreamReader.h
@@ -21,9 +21,9 @@
  *
  */
 
-#include "kodi/libXBMC_addon.h"
-
 #include <ctime>
+
+#include <kodi/libXBMC_addon.h>
 
 namespace enigma2
 {

--- a/src/enigma2/RecordingReader.cpp
+++ b/src/enigma2/RecordingReader.cpp
@@ -37,7 +37,7 @@ RecordingReader::RecordingReader(const std::string& streamURL, std::time_t start
   m_readHandle = XBMC->CURLCreate(m_streamURL.c_str());
   (void)XBMC->CURLOpen(m_readHandle, XFILE::READ_NO_CACHE);
   m_len = XBMC->GetFileLength(m_readHandle);
-  m_nextReopen = time(nullptr) + REOPEN_INTERVAL;
+  m_nextReopen = std::time(nullptr) + REOPEN_INTERVAL;
 
   //If this is an ongoing recording set the duration to the eventual length of the recording
   if (start > 0 && end > 0)

--- a/src/enigma2/RecordingReader.cpp
+++ b/src/enigma2/RecordingReader.cpp
@@ -23,10 +23,11 @@
 #include "RecordingReader.h"
 
 #include "../client.h"
-#include "p8-platform/threads/mutex.h"
 #include "utilities/Logger.h"
 
 #include <algorithm>
+
+#include <p8-platform/threads/mutex.h>
 
 using namespace ADDON;
 using namespace enigma2;

--- a/src/enigma2/RecordingReader.cpp
+++ b/src/enigma2/RecordingReader.cpp
@@ -27,8 +27,6 @@
 
 #include <algorithm>
 
-#include <p8-platform/threads/mutex.h>
-
 using namespace ADDON;
 using namespace enigma2;
 using namespace enigma2::utilities;

--- a/src/enigma2/Recordings.cpp
+++ b/src/enigma2/Recordings.cpp
@@ -32,9 +32,9 @@
 #include <regex>
 #include <sstream>
 
+#include <kodi/util/XMLUtils.h>
 #include <nlohmann/json.hpp>
-#include <util/StringUtils.h>
-#include <util/XMLUtils.h>
+#include <p8-platform/util/StringUtils.h>
 
 using namespace enigma2;
 using namespace enigma2::data;

--- a/src/enigma2/Recordings.cpp
+++ b/src/enigma2/Recordings.cpp
@@ -24,8 +24,6 @@
 
 #include "../Enigma2.h"
 #include "../client.h"
-#include "p8-platform/util/StringUtils.h"
-#include "util/XMLUtils.h"
 #include "utilities/Logger.h"
 #include "utilities/WebUtils.h"
 
@@ -34,6 +32,8 @@
 #include <sstream>
 
 #include <nlohmann/json.hpp>
+#include <util/StringUtils.h>
+#include <util/XMLUtils.h>
 
 using namespace enigma2;
 using namespace enigma2::data;

--- a/src/enigma2/Recordings.cpp
+++ b/src/enigma2/Recordings.cpp
@@ -469,7 +469,7 @@ PVR_ERROR Recordings::UndeleteRecording(const PVR_RECORDING& recording)
 {
   auto recordingEntry = GetRecording(recording.strRecordingId);
 
-  std::regex regex(TRASH_FOLDER);
+  static const std::regex regex(TRASH_FOLDER);
 
   const std::string newRecordingDirectory = std::regex_replace(recordingEntry.GetDirectory(), regex, "");
 

--- a/src/enigma2/Recordings.h
+++ b/src/enigma2/Recordings.h
@@ -68,7 +68,7 @@ namespace enigma2
   private:
     static const std::string FILE_NOT_FOUND_RESPONSE_SUFFIX;
 
-    bool GetRecordingsFromLocation(const std::string recordingFolder, bool deleted);
+    bool GetRecordingsFromLocation(const std::string recordingFolder, bool deleted, std::vector<data::RecordingEntry>& recordings);
     data::RecordingEntry GetRecording(const std::string& recordingId) const;
     bool ReadExtaRecordingCutsInfo(const data::RecordingEntry& recordingEntry, std::vector<std::pair<int, int64_t>>& cuts, std::vector<std::string>& tags);
     bool ReadExtraRecordingPlayCountInfo(const data::RecordingEntry& recordingEntry, std::vector<std::string>& tags);

--- a/src/enigma2/Recordings.h
+++ b/src/enigma2/Recordings.h
@@ -24,12 +24,13 @@
 #include "Channels.h"
 #include "data/RecordingEntry.h"
 #include "extract/EpgEntryExtractor.h"
-#include "kodi/libXBMC_pvr.h"
 
 #include <random>
 #include <string>
 #include <unordered_map>
 #include <vector>
+
+#include <kodi/libXBMC_pvr.h>
 
 namespace enigma2
 {

--- a/src/enigma2/Settings.cpp
+++ b/src/enigma2/Settings.cpp
@@ -26,9 +26,9 @@
 #include "utilities/FileUtils.h"
 #include "utilities/LocalizedString.h"
 
+#include <kodi/util/XMLUtils.h>
+#include <p8-platform/util/StringUtils.h>
 #include <tinyxml.h>
-#include <util/StringUtils.h>
-#include <util/XMLUtils.h>
 
 using namespace ADDON;
 using namespace enigma2;

--- a/src/enigma2/Settings.cpp
+++ b/src/enigma2/Settings.cpp
@@ -23,11 +23,12 @@
 #include "Settings.h"
 
 #include "../client.h"
-#include "p8-platform/util/StringUtils.h"
-#include "tinyxml.h"
-#include "util/XMLUtils.h"
 #include "utilities/FileUtils.h"
 #include "utilities/LocalizedString.h"
+
+#include <tinyxml.h>
+#include <util/StringUtils.h>
+#include <util/XMLUtils.h>
 
 using namespace ADDON;
 using namespace enigma2;

--- a/src/enigma2/Settings.h
+++ b/src/enigma2/Settings.h
@@ -29,7 +29,7 @@
 #include <string>
 
 #include <kodi/xbmc_addon_types.h>
-#include <util/StringUtils.h>
+#include <p8-platform/util/StringUtils.h>
 
 class Vu;
 

--- a/src/enigma2/Settings.h
+++ b/src/enigma2/Settings.h
@@ -268,7 +268,10 @@ namespace enigma2
       T newValue = *static_cast<const T*>(settingValue);
       if (newValue != currentValue)
       {
-        utilities::Logger::Log(utilities::LogLevel::LEVEL_NOTICE, "%s - Changed Setting '%s' from %d to %d", __FUNCTION__, settingName.c_str(), currentValue, newValue);
+        std::string formatString = "%s - Changed Setting '%s' from %d to %d";
+        if (std::is_same<T, float>::value)
+          formatString = "%s - Changed Setting '%s' from %f to %f";
+        utilities::Logger::Log(utilities::LogLevel::LEVEL_NOTICE, formatString.c_str(), __FUNCTION__, settingName.c_str(), currentValue, newValue);
         currentValue = newValue;
         return returnValueIfChanged;
       }

--- a/src/enigma2/Settings.h
+++ b/src/enigma2/Settings.h
@@ -25,11 +25,11 @@
 #include "utilities/DeviceInfo.h"
 #include "utilities/DeviceSettings.h"
 #include "utilities/Logger.h"
-#include "kodi/xbmc_addon_types.h"
 
 #include <string>
 
-#include <p8-platform/util/StringUtils.h>
+#include <kodi/xbmc_addon_types.h>
+#include <util/StringUtils.h>
 
 class Vu;
 

--- a/src/enigma2/StreamReader.h
+++ b/src/enigma2/StreamReader.h
@@ -45,6 +45,6 @@ namespace enigma2
 
   private:
     void* m_streamHandle;
-    std::time_t m_start = time(nullptr);
+    std::time_t m_start = std::time(nullptr);
   };
 } // namespace enigma2

--- a/src/enigma2/Timers.cpp
+++ b/src/enigma2/Timers.cpp
@@ -24,9 +24,6 @@
 
 #include "../Enigma2.h"
 #include "../client.h"
-#include "inttypes.h"
-#include "p8-platform/util/StringUtils.h"
-#include "util/XMLUtils.h"
 #include "utilities/LocalizedString.h"
 #include "utilities/Logger.h"
 #include "utilities/UpdateState.h"
@@ -34,7 +31,11 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <inttypes.h>
 #include <regex>
+
+#include <util/StringUtils.h>
+#include <util/XMLUtils.h>
 
 using namespace ADDON;
 using namespace enigma2;

--- a/src/enigma2/Timers.cpp
+++ b/src/enigma2/Timers.cpp
@@ -30,12 +30,12 @@
 #include "utilities/WebUtils.h"
 
 #include <algorithm>
+#include <cinttypes>
 #include <cstdlib>
-#include <inttypes.h>
 #include <regex>
 
-#include <util/StringUtils.h>
-#include <util/XMLUtils.h>
+#include <kodi/util/XMLUtils.h>
+#include <p8-platform/util/StringUtils.h>
 
 using namespace ADDON;
 using namespace enigma2;

--- a/src/enigma2/Timers.cpp
+++ b/src/enigma2/Timers.cpp
@@ -180,7 +180,7 @@ void Timers::GenerateChildManualRepeatingTimers(std::vector<Timer>* timers, Time
 
 std::string Timers::ConvertToAutoTimerTag(std::string tag)
 {
-  std::regex regex(" ");
+  static const std::regex regex(" ");
   std::string replaceWith = "_";
 
   return std::regex_replace(tag, regex, replaceWith);
@@ -781,7 +781,7 @@ PVR_ERROR Timers::UpdateTimer(const PVR_TIMER& timer)
 
 std::string Timers::RemovePaddingTag(std::string tag)
 {
-  std::regex regex(" Padding=[0-9]+,[0-9]+ *");
+  static const std::regex regex(" Padding=[0-9]+,[0-9]+ *");
   std::string replaceWith = "";
 
   return std::regex_replace(tag, regex, replaceWith);

--- a/src/enigma2/Timers.h
+++ b/src/enigma2/Timers.h
@@ -78,11 +78,11 @@ namespace enigma2
     T* GetTimer(std::function<bool(const T&)> func, std::vector<T>& timerlist);
 
     // functions
-    std::vector<enigma2::data::Timer> LoadTimers() const;
+    bool LoadTimers(std::vector<enigma2::data::Timer>& timers) const;
     void GenerateChildManualRepeatingTimers(std::vector<enigma2::data::Timer>* timers, enigma2::data::Timer* timer) const;
     static std::string ConvertToAutoTimerTag(std::string tag);
     static std::string RemovePaddingTag(std::string tag);
-    std::vector<enigma2::data::AutoTimer> LoadAutoTimers() const;
+    bool LoadAutoTimers(std::vector<enigma2::data::AutoTimer>& autoTimers) const;
     bool IsAutoTimer(const PVR_TIMER& timer) const;
     bool TimerUpdatesRegular();
     bool TimerUpdatesAuto();

--- a/src/enigma2/Timers.h
+++ b/src/enigma2/Timers.h
@@ -25,8 +25,6 @@
 #include "data/AutoTimer.h"
 #include "data/Timer.h"
 #include "extract/EpgEntryExtractor.h"
-#include "tinyxml.h"
-#include "kodi/libXBMC_pvr.h"
 
 #include <atomic>
 #include <ctime>
@@ -34,6 +32,9 @@
 #include <memory>
 #include <string>
 #include <type_traits>
+
+#include <kodi/libXBMC_pvr.h>
+#include <tinyxml.h>
 
 namespace enigma2
 {

--- a/src/enigma2/TimeshiftBuffer.cpp
+++ b/src/enigma2/TimeshiftBuffer.cpp
@@ -26,8 +26,6 @@
 #include "StreamReader.h"
 #include "utilities/Logger.h"
 
-#include <p8-platform/util/util.h>
-
 using namespace ADDON;
 using namespace enigma2;
 using namespace enigma2::utilities;
@@ -63,7 +61,11 @@ TimeshiftBuffer::~TimeshiftBuffer(void)
   if (!XBMC->DeleteFile(m_bufferPath.c_str()))
     Logger::Log(LEVEL_ERROR, "%s Unable to delete file when timeshift buffer is deleted: %s", __FUNCTION__, m_bufferPath.c_str());
 
-  SAFE_DELETE(m_streamReader);
+  if (m_streamReader)
+  {
+    delete m_streamReader;
+    m_streamReader = nullptr;
+  }
   Logger::Log(LEVEL_DEBUG, "%s Timeshift: Stopped", __FUNCTION__);
 }
 

--- a/src/enigma2/TimeshiftBuffer.cpp
+++ b/src/enigma2/TimeshiftBuffer.cpp
@@ -24,8 +24,9 @@
 
 #include "../client.h"
 #include "StreamReader.h"
-#include "p8-platform/util/util.h"
 #include "utilities/Logger.h"
+
+#include <p8-platform/util/util.h>
 
 using namespace ADDON;
 using namespace enigma2;

--- a/src/enigma2/TimeshiftBuffer.cpp
+++ b/src/enigma2/TimeshiftBuffer.cpp
@@ -77,7 +77,7 @@ bool TimeshiftBuffer::Start()
     return true;
 
   Logger::Log(LEVEL_INFO, "%s Timeshift: Started", __FUNCTION__);
-  m_start = time(nullptr);
+  m_start = std::time(nullptr);
   m_running = true;
   m_inputThread = std::thread([&] { DoReadWrite(); });
 

--- a/src/enigma2/data/AutoTimer.cpp
+++ b/src/enigma2/data/AutoTimer.cpp
@@ -23,11 +23,12 @@
 #include "AutoTimer.h"
 
 #include "../utilities/LocalizedString.h"
-#include "inttypes.h"
-#include "p8-platform/util/StringUtils.h"
-#include "util/XMLUtils.h"
 
 #include <cstdlib>
+#include <inttypes.h>
+
+#include <util/StringUtils.h>
+#include <util/XMLUtils.h>
 
 using namespace enigma2;
 using namespace enigma2::data;

--- a/src/enigma2/data/AutoTimer.cpp
+++ b/src/enigma2/data/AutoTimer.cpp
@@ -24,11 +24,11 @@
 
 #include "../utilities/LocalizedString.h"
 
+#include <cinttypes>
 #include <cstdlib>
-#include <inttypes.h>
 
-#include <util/StringUtils.h>
-#include <util/XMLUtils.h>
+#include <kodi/util/XMLUtils.h>
+#include <p8-platform/util/StringUtils.h>
 
 using namespace enigma2;
 using namespace enigma2::data;

--- a/src/enigma2/data/AutoTimer.h
+++ b/src/enigma2/data/AutoTimer.h
@@ -22,12 +22,13 @@
  */
 
 #include "Timer.h"
-#include "tinyxml.h"
-#include "kodi/libXBMC_pvr.h"
 
 #include <ctime>
 #include <string>
 #include <type_traits>
+
+#include <kodi/libXBMC_pvr.h>
+#include <tinyxml.h>
 
 namespace enigma2
 {

--- a/src/enigma2/data/BaseChannel.h
+++ b/src/enigma2/data/BaseChannel.h
@@ -21,12 +21,12 @@
  *
  */
 
-#include "tinyxml.h"
-#include "kodi/libXBMC_pvr.h"
-
 #include <memory>
 #include <string>
 #include <vector>
+
+#include <kodi/libXBMC_pvr.h>
+#include <tinyxml.h>
 
 namespace enigma2
 {

--- a/src/enigma2/data/BaseEntry.cpp
+++ b/src/enigma2/data/BaseEntry.cpp
@@ -22,8 +22,9 @@
 
 #include "BaseEntry.h"
 
-#include "inttypes.h"
-#include "p8-platform/util/StringUtils.h"
+#include <inttypes.h>
+
+#include <util/StringUtils.h>
 
 using namespace enigma2;
 using namespace enigma2::data;

--- a/src/enigma2/data/BaseEntry.cpp
+++ b/src/enigma2/data/BaseEntry.cpp
@@ -22,9 +22,9 @@
 
 #include "BaseEntry.h"
 
-#include <inttypes.h>
+#include <cinttypes>
 
-#include <util/StringUtils.h>
+#include <p8-platform/util/StringUtils.h>
 
 using namespace enigma2;
 using namespace enigma2::data;

--- a/src/enigma2/data/BaseEntry.h
+++ b/src/enigma2/data/BaseEntry.h
@@ -62,6 +62,15 @@ namespace enigma2
       int GetYear() const { return m_year; }
       void SetYear(int value) { m_year = value; }
 
+      bool IsNew() const { return m_new; }
+      void SetNew(int value) { m_new = value; }
+
+      bool IsLive() const { return m_live; }
+      void SetLive(int value) { m_live = value; }
+
+      bool IsPremiere() const { return m_premiere; }
+      void SetPremiere(int value) { m_premiere = value; }
+
       void ProcessPrependMode(PrependOutline prependOutlineMode);
 
     protected:
@@ -75,6 +84,9 @@ namespace enigma2
       int m_episodePartNumber = 0;
       int m_seasonNumber = 0;
       int m_year = 0;
+      bool m_new = false;
+      bool m_live = false;
+      bool m_premiere = false;
     };
   } //namespace data
 } //namespace enigma2

--- a/src/enigma2/data/Channel.cpp
+++ b/src/enigma2/data/Channel.cpp
@@ -26,11 +26,11 @@
 #include "../utilities/WebUtils.h"
 #include "ChannelGroup.h"
 
-#include <inttypes.h>
+#include <cinttypes>
 #include <regex>
 
-#include <util/StringUtils.h>
-#include <util/XMLUtils.h>
+#include <kodi/util/XMLUtils.h>
+#include <p8-platform/util/StringUtils.h>
 
 using namespace enigma2;
 using namespace enigma2::data;

--- a/src/enigma2/data/Channel.cpp
+++ b/src/enigma2/data/Channel.cpp
@@ -167,10 +167,10 @@ std::string Channel::CreateCommonServiceReference(const std::string& serviceRefe
 std::string Channel::CreateGenericServiceReference(const std::string& commonServiceReference)
 {
   //Same as common service reference but starts with SERVICE_REF_GENERIC_PREFIX and ends with SERVICE_REF_GENERIC_POSTFIX
-  std::regex startPrefixRegex("^\\d+:\\d+:\\d+:");
+  static const std::regex startPrefixRegex("^\\d+:\\d+:\\d+:");
   std::string replaceWith = "";
   std::string genericServiceReference = std::regex_replace(commonServiceReference, startPrefixRegex, replaceWith);
-  std::regex endPostfixRegex(":\\d+:\\d+:\\d+$");
+  static const std::regex endPostfixRegex(":\\d+:\\d+:\\d+$");
   genericServiceReference = std::regex_replace(genericServiceReference, endPostfixRegex, replaceWith);
   genericServiceReference = SERVICE_REF_GENERIC_PREFIX + genericServiceReference + SERVICE_REF_GENERIC_POSTFIX;
 
@@ -214,7 +214,8 @@ std::string Channel::ExtractIptvStreamURL()
       {
         iptvStreamURL = iptvStreamURL.substr(0, foundColon);
       }
-      iptvStreamURL = std::regex_replace(iptvStreamURL, std::regex("%3a"), ":");
+      static const std::regex escapedColonRegex("%3a");
+      iptvStreamURL = std::regex_replace(iptvStreamURL, escapedColonRegex, ":");
     }
   }
 

--- a/src/enigma2/data/Channel.cpp
+++ b/src/enigma2/data/Channel.cpp
@@ -25,11 +25,12 @@
 #include "../Settings.h"
 #include "../utilities/WebUtils.h"
 #include "ChannelGroup.h"
-#include "inttypes.h"
-#include "p8-platform/util/StringUtils.h"
-#include "util/XMLUtils.h"
 
+#include <inttypes.h>
 #include <regex>
+
+#include <util/StringUtils.h>
+#include <util/XMLUtils.h>
 
 using namespace enigma2;
 using namespace enigma2::data;

--- a/src/enigma2/data/Channel.h
+++ b/src/enigma2/data/Channel.h
@@ -22,12 +22,13 @@
  */
 
 #include "BaseChannel.h"
-#include "tinyxml.h"
-#include "kodi/libXBMC_pvr.h"
 
 #include <memory>
 #include <string>
 #include <vector>
+
+#include <kodi/libXBMC_pvr.h>
+#include <tinyxml.h>
 
 namespace enigma2
 {

--- a/src/enigma2/data/ChannelGroup.cpp
+++ b/src/enigma2/data/ChannelGroup.cpp
@@ -22,9 +22,10 @@
 
 #include "ChannelGroup.h"
 
-#include "inttypes.h"
-#include "p8-platform/util/StringUtils.h"
-#include "util/XMLUtils.h"
+#include <inttypes.h>
+
+#include <util/StringUtils.h>
+#include <util/XMLUtils.h>
 
 using namespace enigma2;
 using namespace enigma2::data;

--- a/src/enigma2/data/ChannelGroup.cpp
+++ b/src/enigma2/data/ChannelGroup.cpp
@@ -22,10 +22,10 @@
 
 #include "ChannelGroup.h"
 
-#include <inttypes.h>
+#include <cinttypes>
 
-#include <util/StringUtils.h>
-#include <util/XMLUtils.h>
+#include <kodi/util/XMLUtils.h>
+#include <p8-platform/util/StringUtils.h>
 
 using namespace enigma2;
 using namespace enigma2::data;

--- a/src/enigma2/data/ChannelGroup.h
+++ b/src/enigma2/data/ChannelGroup.h
@@ -23,12 +23,13 @@
 
 #include "Channel.h"
 #include "EpgEntry.h"
-#include "tinyxml.h"
-#include "kodi/libXBMC_pvr.h"
 
 #include <memory>
 #include <string>
 #include <vector>
+
+#include <kodi/libXBMC_pvr.h>
+#include <tinyxml.h>
 
 namespace enigma2
 {

--- a/src/enigma2/data/EpgChannel.h
+++ b/src/enigma2/data/EpgChannel.h
@@ -23,12 +23,13 @@
 
 #include "BaseChannel.h"
 #include "EpgEntry.h"
-#include "tinyxml.h"
-#include "kodi/libXBMC_pvr.h"
 
 #include <memory>
 #include <string>
 #include <vector>
+
+#include <kodi/libXBMC_pvr.h>
+#include <tinyxml.h>
 
 namespace enigma2
 {

--- a/src/enigma2/data/EpgEntry.cpp
+++ b/src/enigma2/data/EpgEntry.cpp
@@ -49,7 +49,10 @@ void EpgEntry::UpdateTo(EPG_TAG& left) const
   left.iGenreType          = m_genreType;
   left.iGenreSubType       = m_genreSubType;
   left.strGenreDescription = m_genreDescription.c_str();
-  left.firstAired          = 0;  // unused
+  if (m_new || m_live || m_premiere)
+    left.firstAired = m_startTime; // Kodi-pvr will mark an epg entry as new if the firstAired date and startTime date match
+  else
+    left.firstAired = 0;  // unused
   left.iParentalRating     = 0;  // unused
   left.iStarRating         = 0;  // unused
   left.iSeriesNumber       = m_seasonNumber;

--- a/src/enigma2/data/EpgEntry.cpp
+++ b/src/enigma2/data/EpgEntry.cpp
@@ -22,8 +22,9 @@
 
 #include "EpgEntry.h"
 
-#include "inttypes.h"
-#include "util/XMLUtils.h"
+#include <inttypes.h>
+
+#include <util/XMLUtils.h>
 
 using namespace enigma2;
 using namespace enigma2::data;

--- a/src/enigma2/data/EpgEntry.cpp
+++ b/src/enigma2/data/EpgEntry.cpp
@@ -22,9 +22,9 @@
 
 #include "EpgEntry.h"
 
-#include <inttypes.h>
+#include <cinttypes>
 
-#include <util/XMLUtils.h>
+#include <kodi/util/XMLUtils.h>
 
 using namespace enigma2;
 using namespace enigma2::data;

--- a/src/enigma2/data/EpgEntry.h
+++ b/src/enigma2/data/EpgEntry.h
@@ -23,11 +23,12 @@
 
 #include "BaseEntry.h"
 #include "EpgChannel.h"
-#include "tinyxml.h"
-#include "kodi/libXBMC_pvr.h"
 
 #include <map>
 #include <string>
+
+#include <kodi/libXBMC_pvr.h>
+#include <tinyxml.h>
 
 namespace enigma2
 {

--- a/src/enigma2/data/RecordingEntry.cpp
+++ b/src/enigma2/data/RecordingEntry.cpp
@@ -23,11 +23,12 @@
 #include "RecordingEntry.h"
 
 #include "../utilities/WebUtils.h"
-#include "inttypes.h"
-#include "p8-platform/util/StringUtils.h"
-#include "util/XMLUtils.h"
 
 #include <cstdlib>
+#include <inttypes.h>
+
+#include <util/StringUtils.h>
+#include <util/XMLUtils.h>
 
 using namespace enigma2;
 using namespace enigma2::data;

--- a/src/enigma2/data/RecordingEntry.cpp
+++ b/src/enigma2/data/RecordingEntry.cpp
@@ -24,11 +24,11 @@
 
 #include "../utilities/WebUtils.h"
 
+#include <cinttypes>
 #include <cstdlib>
-#include <inttypes.h>
 
-#include <util/StringUtils.h>
-#include <util/XMLUtils.h>
+#include <kodi/util/XMLUtils.h>
+#include <p8-platform/util/StringUtils.h>
 
 using namespace enigma2;
 using namespace enigma2::data;

--- a/src/enigma2/data/RecordingEntry.h
+++ b/src/enigma2/data/RecordingEntry.h
@@ -25,10 +25,12 @@
 #include "BaseEntry.h"
 #include "Channel.h"
 #include "Tags.h"
-#include "tinyxml.h"
-#include "kodi/libXBMC_pvr.h"
 
 #include <string>
+
+#include <kodi/libXBMC_pvr.h>
+#include <tinyxml.h>
+
 namespace enigma2
 {
   namespace data

--- a/src/enigma2/data/Tags.h
+++ b/src/enigma2/data/Tags.h
@@ -48,7 +48,7 @@ namespace enigma2
 
       bool ContainsTag(const std::string& tag) const
       {
-        std::regex regex("^.* ?" + tag + " ?.*$");
+        const std::regex regex("^.* ?" + tag + " ?.*$");
 
         return (std::regex_match(m_tags, regex));
       }
@@ -95,7 +95,7 @@ namespace enigma2
 
       void RemoveTag(const std::string& tagName)
       {
-        std::regex regex(" *" + tagName + "=?[^\\s-]*");
+        const std::regex regex(" *" + tagName + "=?[^\\s-]*");
         std::string replaceWith = "";
 
         m_tags = std::regex_replace(m_tags, regex, replaceWith);

--- a/src/enigma2/data/Tags.h
+++ b/src/enigma2/data/Tags.h
@@ -24,7 +24,7 @@
 #include <regex>
 #include <string>
 
-#include <util/StringUtils.h>
+#include <p8-platform/util/StringUtils.h>
 
 namespace enigma2
 {

--- a/src/enigma2/data/Tags.h
+++ b/src/enigma2/data/Tags.h
@@ -21,10 +21,10 @@
  *
  */
 
-#include "p8-platform/util/StringUtils.h"
-
 #include <regex>
 #include <string>
+
+#include <util/StringUtils.h>
 
 namespace enigma2
 {

--- a/src/enigma2/data/Timer.cpp
+++ b/src/enigma2/data/Timer.cpp
@@ -24,11 +24,11 @@
 
 #include "../utilities/LocalizedString.h"
 
-#include <inttypes.h>
+#include <cinttypes>
 #include <regex>
 
-#include <util/StringUtils.h>
-#include <util/XMLUtils.h>
+#include <kodi/util/XMLUtils.h>
+#include <p8-platform/util/StringUtils.h>
 
 using namespace enigma2;
 using namespace enigma2::data;

--- a/src/enigma2/data/Timer.cpp
+++ b/src/enigma2/data/Timer.cpp
@@ -23,11 +23,12 @@
 #include "Timer.h"
 
 #include "../utilities/LocalizedString.h"
-#include "inttypes.h"
-#include "p8-platform/util/StringUtils.h"
-#include "util/XMLUtils.h"
 
+#include <inttypes.h>
 #include <regex>
+
+#include <util/StringUtils.h>
+#include <util/XMLUtils.h>
 
 using namespace enigma2;
 using namespace enigma2::data;

--- a/src/enigma2/data/Timer.h
+++ b/src/enigma2/data/Timer.h
@@ -25,12 +25,13 @@
 #include "../utilities/UpdateState.h"
 #include "BaseEntry.h"
 #include "Tags.h"
-#include "tinyxml.h"
-#include "kodi/libXBMC_pvr.h"
 
 #include <ctime>
 #include <string>
 #include <type_traits>
+
+#include <kodi/libXBMC_pvr.h>
+#include <tinyxml.h>
 
 namespace enigma2
 {

--- a/src/enigma2/extract/GenreIdMapper.cpp
+++ b/src/enigma2/extract/GenreIdMapper.cpp
@@ -27,8 +27,8 @@
 #include <cstdlib>
 
 #include <kodi/libXBMC_pvr.h>
+#include <kodi/util/XMLUtils.h>
 #include <tinyxml.h>
-#include <util/XMLUtils.h>
 
 using namespace enigma2;
 using namespace enigma2::data;

--- a/src/enigma2/extract/GenreIdMapper.cpp
+++ b/src/enigma2/extract/GenreIdMapper.cpp
@@ -24,11 +24,11 @@
 
 #include "../utilities/FileUtils.h"
 
-#include "tinyxml.h"
-#include "kodi/libXBMC_pvr.h"
-#include "util/XMLUtils.h"
-
 #include <cstdlib>
+
+#include <kodi/libXBMC_pvr.h>
+#include <tinyxml.h>
+#include <util/XMLUtils.h>
 
 using namespace enigma2;
 using namespace enigma2::data;

--- a/src/enigma2/extract/GenreIdMapper.cpp
+++ b/src/enigma2/extract/GenreIdMapper.cpp
@@ -154,15 +154,18 @@ bool GenreIdMapper::LoadIdToIdGenreFile(const std::string& xmlFile, std::map<int
 
   for (; pNode != nullptr; pNode = pNode->NextSiblingElement("mapping"))
   {
-    const std::string sourceIdString = pNode->Attribute("sourceId");
+    const std::string sourceIdString = pNode->Attribute("sourceId") ? pNode->Attribute("sourceId") : "";
     const std::string targetIdString = pNode->GetText();
 
-    int sourceId = std::strtol(sourceIdString.c_str(), nullptr, 16);
-    int targetId = std::strtol(targetIdString.c_str(), nullptr, 16);
+    if (!sourceIdString.empty())
+    {
+      int sourceId = std::strtol(sourceIdString.c_str(), nullptr, 16);
+      int targetId = std::strtol(targetIdString.c_str(), nullptr, 16);
 
-    map.insert({sourceId, targetId});
+      map.insert({sourceId, targetId});
 
-    Logger::Log(LEVEL_TRACE, "%s Read ID Mapping for: %s, sourceId=%#02X, targetId=%#02X", __FUNCTION__, mapperName.c_str(), sourceId, targetId);
+      Logger::Log(LEVEL_TRACE, "%s Read ID Mapping for: %s, sourceId=%#02X, targetId=%#02X", __FUNCTION__, mapperName.c_str(), sourceId, targetId);
+    }
   }
 
   return true;

--- a/src/enigma2/extract/GenreRytecTextMapper.cpp
+++ b/src/enigma2/extract/GenreRytecTextMapper.cpp
@@ -207,14 +207,17 @@ bool GenreRytecTextMapper::LoadTextToIdGenreFile(const std::string& xmlFile, std
 
   for (; pNode != nullptr; pNode = pNode->NextSiblingElement("mapping"))
   {
-    const std::string targetIdString = pNode->Attribute("targetId");
+    const std::string targetIdString = pNode->Attribute("targetId") ? pNode->Attribute("targetId") : "";
     const std::string textMapping = pNode->GetText();
 
-    int targetId = std::strtol(targetIdString.c_str(), nullptr, 16);
+    if (!targetIdString.empty())
+    {
+      int targetId = std::strtol(targetIdString.c_str(), nullptr, 16);
 
-    map.insert({textMapping, targetId});
+      map.insert({textMapping, targetId});
 
-    Logger::Log(LEVEL_TRACE, "%s Read Text Mapping for: %s, text=%s, targetId=%#02X", __FUNCTION__, mapperName.c_str(), textMapping.c_str(), targetId);
+      Logger::Log(LEVEL_TRACE, "%s Read Text Mapping for: %s, text=%s, targetId=%#02X", __FUNCTION__, mapperName.c_str(), textMapping.c_str(), targetId);
+    }
   }
 
   return true;

--- a/src/enigma2/extract/GenreRytecTextMapper.cpp
+++ b/src/enigma2/extract/GenreRytecTextMapper.cpp
@@ -27,8 +27,8 @@
 #include <cstdlib>
 
 #include <kodi/libXBMC_pvr.h>
+#include <kodi/util/XMLUtils.h>
 #include <tinyxml.h>
-#include <util/XMLUtils.h>
 
 using namespace enigma2;
 using namespace enigma2::data;

--- a/src/enigma2/extract/GenreRytecTextMapper.cpp
+++ b/src/enigma2/extract/GenreRytecTextMapper.cpp
@@ -24,11 +24,11 @@
 
 #include "../utilities/FileUtils.h"
 
-#include "tinyxml.h"
-#include "kodi/libXBMC_pvr.h"
-#include "util/XMLUtils.h"
-
 #include <cstdlib>
+
+#include <kodi/libXBMC_pvr.h>
+#include <tinyxml.h>
+#include <util/XMLUtils.h>
 
 using namespace enigma2;
 using namespace enigma2::data;

--- a/src/enigma2/extract/IExtractor.h
+++ b/src/enigma2/extract/IExtractor.h
@@ -66,6 +66,24 @@ namespace enigma2
         return matchedText;
       }
 
+      static bool Matches(const std::string& text, const std::regex& pattern)
+      {
+        std::smatch match;
+
+        std::regex_match(text, match, pattern);
+        return match.size() != 0;
+      };
+
+      static bool Matches(const std::string& firstText, const std::string& secondText, const std::regex& pattern)
+      {
+        bool matches = Matches(firstText, pattern);
+
+        if (!matches)
+          matches = Matches(secondText, pattern);
+
+        return matches;
+      };
+
       enigma2::Settings& m_settings = Settings::GetInstance();
     };
   } //namespace extract

--- a/src/enigma2/extract/ShowInfoExtractor.cpp
+++ b/src/enigma2/extract/ShowInfoExtractor.cpp
@@ -162,18 +162,18 @@ bool ShowInfoExtractor::LoadShowInfoPatternsFile(const std::string& xmlFile, std
 
     if (childNode)
     {
-      const std::string masterPattern = childNode->Attribute("pattern");
+      const std::string masterPattern = childNode->Attribute("pattern") ? childNode->Attribute("pattern") : "";
 
       childNode = pNode->FirstChildElement("episode");
 
       if (childNode)
       {
-        const std::string episodePattern = childNode->Attribute("pattern");
+        const std::string episodePattern = childNode->Attribute("pattern") ? childNode->Attribute("pattern") : "";
 
         childNode = pNode->FirstChildElement("season");
         if (childNode != nullptr)
         {
-          const std::string seasonPattern = childNode->Attribute("pattern");
+          const std::string seasonPattern = childNode->Attribute("pattern") ? childNode->Attribute("pattern") : "";
 
           if (!masterPattern.empty() && !seasonPattern.empty() && !episodePattern.empty())
           {
@@ -222,7 +222,7 @@ bool ShowInfoExtractor::LoadShowInfoPatternsFile(const std::string& xmlFile, std
 
   for (; pNode != nullptr; pNode = pNode->NextSiblingElement("year"))
   {
-    const std::string yearPattern = pNode->Attribute("pattern");
+    const std::string yearPattern = pNode->Attribute("pattern") ? pNode->Attribute("pattern") : "";
 
     yearPatterns.emplace_back(std::regex(yearPattern));
 

--- a/src/enigma2/extract/ShowInfoExtractor.cpp
+++ b/src/enigma2/extract/ShowInfoExtractor.cpp
@@ -26,9 +26,9 @@
 
 #include <cstdlib>
 
+#include <kodi/util/XMLUtils.h>
+#include <p8-platform/util/StringUtils.h>
 #include <tinyxml.h>
-#include <util/XMLUtils.h>
-#include <util/StringUtils.h>
 
 using namespace enigma2;
 using namespace enigma2::data;

--- a/src/enigma2/extract/ShowInfoExtractor.cpp
+++ b/src/enigma2/extract/ShowInfoExtractor.cpp
@@ -23,10 +23,12 @@
 #include "ShowInfoExtractor.h"
 
 #include "../utilities/FileUtils.h"
-#include "tinyxml.h"
-#include "util/XMLUtils.h"
 
 #include <cstdlib>
+
+#include <tinyxml.h>
+#include <util/XMLUtils.h>
+#include <util/StringUtils.h>
 
 using namespace enigma2;
 using namespace enigma2::data;

--- a/src/enigma2/extract/ShowInfoExtractor.h
+++ b/src/enigma2/extract/ShowInfoExtractor.h
@@ -24,6 +24,7 @@
 #include "EpisodeSeasonPattern.h"
 #include "IExtractor.h"
 
+#include <map>
 #include <regex>
 #include <string>
 #include <vector>
@@ -32,6 +33,16 @@ namespace enigma2
 {
   namespace extract
   {
+    enum class TextPropertyType
+      : int // same type as addon settings
+    {
+      NEW = 0,
+      LIVE,
+      PREMIERE
+    };
+
+    static const std::map<std::string, TextPropertyType> m_textPropetyTypeMap{{"new", TextPropertyType::NEW}, {"live", TextPropertyType::LIVE}, {"premiere", TextPropertyType::PREMIERE}};
+
     // (S4E37) (S04E37) (S2 Ep3/6) (S2 Ep7)
     static const std::string MASTER_SEASON_EPISODE_PATTERN = "^.*\\(?([sS]\\.?[0-9]+ ?[eE][pP]?\\.?[0-9]+/?[0-9]*)\\)?[^]*$";
     // (E130) (Ep10) (E7/9) (Ep7/10) (Ep.25)
@@ -62,10 +73,12 @@ namespace enigma2
       bool IsEnabled();
 
     private:
-      bool LoadShowInfoPatternsFile(const std::string& xmlFile, std::vector<EpisodeSeasonPattern>& episodeSeasonPatterns, std::vector<std::regex> yearPatterns);
+      bool LoadShowInfoPatternsFile(const std::string& xmlFile, std::vector<EpisodeSeasonPattern>& episodeSeasonPatterns, std::vector<std::regex>& yearPatterns, std::vector<std::pair<TextPropertyType, std::regex>>& titleTextPatterns, std::vector<std::pair<TextPropertyType, std::regex>>& descTextPatterns);
 
       std::vector<EpisodeSeasonPattern> m_episodeSeasonPatterns;
       std::vector<std::regex> m_yearPatterns;
+      std::vector<std::pair<TextPropertyType, std::regex>> m_titleTextPatterns;
+      std::vector<std::pair<TextPropertyType, std::regex>> m_descriptionTextPatterns;
     };
   } //namespace extract
 } //namespace enigma2

--- a/src/enigma2/utilities/WebUtils.cpp
+++ b/src/enigma2/utilities/WebUtils.cpp
@@ -24,9 +24,10 @@
 #include "../Settings.h"
 #include "CurlFile.h"
 #include "Logger.h"
-#include "p8-platform/util/StringUtils.h"
-#include "tinyxml.h"
-#include "util/XMLUtils.h"
+
+#include <tinyxml.h>
+#include <util/StringUtils.h>
+#include <util/XMLUtils.h>
 
 using namespace enigma2;
 using namespace enigma2::utilities;

--- a/src/enigma2/utilities/WebUtils.cpp
+++ b/src/enigma2/utilities/WebUtils.cpp
@@ -25,9 +25,9 @@
 #include "CurlFile.h"
 #include "Logger.h"
 
+#include <kodi/util/XMLUtils.h>
+#include <p8-platform/util/StringUtils.h>
 #include <tinyxml.h>
-#include <util/StringUtils.h>
-#include <util/XMLUtils.h>
 
 using namespace enigma2;
 using namespace enigma2::utilities;


### PR DESCRIPTION
v4.8.0
- Added: Support group (bouquet) channel order from the backend
- Added: Extract new/live/premiere as part of show info from EPG
- Fixed: Fix possible runtime error assigning nullptr to string
- Fixed: Preserve recordings and timer lists if connection lost
- Update: Remove p8-platform dependency on Threads, Mutex, Condition, Util and OS
- Fixed: Fix long kodi shutdown delay if shutodwn happens before addon fully starts
- Update: Update regex to static/const (perf benefit)
- Update: Update show info regex's