### PR TITLE
Always set MIME type for native streams

### DIFF
--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -6,7 +6,7 @@
   provider-name="Joerg Dembski and Ross Nicholson">
   <requires>
     @ADDON_DEPENDS@
-    <import addon="inputstream.ffmpegdirect" minversion="1.15.0" optional="true"/>
+    <import addon="inputstream.ffmpegdirect" minversion="1.18.0" optional="true"/>
   </requires>
   <requires>@ADDON_DEPENDS@</requires>
   <extension

--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="7.0.0"
+  version="7.1.0"
   name="Enigma2 Client"
   provider-name="Joerg Dembski and Ross Nicholson">
   <requires>
@@ -184,7 +184,13 @@
     <assets>
       <icon>icon.png</icon>
     </assets>
-    <news>v7.0.0
+    <news>
+v7.1.0
+- Set MIME type for Enigma2 native streams and only set program/PID for native also
+- Set minimim inputstream.ffmpegdirect version to API stable version for Matrix
+- Fix seg fault if trying to play a channel when not connected
+
+v7.0.0
 - Update: PVR API 7.0.2
 
 v6.4.0

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,3 +1,8 @@
+v7.1.0
+- Set MIME type for Enigma2 native streams and only set program/PID for native also
+- Set minimim inputstream.ffmpegdirect version to API stable version for Matrix
+- Fix seg fault if trying to play a channel when not connected
+
 v7.0.0
 - Update: PVR API 7.0.2
 

--- a/src/Enigma2.cpp
+++ b/src/Enigma2.cpp
@@ -485,6 +485,9 @@ PVR_ERROR Enigma2::GetChannels(bool radio, kodi::addon::PVRChannelsResultSet& re
 
 PVR_ERROR Enigma2::GetChannelStreamProperties(const kodi::addon::PVRChannel& channel, std::vector<kodi::addon::PVRStreamProperty>& properties)
 {
+  if (!IsConnected())
+    return PVR_ERROR_SERVER_ERROR;
+
   if (!m_settings.SetStreamProgramID() && !IsIptvStream(channel))
     return PVR_ERROR_NOT_IMPLEMENTED;
 
@@ -492,9 +495,6 @@ PVR_ERROR Enigma2::GetChannelStreamProperties(const kodi::addon::PVRChannel& cha
   // We only use this function to set the program number which comes with every Enigma2 channel. For providers that
   // use MPTS it allows the FFMPEG Demux to identify the correct Program/PID.
   //
-
-  if (!IsConnected())
-    return PVR_ERROR_SERVER_ERROR;
 
   if (IsIptvStream(channel))
   {


### PR DESCRIPTION
v7.1.0
- Set MIME type for Enigma2 native streams and only set program/PID for native also
- Set minimim inputstream.ffmpegdirect version to API stable version for Matrix
- Fix seg fault if trying to play a channel when not connected