### PR TITLE
Fix crash2

### DIFF
--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="7.1.2"
+  version="7.1.3"
   name="Enigma2 Client"
   provider-name="Joerg Dembski and Ross Nicholson">
   <requires>
@@ -185,6 +185,9 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v7.1.3
+- Fixed: Set default values for start and end time to avoid overflow crash on windows
+
 v7.1.2
 - Fixed: Fix setting wrong value for gen repeat timers
 - Fixed: Only send autotimers settings to device if they are enabled

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,3 +1,6 @@
+v7.1.3
+- Fixed: Set default values for start and end time to avoid overflow crash on windows
+
 v7.1.2
 - Fixed: Fix setting wrong value for gen repeat timers
 - Fixed: Only send autotimers settings to device if they are enabled

--- a/src/enigma2/data/EpgEntry.h
+++ b/src/enigma2/data/EpgEntry.h
@@ -50,8 +50,8 @@ namespace enigma2
       unsigned int m_epgId;
       std::string m_serviceReference;
       int m_channelId;
-      time_t m_startTime;
-      time_t m_endTime;
+      time_t m_startTime = 0;
+      time_t m_endTime = 0;
       std::string m_startTimeW3CDateString;
     };
   } //namespace data


### PR DESCRIPTION
v7.1.3
- Fixed: Set default values for start and end time to avoid overflow crash on windows
