### PR TITLE
Fix windows crashes caused by negative values

### DIFF
--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="6.1.1"
+  version="6.1.2"
   name="Enigma2 Client"
   provider-name="Joerg Dembski and Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>
@@ -181,6 +181,10 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v6.1.2
+- Fixed: Fix char treated as negative values on windows causes crash on isspace call
+- Fixed: Check for invalid time struct when converting epg/recording entry to string
+
 v6.1.1
 - Update: Spelling fixes (Closes: pvr.vuplus#292)
 

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,3 +1,7 @@
+v6.1.2
+- Fixed: Fix char treated as negative values on windows causes crash on isspace call
+- Fixed: Check for invalid time struct when converting epg/recording entry to string
+
 v6.1.1
 - Update: Spelling fixes (Closes: pvr.vuplus#292)
 

--- a/src/enigma2/data/Channel.cpp
+++ b/src/enigma2/data/Channel.cpp
@@ -61,7 +61,13 @@ bool Channel::UpdateFrom(TiXmlElement* channelNode)
     return false;
 
   m_fuzzyChannelName = m_channelName;
-  m_fuzzyChannelName.erase(std::remove_if(m_fuzzyChannelName.begin(), m_fuzzyChannelName.end(), isspace), m_fuzzyChannelName.end());
+
+  // We need to correctly cast to unsigned char as for some platforms such as windows it will 
+  // fail on a negative value as it will be treated as an int instead of character
+  auto func = [](char c) { return isspace(static_cast<unsigned char>(c)); };
+  // alternatively this can be done as follows:
+  //auto func = [](unsigned char const c) { return isspace(std::char_traits<char>::to_int_type(c)); };
+  m_fuzzyChannelName.erase(std::remove_if(m_fuzzyChannelName.begin(), m_fuzzyChannelName.end(), func), m_fuzzyChannelName.end());
 
   if (m_radio != HasRadioServiceType())
     return false;

--- a/src/enigma2/data/EpgEntry.cpp
+++ b/src/enigma2/data/EpgEntry.cpp
@@ -90,7 +90,10 @@ std::string ParseAsW3CDateString(time_t time)
 {
   std::tm* tm = std::localtime(&time);
   char buffer[16];
-  std::strftime(buffer, 16, "%Y-%m-%d", tm);
+  if (tm)
+    std::strftime(buffer, 16, "%Y-%m-%d", tm);
+  else // negative time or other invalid time_t value
+     std::strcpy(buffer, "1970-01-01");
 
   return buffer;
 }

--- a/src/enigma2/data/RecordingEntry.cpp
+++ b/src/enigma2/data/RecordingEntry.cpp
@@ -26,7 +26,10 @@ std::string ParseAsW3CDateString(time_t time)
 {
   std::tm* tm = std::localtime(&time);
   char buffer[16];
-  std::strftime(buffer, 16, "%Y-%m-%d", tm);
+  if (tm)
+    std::strftime(buffer, 16, "%Y-%m-%d", tm);
+  else // negative time or other invalid time_t value
+     std::strcpy(buffer, "1970-01-01");
 
   return buffer;
 }

--- a/src/enigma2/data/RecordingEntry.cpp
+++ b/src/enigma2/data/RecordingEntry.cpp
@@ -306,7 +306,12 @@ std::shared_ptr<Channel> RecordingEntry::GetChannelFromChannelNameFuzzySearch(Ch
   for (const auto& channel : channels.GetChannelsList())
   {
     fuzzyRecordingChannelName = m_channelName;
-    fuzzyRecordingChannelName.erase(remove_if(fuzzyRecordingChannelName.begin(), fuzzyRecordingChannelName.end(), isspace), fuzzyRecordingChannelName.end());
+    // We need to correctly cast to unsigned char as for some platforms such as windows it will
+    // fail on a negative value as it will be treated as an int instead of character
+    auto func = [](char c) { return isspace(static_cast<unsigned char>(c)); };
+    // alternatively this can be done as follows:
+    //auto func = [](unsigned char const c) { return isspace(std::char_traits<char>::to_int_type(c)); };
+    fuzzyRecordingChannelName.erase(remove_if(fuzzyRecordingChannelName.begin(), fuzzyRecordingChannelName.end(), func), fuzzyRecordingChannelName.end());
 
     if (fuzzyRecordingChannelName == channel->GetFuzzyChannelName() && (!m_haveChannelType || (channel->IsRadio() == m_radio)))
     {


### PR DESCRIPTION
v6.1.2
- Fixed: Fix char treated as negative values on windows causes crash on isspace call
- Fixed: Check for invalid time struct when converting epg/recording entry to string