### PR TITLE
Fix settings

### DIFF
--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="7.1.1"
+  version="7.1.2"
   name="Enigma2 Client"
   provider-name="Joerg Dembski and Ross Nicholson">
   <requires>
@@ -185,6 +185,10 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v7.1.2
+- Fixed: Fix setting wrong value for gen repeat timers
+- Fixed: Only send autotimers settings to device if they are enabled
+
 v7.1.1
 - Fixed: Fix crash on restart from settings change
 - Fixed: Always create autotimer once timer type and can be sent even if autotimers are disabled

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,3 +1,7 @@
+v7.1.2
+- Fixed: Fix setting wrong value for gen repeat timers
+- Fixed: Only send autotimers settings to device if they are enabled
+
 v7.1.1
 - Fixed: Fix crash on restart from settings change
 - Fixed: Always create autotimer once timer type and can be sent even if autotimers are disabled

--- a/src/enigma2/Admin.cpp
+++ b/src/enigma2/Admin.cpp
@@ -85,7 +85,7 @@ bool Admin::Initialise()
     if (deviceSettingsLoaded)
     {
       //If OpenWebVersion is new enough to allow the setting of AutoTimer setttings
-      if (Settings::GetInstance().SupportsAutoTimers())
+      if (Settings::GetInstance().SupportsAutoTimers() && Settings::GetInstance().GetAutoTimersEnabled())
         SendAutoTimerSettings();
     }
   }

--- a/src/enigma2/Settings.cpp
+++ b/src/enigma2/Settings.cpp
@@ -311,7 +311,7 @@ ADDON_STATUS Settings::SetValue(const std::string& settingName, const kodi::CSet
     return SetSetting<int, ADDON_STATUS>(settingName, settingValue, m_edlStopTimePadding, ADDON_STATUS_OK, ADDON_STATUS_OK);
   //Timers
   else if (settingName == "enablegenrepeattimers")
-    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_enableAutoTimers, ADDON_STATUS_OK, ADDON_STATUS_OK);
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_enableGenRepeatTimers, ADDON_STATUS_OK, ADDON_STATUS_OK);
   else if (settingName == "numgenrepeattimers")
     return SetSetting<int, ADDON_STATUS>(settingName, settingValue, m_numGenRepeatTimers, ADDON_STATUS_OK, ADDON_STATUS_OK);
   else if (settingName == "timerlistcleanup")


### PR DESCRIPTION
v7.1.2
- Fixed: Fix setting wrong value for gen repeat timers
- Fixed: Only send autotimers settings to device if they are enabled