### PR TITLE
Fix crash

### DIFF
--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="7.1.0"
+  version="7.1.1"
   name="Enigma2 Client"
   provider-name="Joerg Dembski and Ross Nicholson">
   <requires>
@@ -185,10 +185,14 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v7.1.1
+- Fixed: Fix crash on restart from settings change
+- Fixed: Always create autotimer once timer type and can be sent even if autotimers are disabled
+
 v7.1.0
-- Set MIME type for Enigma2 native streams and only set program/PID for native also
-- Set minimim inputstream.ffmpegdirect version to API stable version for Matrix
-- Fix seg fault if trying to play a channel when not connected
+- Added: Set MIME type for Enigma2 native streams and only set program/PID for native also
+- Added: Set minimim inputstream.ffmpegdirect version to API stable version for Matrix
+- Fixed: Fix seg fault if trying to play a channel when not connected
 
 v7.0.0
 - Update: PVR API 7.0.2

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,7 +1,11 @@
+v7.1.1
+- Fixed: Fix crash on restart from settings change
+- Fixed: Always create autotimer once timer type and can be sent even if autotimers are disabled
+
 v7.1.0
-- Set MIME type for Enigma2 native streams and only set program/PID for native also
-- Set minimim inputstream.ffmpegdirect version to API stable version for Matrix
-- Fix seg fault if trying to play a channel when not connected
+- Added: Set MIME type for Enigma2 native streams and only set program/PID for native also
+- Added: Set minimim inputstream.ffmpegdirect version to API stable version for Matrix
+- Fixed: Fix seg fault if trying to play a channel when not connected
 
 v7.0.0
 - Update: PVR API 7.0.2

--- a/src/enigma2/Settings.cpp
+++ b/src/enigma2/Settings.cpp
@@ -338,12 +338,12 @@ ADDON_STATUS Settings::SetValue(const std::string& settingName, const kodi::CSet
     return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_wakeOnLanMac, ADDON_STATUS_OK, ADDON_STATUS_OK);
   else if (settingName == "globalstartpaddingstb")
   {
-    if (SetSetting<int, bool>(settingName, settingValue, m_globalStartPaddingStb, true, false))
+    if (m_admin && SetSetting<int, bool>(settingName, settingValue, m_globalStartPaddingStb, true, false))
       m_admin->SendGlobalRecordingStartMarginSetting(m_globalStartPaddingStb);
   }
   else if (settingName == "globalendpaddingstb")
   {
-    if (SetSetting<int, bool>(settingName, settingValue, m_globalEndPaddingStb, true, false))
+    if (m_admin && SetSetting<int, bool>(settingName, settingValue, m_globalEndPaddingStb, true, false))
       m_admin->SendGlobalRecordingEndMarginSetting(m_globalEndPaddingStb);
   }
   //Advanced

--- a/src/enigma2/Settings.h
+++ b/src/enigma2/Settings.h
@@ -428,7 +428,7 @@ namespace enigma2
     std::string m_connectionURL;
     enigma2::utilities::DeviceInfo* m_deviceInfo;
     enigma2::utilities::DeviceSettings* m_deviceSettings;
-    enigma2::Admin* m_admin;
+    enigma2::Admin* m_admin = nullptr;
     bool m_deviceInfoSet = false;
     bool m_deviceSettingsSet = false;
 

--- a/src/enigma2/Timers.cpp
+++ b/src/enigma2/Timers.cpp
@@ -381,26 +381,29 @@ void Timers::GetTimerTypes(std::vector<kodi::addon::PVRTimerType>& types) const
       groupValues, deDupValues, AutoTimer::DeDup::CHECK_TITLE_AND_ALL_DESCS);
     types.emplace_back(*t);
     delete t;
-
-    /* One-shot created by epg auto search */
-    t = new TimerType(
-      Timer::Type::EPG_AUTO_ONCE,
-      PVR_TIMER_TYPE_IS_MANUAL                 |
-      PVR_TIMER_TYPE_FORBIDS_NEW_INSTANCES     |
-      PVR_TIMER_TYPE_IS_READONLY               |
-      PVR_TIMER_TYPE_SUPPORTS_READONLY_DELETE  |
-      PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE   |
-      PVR_TIMER_TYPE_SUPPORTS_CHANNELS         |
-      PVR_TIMER_TYPE_SUPPORTS_START_TIME       |
-      PVR_TIMER_TYPE_SUPPORTS_END_TIME         |
-      PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN |
-      PVR_TIMER_TYPE_SUPPORTS_RECORDING_GROUP |
-      PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE,
-      kodi::GetLocalizedString(30420), // Once off timer (set by auto guide-based rule)
-      groupValues);
-    types.emplace_back(*t);
-    delete t;
   }
+
+  // We always create this as even if autotimers are disabled the backend
+  // can still send regular timers of this type
+
+  /* One-shot created by epg auto search */
+  t = new TimerType(
+    Timer::Type::EPG_AUTO_ONCE,
+    PVR_TIMER_TYPE_IS_MANUAL                 |
+    PVR_TIMER_TYPE_FORBIDS_NEW_INSTANCES     |
+    PVR_TIMER_TYPE_IS_READONLY               |
+    PVR_TIMER_TYPE_SUPPORTS_READONLY_DELETE  |
+    PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE   |
+    PVR_TIMER_TYPE_SUPPORTS_CHANNELS         |
+    PVR_TIMER_TYPE_SUPPORTS_START_TIME       |
+    PVR_TIMER_TYPE_SUPPORTS_END_TIME         |
+    PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN |
+    PVR_TIMER_TYPE_SUPPORTS_RECORDING_GROUP |
+    PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE,
+    kodi::GetLocalizedString(30420), // Once off timer (set by auto guide-based rule)
+    groupValues);
+  types.emplace_back(*t);
+  delete t;
 }
 
 int Timers::GetTimerCount() const

--- a/src/enigma2/data/EpgEntry.cpp
+++ b/src/enigma2/data/EpgEntry.cpp
@@ -93,7 +93,7 @@ std::string ParseAsW3CDateString(time_t time)
   if (tm)
     std::strftime(buffer, 16, "%Y-%m-%d", tm);
   else // negative time or other invalid time_t value
-     std::strcpy(buffer, "1970-01-01");
+    std::strcpy(buffer, "1970-01-01");
 
   return buffer;
 }

--- a/src/enigma2/data/RecordingEntry.cpp
+++ b/src/enigma2/data/RecordingEntry.cpp
@@ -31,7 +31,7 @@ std::string ParseAsW3CDateString(time_t time)
   if (tm)
     std::strftime(buffer, 16, "%Y-%m-%d", tm);
   else // negative time or other invalid time_t value
-     std::strcpy(buffer, "1970-01-01");
+    std::strcpy(buffer, "1970-01-01");
 
   return buffer;
 }


### PR DESCRIPTION
v7.1.1
- Fixed: Fix crash on restart from settings change
- Fixed: Always create autotimer once timer type and can be sent even if autotimers are disabled