### PR TITLE
Autotimer timespan/offset support and Timeshift disk limit for native Enigma2 streams for devices with limited space

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,8 @@ Timeshifting allows you to pause live TV as well as move back and forward from y
     - `On Pause` - Timeshifting starts when a live stream is paused. E.g. you want to continue from where you were at after pausing.
     - `On Playback` - Timeshifting starts when a live stream is opened. E.g. You can go to any point in the stream since it was opened.
 * **Timeshift buffer path**: The path used to store the timeshift buffer. The default is the `addon_data/pvr.vuplus` folder in userdata.
+* **Enable timeshift disk limit**: For devices with limited disk space a limit in Gigabytes can be set whereby timeshift will be switched off and playback will return to the live stream. Note that for timeshift on playback it will not be possible to timeshift again until a stream is restarted once this limit is reached.
+* **Timeshift disk limit**: The disk space limit to use for the timeshift buffer in Gigabytes.
 * **Enable timeshift for IPTV streams**: Enable the timeshift feature for HTTP IPTV streams using `inputstream.ffmpegdirect`. Note that this feature only works `On playback` and will ignore the timeshift mode used for regular channel playback.
 * **Use FFMpeg http reconnect options if possible**: Note this can only apply to http/https streams that are processed by libavformat (e.g. M3u8/HLS).
 * **Use mpegts MIME type for unknown streams**: If the type of stream cannot be determined assume it's an MPEG TS stream.

--- a/README.md
+++ b/README.md
@@ -272,6 +272,8 @@ This category contains information and settings on/about the Enigma2 STB.
     - `Standby` - Send the standby command on exit
     - `Deep standby` - Send the deep standby command on exit. Note, the set-top box will not respond to Kodi after this command is sent.
     - `Wakeup, then standby` - Similar to standby but first sends a wakeup command. Can be useful if you want to ensure all streams have stopped. Note: if you use CEC this could cause your TV to wake.
+* **Global start padding**: This value reflects the backend setting `Margin before recording`. It will be applied to the start of all new regular timers created including those created from Autotimers. Note that if a padding/margin is set on an Autotimer it will be custom for that Autotimer and will override this value.
+* **Global end padding**: This value reflects the backend setting `Margin after recording`. It will be applied to the end of all new regular timers created including those created from Autotimers. Note that if a padding/margin is set on an Autotimer it will be custom for that Autotimer and will override this value.
 
 ### Advanced
 Within this tab more uncommon and advanced options can be configured.

--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="7.1.3"
+  version="7.2.0"
   name="Enigma2 Client"
   provider-name="Joerg Dembski and Ross Nicholson">
   <requires>
@@ -185,6 +185,18 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v7.2.0
+- Added: Support timespans for anyday auto timers
+- Fixed: Fix illegal index access when reading empty string from XML
+- Added: Redact URLs when logged
+- Added: Support custom start/end padding for Autotimers
+- Added: URL encode username and password
+- Fixed: Only set backend recording padding/margin if device settings have been loaded
+- Added: Help and README text for Global start/end recording padding backend settings
+- Update: Replace square brackets with bold text in addon settings help text
+- Added: Timeshift disk limit for native Enigma2 streams for devices with limited space
+- Fixed: Fix incorrect type for recordings size in bytes
+
 v7.1.3
 - Fixed: Set default values for start and end time to avoid overflow crash on windows
 

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,3 +1,15 @@
+v7.2.0
+- Added: Support timespans for anyday auto timers
+- Fixed: Fix illegal index access when reading empty string from XML
+- Added: Redact URLs when logged
+- Added: Support custom start/end padding for Autotimers
+- Added: URL encode username and password
+- Fixed: Only set backend recording padding/margin if device settings have been loaded
+- Added: Help and README text for Global start/end recording padding backend settings
+- Update: Replace square brackets with bold text in addon settings help text
+- Added: Timeshift disk limit for native Enigma2 streams for devices with limited space
+- Fixed: Fix incorrect type for recordings size in bytes
+
 v7.1.3
 - Fixed: Set default values for start and end time to avoid overflow crash on windows
 

--- a/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
@@ -1380,12 +1380,12 @@ msgstr ""
 
 #. help: Backend - globalstartpaddingstb
 msgctxt "#30764"
-msgid "globalstartpaddingstb"
+msgid "This value reflects the backend setting [B]Margin before recording[/B]. It will be applied to the start of all new regular timers created including those created from Autotimers. Note that if a padding/margin is set on an Autotimer it will be custom for that Autotimer and will override this value."
 msgstr ""
 
 #. help: Backend - globalendpaddingstb
 msgctxt "#30765"
-msgid "globalendpaddingstb"
+msgid "This value reflects the backend setting [B]]Margin after recording[/B]. It will be applied to the end of all new regular timers created including those created from Autotimers. Note that if a padding/margin is set on an Autotimer it will be custom for that Autotimer and will override this value."
 msgstr ""
 
 #. label: Backend - wakeonlanmac

--- a/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
@@ -780,7 +780,22 @@ msgctxt "#30152"
 msgid "Retrieve provider name for channels"
 msgstr ""
 
-#empty strings from id 30153 to 30409
+#. label: Timeshift - enabletimeshiftdisklimit
+msgctxt "#30153"
+msgid "Enable timeshift disk limit"
+msgstr ""
+
+#. label: Timeshift - timeshiftdisklimit
+msgctxt "#30154"
+msgid "Timeshift disk limit"
+msgstr ""
+
+#. format-label: Timeshift - timeshiftdisklimit
+msgctxt "#30155"
+msgid "{0:.1f} GiB"
+msgstr ""
+
+#empty strings from id 30156 to 30409
 
 #. ##############
 #. application #
@@ -1310,7 +1325,17 @@ msgctxt "#30726"
 msgid "Open settings dialog for inputstream.ffmpegdirect for modification of timeshift and other settings."
 msgstr ""
 
-#empty strings from id 30727 to 30739
+#. help: Timeshift - enabletimeshiftdisklimit
+msgctxt "#30727"
+msgid "For devices with limited disk space a limit in Gigabytes can be set whereby timeshift will be switched off and playback will return to the live stream. Note that for timeshift on playback it will not be possible to timeshift again until a stream is restarted once this limit is reached."
+msgstr ""
+
+#. help: Timeshift - timeshiftdisklimit
+msgctxt "#30728"
+msgid "The disk space limit to use for the timeshift buffer in Gigabytes."
+msgstr ""
+
+#empty strings from id 30729 to 30739
 
 #. help info - Advanced
 

--- a/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
@@ -1009,12 +1009,12 @@ msgstr ""
 
 #. help: General - updatemode
 msgctxt "#30626"
-msgid "The mode used when the update interval is reached. Note that if there is any timer change detected a recordings update will always occur regardless of the update mode. Choose from one of the following two modes: [Timers and Recordings] Update all timers and recordings; [Timers only] Only update the timers. If it's important to not spin up the HDD on your STB use this option. The HDD should then only spin up when a timer event occurs."
+msgid "The mode used when the update interval is reached. Note that if there is any timer change detected a recordings update will always occur regardless of the update mode. Choose from one of the following two modes: [B]Timers and Recordings[/B] Update all timers and recordings; [B]Timers only[/B] Only update the timers. If it's important to not spin up the HDD on your STB use this option. The HDD should then only spin up when a timer event occurs."
 msgstr ""
 
 #. help: General - channelandgroupupdatemode
 msgctxt "#30627"
-msgid "The mode used when the hour in the next settings is reached. Choose from one of the following three modes: [Disabled] Never check for channel and group changes; [Notify on UI and Log] Display a notice in the UI and log the fact that a change was detectetd]; [Reload Channels and Groups] Disconnect and reconnect with E2 device to reload channels only if a change is detected."
+msgid "The mode used when the hour in the next settings is reached. Choose from one of the following three modes: [B]Disabled[/B] Never check for channel and group changes; [B]Notify on UI and Log[/B] Display a notice in the UI and log the fact that a change was detectetd[/B]; [B]Reload Channels and Groups[/B] Disconnect and reconnect with E2 device to reload channels only if a change is detected."
 msgstr ""
 
 #. help: General - channelandgroupupdatehour
@@ -1043,12 +1043,12 @@ msgstr ""
 
 #. help: Channels - zap
 msgctxt "#30642"
-msgid "When using the addon with a single tuner box it may be necessary that the addon needs to be able to zap to another channel on the set-top box. If this option is enabled each channel switch in Kodi will also result in a channel switch on the set-top box. Please note that [allow channel switching] needs to be enabled in the webinterface on the set-top box."
+msgid "When using the addon with a single tuner box it may be necessary that the addon needs to be able to zap to another channel on the set-top box. If this option is enabled each channel switch in Kodi will also result in a channel switch on the set-top box. Please note that [B]allow channel switching[/B] needs to be enabled in the webinterface on the set-top box."
 msgstr ""
 
 #. help: Channels - tvgroupmode
 msgctxt "#30643"
-msgid "Choose from one of the following three modes: [All bouquets] Fetch all TV bouquets from the set-top box; [Some bouquets] Only fetch the bouquets specified in the next options; [Favourites group] Only fetch the system bouquet for TV favourites; [Custom groups] Fetch a set of bouquets from the Set-top box whose names are loaded from an XML file."
+msgid "Choose from one of the following three modes: [B]All bouquets[/B] Fetch all TV bouquets from the set-top box; [B]Some bouquets[/B] Only fetch the bouquets specified in the next options; [B]Favourites group[/B] Only fetch the system bouquet for TV favourites; [B]Custom groups[/B] Fetch a set of bouquets from the Set-top box whose names are loaded from an XML file."
 msgstr ""
 
 #. help: Channels - onetvgroup
@@ -1062,7 +1062,7 @@ msgstr ""
 
 #. help: Channels - tvfavouritesmode
 msgctxt "#30645"
-msgid "If the fetch mode is 'All bouquets' or 'Some bouquets' depending on your Enigma2 image you may need to explicitly fetch favourites if you require them. The options are: [Disabled] Don't explicitly fetch TV favourites; [As first bouquet] Explicitly fetch them as the first bouquet; [As last bouquet] Explicitly fetch them as the last bouquet."
+msgid "If the fetch mode is 'All bouquets' or 'Some bouquets' depending on your Enigma2 image you may need to explicitly fetch favourites if you require them. The options are: [B]Disabled[/B] Don't explicitly fetch TV favourites; [B]As first bouquet[/B] Explicitly fetch them as the first bouquet; [B]As last bouquet[/B] Explicitly fetch them as the last bouquet."
 msgstr ""
 
 #. help: Channels - excludelastscannedtv
@@ -1072,7 +1072,7 @@ msgstr ""
 
 #. help: Channels - radiogroupmode
 msgctxt "#30647"
-msgid "Choose from one of the following three modes: [All bouquets] Fetch all Radio bouquets from the set-top box]; [Some bouquets] Only fetch the bouquets specified in the next options; [Favourites group] Only fetch the system bouquet for Radio favourites; [Custom groups] Fetch a set of bouquets from the Set-top box whose names are loaded from an XML file."
+msgid "Choose from one of the following three modes: [B]All bouquets[/B] Fetch all Radio bouquets from the set-top box[/B]; [B]Some bouquets[/B] Only fetch the bouquets specified in the next options; [B]Favourites group[/B] Only fetch the system bouquet for Radio favourites; [B]Custom groups[/B] Fetch a set of bouquets from the Set-top box whose names are loaded from an XML file."
 msgstr ""
 
 #. help: Channels - oneradiogroup
@@ -1086,7 +1086,7 @@ msgstr ""
 
 #. help: Channels - radiofavouritesmode
 msgctxt "#30649"
-msgid "If the fetch mode is 'All bouquets' or 'Some bouquets' depending on your Enigma2 image you may need to explicitly fetch favourites if you require them. The options are: [Disabled] Don't explicitly fetch Radio favourites; [As first bouquet] Explicitly fetch them as the first bouquet; [As last bouquet] Explicitly fetch them as the last bouquet."
+msgid "If the fetch mode is 'All bouquets' or 'Some bouquets' depending on your Enigma2 image you may need to explicitly fetch favourites if you require them. The options are: [B]Disabled[/B] Don't explicitly fetch Radio favourites; [B]As first bouquet[/B] Explicitly fetch them as the first bouquet; [B]As last bouquet[/B] Explicitly fetch them as the last bouquet."
 msgstr ""
 
 #. help: Channels - excludelastscannedradio
@@ -1165,7 +1165,7 @@ msgstr ""
 
 #. help: EPG - logmissinggenremapping
 msgctxt "#30667"
-msgid "If you would like missing genre mappings to be logged so you can report them enable this option. Note: any genres found that don't have a mapping will still be extracted and sent to Kodi as strings. Currently genres are extracted by looking for text between square brackets, e.g. [TV Drama], or for major, minor genres using a dot (.) to separate [TV Drama. Soap Opera]"
+msgid "If you would like missing genre mappings to be logged so you can report them enable this option. Note: any genres found that don't have a mapping will still be extracted and sent to Kodi as strings. Currently genres are extracted by looking for text between square brackets, e.g. [B]TV Drama[/B], or for major, minor genres using a dot (.) to separate [B]TV Drama. Soap Opera[/B]"
 msgstr ""
 
 #. help: EPG - epgdelayperchannel
@@ -1194,7 +1194,7 @@ msgstr ""
 
 #. help: Recordings - sharerecordinglastplayed
 msgctxt "#30682"
-msgid "The options are: [Kodi instances] Only use the value in kodi and will not affect last played on the E2 device; [Kodi/E2 instances] Use the value across kodi and the E2 device so they stay in sync. Last played will be synced with the E2 device once every 5-10 minutes per recording if the PVR menus are in use. Note that only a single kodi instance is required to have this option enabled."
+msgid "The options are: [B]Kodi instances[/B] Only use the value in kodi and will not affect last played on the E2 device; [B]Kodi/E2 instances[/B] Use the value across kodi and the E2 device so they stay in sync. Last played will be synced with the E2 device once every 5-10 minutes per recording if the PVR menus are in use. Note that only a single kodi instance is required to have this option enabled."
 msgstr ""
 
 #. help: Recordings - recordingpath
@@ -1282,7 +1282,7 @@ msgstr ""
 
 #. help: Timeshift - enabletimeshift
 msgctxt "#30721"
-msgid "What timeshift option do you want: [Disabled] No timeshifting; [On Pause] Timeshifting starts when a live stream is paused. E.g. you want to continue from where you were at after pausing; [On Playback] Timeshifting starts when a live stream is opened. E.g. You can go to any point in the stream since it was opened."
+msgid "What timeshift option do you want: [B]Disabled[/B] No timeshifting; [B]On Pause[/B] Timeshifting starts when a live stream is paused. E.g. you want to continue from where you were at after pausing; [B]On Playback[/B] Timeshifting starts when a live stream is opened. E.g. You can go to any point in the stream since it was opened."
 msgstr ""
 
 #. help: Timeshift - timeshiftbufferpath
@@ -1326,7 +1326,7 @@ msgstr ""
 
 #. help: Advanced - powerstatemode
 msgctxt "#30742"
-msgid "If this option is set to a value other than `Disabled` then the addon will send a Powerstate command to the set-top box when Kodi will be closed (or the addon will be deactivated): [Disabled] No command sent when the addon exits; [Standby] Send the standby command on exit; [Deep standby] Send the deep standby command on exit. Note, the set-top box will not respond to Kodi after this command is sent; [Wakeup, then standby] Similar to standby but first sends a wakeup command. Can be useful if you want to ensure all streams have stopped. Note: if you use CEC this could cause your TV to wake."
+msgid "If this option is set to a value other than `Disabled` then the addon will send a Powerstate command to the set-top box when Kodi will be closed (or the addon will be deactivated): [B]Disabled[/B] No command sent when the addon exits; [B]Standby[/B] Send the standby command on exit; [B]Deep standby[/B] Send the deep standby command on exit. Note, the set-top box will not respond to Kodi after this command is sent; [B]Wakeup, then standby[/B] Similar to standby but first sends a wakeup command. Can be useful if you want to ensure all streams have stopped. Note: if you use CEC this could cause your TV to wake."
 msgstr ""
 
 #. help: Advanced - readtimeout
@@ -1385,7 +1385,7 @@ msgstr ""
 
 #. help: Backend - globalendpaddingstb
 msgctxt "#30765"
-msgid "This value reflects the backend setting [B]]Margin after recording[/B]. It will be applied to the end of all new regular timers created including those created from Autotimers. Note that if a padding/margin is set on an Autotimer it will be custom for that Autotimer and will override this value."
+msgid "This value reflects the backend setting [B]Margin after recording[/B]. It will be applied to the end of all new regular timers created including those created from Autotimers. Note that if a padding/margin is set on an Autotimer it will be custom for that Autotimer and will override this value."
 msgstr ""
 
 #. label: Backend - wakeonlanmac

--- a/pvr.vuplus/resources/settings.xml
+++ b/pvr.vuplus/resources/settings.xml
@@ -802,6 +802,26 @@
             <heading>657</heading>
           </control>
         </setting>
+        <setting id="enabletimeshiftdisklimit" type="boolean" label="30153" help="30727">
+          <level>0</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="timeshiftdisklimit" type="number" label="30154" help="30628">
+          <level>0</level>
+          <default>4.0</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>0.1</step>
+            <maximum>128</maximum>
+          </constraints>
+          <dependencies>
+            <dependency type="visible" setting="enabletimeshiftdisklimit" operator="is">true</dependency>
+          </dependencies>
+          <control type="slider" format="number">
+            <formatlabel>30155</formatlabel>
+          </control>
+        </setting>
       </group>
       <group id="2" label="30147">
         <setting id="timeshiftEnabledIptv" type="boolean" label="30148" help="30723">

--- a/src/Enigma2.cpp
+++ b/src/Enigma2.cpp
@@ -125,7 +125,6 @@ void Enigma2::ConnectionLost()
   m_isConnected = false;
 }
 
-
 void Enigma2::ConnectionEstablished()
 {
   std::lock_guard<std::mutex> lock(m_mutex);

--- a/src/Enigma2.cpp
+++ b/src/Enigma2.cpp
@@ -145,14 +145,6 @@ void Enigma2::ConnectionEstablished()
   else
     Logger::Log(LEVEL_INFO, "%s Use HTTPS: 'true'", __func__);
 
-  if ((m_settings.GetUsername().length() > 0) && (m_settings.GetPassword().length() > 0))
-  {
-    if ((m_settings.GetUsername().find("@") != std::string::npos) || (m_settings.GetPassword().find("@") != std::string::npos))
-    {
-      Logger::Log(LEVEL_ERROR, "%s - You cannot use the '@' character in either the username or the password with this addon. Please change your configuration!", __func__);
-      return;
-    }
-  }
   m_isConnected = m_admin.Initialise();
 
   if (!m_isConnected)

--- a/src/Enigma2.cpp
+++ b/src/Enigma2.cpp
@@ -607,18 +607,23 @@ bool Enigma2::OpenLiveStream(const kodi::addon::PVRChannel& channelinfo)
     kodi::QueueNotification(QUEUE_ERROR, "", kodi::GetLocalizedString(30514));
 
   const std::string streamURL = GetLiveStreamURL(channelinfo);
-  m_streamReader = new StreamReader(streamURL, m_settings.GetReadTimeoutSecs());
-  if (m_settings.GetTimeshift() == Timeshift::ON_PLAYBACK)
-    m_streamReader = new TimeshiftBuffer(m_streamReader, m_settings.GetTimeshiftBufferPath(), m_settings.GetReadTimeoutSecs());
+  m_activeStreamReader = new StreamReader(streamURL, m_settings.GetReadTimeoutSecs());
+  if (m_settings.GetTimeshift() == Timeshift::ON_PLAYBACK && m_settings.IsTimeshiftBufferPathValid())
+  {
+    m_timeshiftInternalStreamReader = m_activeStreamReader;
+    m_activeStreamReader = new TimeshiftBuffer(m_activeStreamReader);
+  }
 
-  return m_streamReader->Start();
+  return m_activeStreamReader->Start();
 }
 
 void Enigma2::CloseLiveStream()
 {
   std::lock_guard<std::mutex> lock(m_mutex);
   m_currentChannel = -1;
-  SafeDelete(m_streamReader);
+  SafeDelete(m_activeStreamReader);
+  if (m_timeshiftInternalStreamReader)
+    SafeDelete(m_timeshiftInternalStreamReader);
 }
 
 const std::string Enigma2::GetLiveStreamURL(const kodi::addon::PVRChannel& channelinfo)
@@ -994,7 +999,7 @@ PVR_ERROR Enigma2::GetStreamReadChunkSize(int& chunksize)
 
 bool Enigma2::IsRealTimeStream()
 {
-  return (m_streamReader) ? m_streamReader->IsRealTime() : false;
+  return (m_activeStreamReader) ? m_activeStreamReader->IsRealTime() : false;
 }
 
 bool Enigma2::CanPauseStream()
@@ -1002,8 +1007,8 @@ bool Enigma2::CanPauseStream()
   if (!IsConnected())
     return false;
 
-  if (m_settings.GetTimeshift() != Timeshift::OFF && m_streamReader)
-    return (m_streamReader->IsTimeshifting() || m_settings.IsTimeshiftBufferPathValid());
+  if (m_settings.GetTimeshift() != Timeshift::OFF && m_activeStreamReader && m_settings.IsTimeshiftBufferPathValid())
+    return (m_settings.GetTimeshift() == Timeshift::ON_PAUSE || m_paused || m_activeStreamReader->HasTimeshiftCapacity());
 
   return false;
 }
@@ -1018,28 +1023,40 @@ bool Enigma2::CanSeekStream()
 
 int Enigma2::ReadLiveStream(unsigned char* buffer, unsigned int size)
 {
-  return (m_streamReader) ? m_streamReader->ReadData(buffer, size) : 0;
+  return (m_activeStreamReader) ? m_activeStreamReader->ReadData(buffer, size) : 0;
 }
 
 int64_t Enigma2::SeekLiveStream(int64_t position, int whence)
 {
-  return (m_streamReader) ? m_streamReader->Seek(position, whence) : -1;
+  return (m_activeStreamReader) ? m_activeStreamReader->Seek(position, whence) : -1;
 }
 
 int64_t Enigma2::LengthLiveStream()
 {
-  return (m_streamReader) ? m_streamReader->Length() : -1;
+  return (m_activeStreamReader) ? m_activeStreamReader->Length() : -1;
 }
 
 PVR_ERROR Enigma2::GetStreamTimes(kodi::addon::PVRStreamTimes& times)
 {
-  if (m_streamReader)
+  if (m_activeStreamReader)
   {
-    times.SetStartTime(m_streamReader->TimeStart());
+    times.SetStartTime(m_activeStreamReader->TimeStart());
     times.SetPTSStart(0);
     times.SetPTSBegin(0);
-    times.SetPTSEnd((!m_streamReader->IsTimeshifting()) ? 0
-      : (m_streamReader->TimeEnd() - m_streamReader->TimeStart()) * STREAM_TIME_BASE);
+    times.SetPTSEnd((!m_activeStreamReader->IsTimeshifting()) ? 0
+      : (m_activeStreamReader->TimeEnd() - m_activeStreamReader->TimeStart()) * STREAM_TIME_BASE);
+
+    if (m_activeStreamReader->IsTimeshifting())
+    {
+      if (!m_activeStreamReader->HasTimeshiftCapacity())
+      {
+        Logger::Log(LEVEL_INFO, "%s Timeshift disk limit of %.1f GiB exceeded, switching to live stream without timehift", __func__, m_settings.GetTimeshiftDiskLimitGB());
+        IStreamReader* timeshiftedReader = m_activeStreamReader;
+        m_activeStreamReader = m_timeshiftInternalStreamReader;
+        m_timeshiftInternalStreamReader = nullptr;
+        SafeDelete(timeshiftedReader);
+      }
+    }
 
     return PVR_ERROR_NO_ERROR;
   }
@@ -1063,12 +1080,15 @@ void Enigma2::PauseStream(bool paused)
 
   /* start timeshift on pause */
   if (paused && m_settings.GetTimeshift() == Timeshift::ON_PAUSE &&
-      m_streamReader && !m_streamReader->IsTimeshifting() &&
+      m_activeStreamReader && !m_activeStreamReader->IsTimeshifting() &&
       m_settings.IsTimeshiftBufferPathValid())
   {
-    m_streamReader = new TimeshiftBuffer(m_streamReader, m_settings.GetTimeshiftBufferPath(), m_settings.GetReadTimeoutSecs());
-    m_streamReader->Start();
+    m_timeshiftInternalStreamReader = m_activeStreamReader;
+    m_activeStreamReader = new TimeshiftBuffer(m_activeStreamReader);
+    m_activeStreamReader->Start();
   }
+
+  m_paused = paused;
 }
 
 void Enigma2::CloseRecordedStream()

--- a/src/Enigma2.h
+++ b/src/Enigma2.h
@@ -154,10 +154,13 @@ private:
   enigma2::utilities::SignalStatus m_signalStatus;
   enigma2::ConnectionManager* connectionManager;
 
-  enigma2::IStreamReader* m_streamReader = nullptr;
+  enigma2::IStreamReader* m_activeStreamReader = nullptr;
+  enigma2::IStreamReader* m_timeshiftInternalStreamReader = nullptr;
   enigma2::RecordingReader* m_recordingReader = nullptr;
 
   std::atomic<bool> m_running = {false};
   std::thread m_thread;
   mutable std::mutex m_mutex;
+
+  std::atomic<bool> m_paused = {false};
 };

--- a/src/enigma2/IStreamReader.h
+++ b/src/enigma2/IStreamReader.h
@@ -27,5 +27,6 @@ namespace enigma2
     virtual std::time_t TimeEnd() = 0;
     virtual bool IsRealTime() = 0;
     virtual bool IsTimeshifting() = 0;
+    virtual bool HasTimeshiftCapacity() = 0;
   };
 } // namespace enigma2

--- a/src/enigma2/Recordings.cpp
+++ b/src/enigma2/Recordings.cpp
@@ -409,7 +409,7 @@ PVR_ERROR Recordings::GetRecordingSize(const kodi::addon::PVRRecording& recordin
   auto recordingEntry = GetRecording(recording.GetRecordingId());
   UpdateRecordingSizeFromMovieDetails(recordingEntry);
 
-  Logger::Log(LEVEL_DEBUG, "%s In progress recording size is %lld for sRef: %s", __func__, recordingEntry.GetSizeInBytes(), recording.GetRecordingId().c_str());
+  Logger::Log(LEVEL_DEBUG, "%s In progress recording size is %lld for sRef: %s", __func__, static_cast<long long>(recordingEntry.GetSizeInBytes()), recording.GetRecordingId().c_str());
 
   sizeInBytes = recordingEntry.GetSizeInBytes();
 
@@ -432,8 +432,6 @@ bool Recordings::UpdateRecordingSizeFromMovieDetails(RecordingEntry& recordingEn
 
     if (!jsonDoc["movie"].empty())
     {
-      uint64_t size;
-
       for (const auto& element : jsonDoc["movie"].items())
       {
         if (element.key() == "filesize")

--- a/src/enigma2/Settings.cpp
+++ b/src/enigma2/Settings.cpp
@@ -151,6 +151,8 @@ void Settings::ReadFromAddon()
   //Timeshift
   m_timeshift = kodi::GetSettingEnum<Timeshift>("enabletimeshift", Timeshift::OFF);
   m_timeshiftBufferPath = kodi::GetSettingString("timeshiftbufferpath", ADDON_DATA_BASE_DIR);
+  m_enableTimeshiftDiskLimit = kodi::GetSettingBoolean("enabletimeshiftdisklimit", false);
+  m_timeshiftDiskLimitGB = kodi::GetSettingFloat("timeshiftdisklimit", 4.0f);
   m_timeshiftEnabledIptv = kodi::GetSettingBoolean("timeshiftEnabledIptv", true);
   m_useFFmpegReconnect = kodi::GetSettingBoolean("useFFmpegReconnect", true);
   m_useMpegtsForUnknownStreams = kodi::GetSettingBoolean("useMpegtsForUnknownStreams", true);
@@ -328,6 +330,10 @@ ADDON_STATUS Settings::SetValue(const std::string& settingName, const kodi::CSet
     return SetEnumSetting<Timeshift, ADDON_STATUS>(settingName, settingValue, m_timeshift, ADDON_STATUS_NEED_RESTART, ADDON_STATUS_OK);
   else if (settingName == "timeshiftbufferpath")
     return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_timeshiftBufferPath, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  else if (settingName == "enabletimeshiftdisklimit")
+    return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_enableTimeshiftDiskLimit, ADDON_STATUS_OK, ADDON_STATUS_OK);
+  else if (settingName == "timeshiftdisklimit")
+    return SetSetting<float, ADDON_STATUS>(settingName, settingValue, m_timeshiftDiskLimitGB, ADDON_STATUS_OK, ADDON_STATUS_OK);
   else if (settingName == "timeshiftEnabledIptv")
     return SetSetting<bool, ADDON_STATUS>(settingName, settingValue, m_timeshiftEnabledIptv, ADDON_STATUS_OK, ADDON_STATUS_OK);
   else if (settingName == "useFFmpegReconnect")

--- a/src/enigma2/Settings.cpp
+++ b/src/enigma2/Settings.cpp
@@ -9,6 +9,7 @@
 #include "Settings.h"
 
 #include "utilities/FileUtils.h"
+#include "utilities/WebUtils.h"
 #include "utilities/XMLUtils.h"
 
 #include <kodi/tools/StringUtils.h>
@@ -171,7 +172,7 @@ void Settings::ReadFromAddon()
   m_connectionURL.clear();
   // simply add user@pass in front of the URL if username/password is set
   if ((m_username.length() > 0) && (m_password.length() > 0))
-    m_connectionURL = StringUtils::Format("%s:%s@", m_username.c_str(), m_password.c_str());
+    m_connectionURL = StringUtils::Format("%s:%s@", WebUtils::URLEncodeInline(m_username).c_str(), WebUtils::URLEncodeInline(m_password).c_str());
   if (!m_useSecureHTTP)
     m_connectionURL = StringUtils::Format("http://%s%s:%u/", m_connectionURL.c_str(), m_hostname.c_str(), m_portWeb);
   else

--- a/src/enigma2/Settings.cpp
+++ b/src/enigma2/Settings.cpp
@@ -339,12 +339,12 @@ ADDON_STATUS Settings::SetValue(const std::string& settingName, const kodi::CSet
     return SetStringSetting<ADDON_STATUS>(settingName, settingValue, m_wakeOnLanMac, ADDON_STATUS_OK, ADDON_STATUS_OK);
   else if (settingName == "globalstartpaddingstb")
   {
-    if (m_admin && SetSetting<int, bool>(settingName, settingValue, m_globalStartPaddingStb, true, false))
+    if (m_admin && m_deviceSettingsSet && SetSetting<int, bool>(settingName, settingValue, m_globalStartPaddingStb, true, false))
       m_admin->SendGlobalRecordingStartMarginSetting(m_globalStartPaddingStb);
   }
   else if (settingName == "globalendpaddingstb")
   {
-    if (m_admin && SetSetting<int, bool>(settingName, settingValue, m_globalEndPaddingStb, true, false))
+    if (m_admin && m_deviceSettingsSet && SetSetting<int, bool>(settingName, settingValue, m_globalEndPaddingStb, true, false))
       m_admin->SendGlobalRecordingEndMarginSetting(m_globalEndPaddingStb);
   }
   //Advanced

--- a/src/enigma2/Settings.h
+++ b/src/enigma2/Settings.h
@@ -195,6 +195,9 @@ namespace enigma2
     const Timeshift& GetTimeshift() const { return m_timeshift; }
     const std::string& GetTimeshiftBufferPath() const { return m_timeshiftBufferPath; }
     bool IsTimeshiftBufferPathValid() const;
+    bool EnableTimeshiftDiskLimit() const { return m_enableTimeshiftDiskLimit; };
+    float GetTimeshiftDiskLimitGB() const { return m_timeshiftDiskLimitGB; };
+    uint64_t GetTimeshiftDiskLimitBytes() const { return static_cast<uint64_t>(1024LL * 1024LL * 1024LL * m_timeshiftDiskLimitGB); }
     bool IsTimeshiftEnabledIptv() const { return m_timeshiftEnabledIptv; }
     bool UseFFmpegReconnect() const { return m_useFFmpegReconnect; }
     bool UseMpegtsForUnknownStreams() const { return m_useMpegtsForUnknownStreams; }
@@ -404,6 +407,8 @@ namespace enigma2
     //Timeshift
     Timeshift m_timeshift = Timeshift::OFF;
     std::string m_timeshiftBufferPath = ADDON_DATA_BASE_DIR;
+    bool m_enableTimeshiftDiskLimit = false;
+    float m_timeshiftDiskLimitGB = 0.0f;
     bool m_timeshiftEnabledIptv = true;
     bool m_useFFmpegReconnect = true;
     bool m_useMpegtsForUnknownStreams = true;

--- a/src/enigma2/StreamReader.cpp
+++ b/src/enigma2/StreamReader.cpp
@@ -71,3 +71,8 @@ bool StreamReader::IsTimeshifting()
 {
   return false;
 }
+
+bool StreamReader::HasTimeshiftCapacity()
+{
+  return false;
+}

--- a/src/enigma2/StreamReader.h
+++ b/src/enigma2/StreamReader.h
@@ -31,6 +31,7 @@ namespace enigma2
     std::time_t TimeEnd() override;
     bool IsRealTime() override;
     bool IsTimeshifting() override;
+    bool HasTimeshiftCapacity() override;
 
   private:
     kodi::vfs::CFile m_streamHandle;

--- a/src/enigma2/Timers.cpp
+++ b/src/enigma2/Timers.cpp
@@ -369,6 +369,7 @@ void Timers::GetTimerTypes(std::vector<kodi::addon::PVRTimerType>& types) const
       PVR_TIMER_TYPE_SUPPORTS_ANY_CHANNEL        |
       PVR_TIMER_TYPE_SUPPORTS_START_TIME         |
       PVR_TIMER_TYPE_SUPPORTS_END_TIME           |
+      PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN   |
       PVR_TIMER_TYPE_SUPPORTS_START_ANYTIME      |
       PVR_TIMER_TYPE_SUPPORTS_END_ANYTIME        |
       PVR_TIMER_TYPE_SUPPORTS_WEEKDAYS           |
@@ -597,6 +598,14 @@ PVR_ERROR Timers::AddAutoTimer(const kodi::addon::PVRTimer& timer)
     strTmp += StringUtils::Format("&timespanTo=%02d:%02d", timeinfo.tm_hour, timeinfo.tm_min);
   }
 
+  if (timer.GetMarginStart() != 0 || timer.GetMarginEnd() != 0)
+  {
+    if (timer.GetMarginStart() == timer.GetMarginEnd())
+      strTmp += StringUtils::Format("&offset=%d", timer.GetMarginStart());
+    else
+      strTmp += StringUtils::Format("&offset=%d,%d", timer.GetMarginStart(), timer.GetMarginEnd());
+  }
+
   strTmp += StringUtils::Format("&encoding=%s", WebUtils::URLEncodeInline(AUTOTIMER_ENCODING).c_str());
   strTmp += StringUtils::Format("&searchCase=%s", WebUtils::URLEncodeInline(AUTOTIMER_SEARCH_CASE_SENSITIVE).c_str());
   if (timer.GetFullTextEpgSearch())
@@ -821,6 +830,18 @@ PVR_ERROR Timers::UpdateAutoTimer(const kodi::addon::PVRTimer& timer)
       time_t endTime = timer.GetEndTime();
       std::tm timeinfo = *std::localtime(&endTime);
       strTmp += StringUtils::Format("&timespanTo=%02d:%02d", timeinfo.tm_hour, timeinfo.tm_min);
+    }
+
+    if (timer.GetMarginStart() == 0 && timer.GetMarginEnd() == 0)
+    {
+      strTmp += "&offset=";
+    }
+    else
+    {
+      if (timer.GetMarginStart() == timer.GetMarginEnd())
+        strTmp += StringUtils::Format("&offset=%d", timer.GetMarginStart());
+      else
+        strTmp += StringUtils::Format("&offset=%d,%d", timer.GetMarginStart(), timer.GetMarginEnd());
     }
 
     strTmp += StringUtils::Format("&encoding=%s", WebUtils::URLEncodeInline(AUTOTIMER_ENCODING).c_str());

--- a/src/enigma2/TimeshiftBuffer.h
+++ b/src/enigma2/TimeshiftBuffer.h
@@ -22,7 +22,7 @@ namespace enigma2
   class ATTRIBUTE_HIDDEN TimeshiftBuffer : public IStreamReader
   {
   public:
-    TimeshiftBuffer(IStreamReader* strReader, const std::string& m_timeshiftBufferPath, const unsigned int m_readTimeoutX);
+    TimeshiftBuffer(IStreamReader* strReader);
     ~TimeshiftBuffer();
 
     bool Start() override;
@@ -34,6 +34,7 @@ namespace enigma2
     std::time_t TimeEnd() override;
     bool IsRealTime() override;
     bool IsTimeshifting() override;
+    bool HasTimeshiftCapacity() override;
 
   private:
     void DoReadWrite();
@@ -49,6 +50,7 @@ namespace enigma2
     int m_readTimeout;
     std::time_t m_start = 0;
     std::atomic<uint64_t> m_writePos = {0};
+    uint64_t m_timeshiftBufferByteLimit = 0LL;
 
     std::atomic<bool> m_running = {false};
     std::thread m_inputThread;

--- a/src/enigma2/data/AutoTimer.cpp
+++ b/src/enigma2/data/AutoTimer.cpp
@@ -33,6 +33,8 @@ bool AutoTimer::operator==(const AutoTimer& right) const
   isEqual &= (m_endTime == right.m_endTime);
   isEqual &= (m_channelId == right.m_channelId);
   isEqual &= (m_weekdays == right.m_weekdays);
+  isEqual &= (m_paddingStartMins == right.m_paddingStartMins);
+  isEqual &= (m_paddingEndMins == right.m_paddingEndMins);
 
   isEqual &= (m_searchPhrase == right.m_searchPhrase);
   isEqual &= (m_searchType == right.m_searchType);
@@ -80,8 +82,8 @@ void AutoTimer::UpdateTo(kodi::addon::PVRTimer& left) const
   left.SetLifetime(0); // unused
   left.SetFirstDay(0); // unused
   left.SetWeekdays(m_weekdays);
-  left.SetMarginStart(0); // unused
-  left.SetMarginEnd(0); // unused
+  left.SetMarginStart(m_paddingStartMins);
+  left.SetMarginEnd(m_paddingEndMins);
   left.SetGenreType(0); // unused
   left.SetGenreSubType(0); // unused
   left.SetClientIndex(m_clientIndex);
@@ -153,6 +155,21 @@ bool AutoTimer::UpdateFrom(TiXmlElement* autoTimerNode, Channels& channels)
 
   if (autoTimerNode->QueryStringAttribute("searchCase", &strTmp) == TIXML_SUCCESS)
     m_searchCase = strTmp;
+
+  if (autoTimerNode->QueryStringAttribute("offset", &strTmp) == TIXML_SUCCESS)
+  {
+    size_t found = strTmp.find(",");
+    if (found != std::string::npos)
+    {
+      m_paddingStartMins = std::atoi(strTmp.substr(0, found).c_str());
+      m_paddingEndMins = std::atoi(strTmp.substr(found + 1).c_str());
+    }
+    else
+    {
+      m_paddingStartMins = std::atoi(strTmp.c_str());
+      m_paddingEndMins = m_paddingStartMins;
+    }
+  }
 
   TiXmlElement* serviceNode = autoTimerNode->FirstChildElement("e2service");
 

--- a/src/enigma2/data/AutoTimer.cpp
+++ b/src/enigma2/data/AutoTimer.cpp
@@ -216,12 +216,24 @@ bool AutoTimer::UpdateFrom(TiXmlElement* autoTimerNode, Channels& channels)
     }
   }
 
-  if (m_weekdays != PVR_WEEKDAY_NONE)
+  if (m_weekdays == PVR_WEEKDAY_NONE)
+  {
+    for (int i = 0; i < DAYS_IN_WEEK; i++)
+    {
+      m_weekdays = m_weekdays |= (1 << i);
+    }
+    m_startAnyTime = true;
+    m_endAnyTime = true;
+  }
+
+  m_startTime = 0;
+  m_endTime = 0;
+
+  if (!from.empty() && !to.empty())
   {
     std::time_t t = std::time(nullptr);
     std::tm timeinfo = *std::localtime(&t);
     timeinfo.tm_sec = 0;
-    m_startTime = 0;
     if (!from.empty())
     {
       ParseTime(from, timeinfo);
@@ -230,19 +242,17 @@ bool AutoTimer::UpdateFrom(TiXmlElement* autoTimerNode, Channels& channels)
 
     timeinfo = *std::localtime(&t);
     timeinfo.tm_sec = 0;
-    m_endTime = 0;
     if (!to.empty())
     {
       ParseTime(to, timeinfo);
       m_endTime = std::mktime(&timeinfo);
     }
+
+    m_startAnyTime = false;
+    m_endAnyTime = false;
   }
   else
   {
-    for (int i = 0; i < DAYS_IN_WEEK; i++)
-    {
-      m_weekdays = m_weekdays |= (1 << i);
-    }
     m_startAnyTime = true;
     m_endAnyTime = true;
   }

--- a/src/enigma2/data/RecordingEntry.h
+++ b/src/enigma2/data/RecordingEntry.h
@@ -80,8 +80,8 @@ namespace enigma2
       const std::string& GetStartTimeW3CDate() const { return m_startTimeW3CDateString; }
       void SetStartTimeW3CDate(const std::string& value) { m_startTimeW3CDateString = value; }
 
-      int GetSizeInBytes() const { return m_sizeInBytes; }
-      void SetSizeInBytes(int value) { m_sizeInBytes = value; }
+      int64_t GetSizeInBytes() const { return m_sizeInBytes; }
+      void SetSizeInBytes(int64_t value) { m_sizeInBytes = value; }
 
       bool UpdateFrom(TiXmlElement* recordingNode, const std::string& directory, bool deleted, enigma2::Channels& channels);
       void UpdateTo(kodi::addon::PVRRecording& left, Channels& channels, bool isInRecordingFolder);

--- a/src/enigma2/utilities/CurlFile.cpp
+++ b/src/enigma2/utilities/CurlFile.cpp
@@ -10,6 +10,7 @@
 
 #include "../Settings.h"
 #include "Logger.h"
+#include "WebUtils.h"
 
 #include <cstdarg>
 
@@ -35,7 +36,7 @@ bool CurlFile::Post(const std::string& strURL, std::string& strResult)
   kodi::vfs::CFile fileHandle;
   if (!fileHandle.CURLCreate(strURL))
   {
-    Logger::Log(LEVEL_ERROR, "%s Unable to create curl handle for %s", __func__, strURL.c_str());
+    Logger::Log(LEVEL_ERROR, "%s Unable to create curl handle for %s", __func__, WebUtils::RedactUrl(strURL).c_str());
     return false;
   }
 
@@ -43,7 +44,7 @@ bool CurlFile::Post(const std::string& strURL, std::string& strResult)
 
   if (!fileHandle.CURLOpen(ADDON_READ_NO_CACHE))
   {
-    Logger::Log(LEVEL_ERROR, "%s Unable to open url: %s", __func__, strURL.c_str());
+    Logger::Log(LEVEL_ERROR, "%s Unable to open url: %s", __func__, WebUtils::RedactUrl(strURL).c_str());
     return false;
   }
 
@@ -62,7 +63,7 @@ bool CurlFile::Check(const std::string& strURL)
   kodi::vfs::CFile fileHandle;
   if (!fileHandle.CURLCreate(strURL))
   {
-    Logger::Log(LEVEL_ERROR, "%s Unable to create curl handle for %s", __func__, strURL.c_str());
+    Logger::Log(LEVEL_ERROR, "%s Unable to create curl handle for %s", __func__, WebUtils::RedactUrl(strURL).c_str());
     return false;
   }
 
@@ -71,7 +72,7 @@ bool CurlFile::Check(const std::string& strURL)
 
   if (!fileHandle.CURLOpen(ADDON_READ_NO_CACHE))
   {
-    Logger::Log(LEVEL_TRACE, "%s Unable to open url: %s", __func__, strURL.c_str());
+    Logger::Log(LEVEL_TRACE, "%s Unable to open url: %s", __func__, WebUtils::RedactUrl(strURL).c_str());
     return false;
   }
 

--- a/src/enigma2/utilities/WebUtils.cpp
+++ b/src/enigma2/utilities/WebUtils.cpp
@@ -113,7 +113,7 @@ std::string WebUtils::GetHttpXML(const std::string& url)
 
   // If there is no newline add it as it not being there will cause a parse error
   // TODO: Remove once bug is fixed in Open WebIf
-  if (strTmp.back() != '\n')
+  if (!strTmp.empty() && strTmp.back() != '\n')
     strTmp += "\n";
 
   return strTmp;
@@ -134,7 +134,7 @@ std::string WebUtils::PostHttpJson(const std::string& url)
 
   // If there is no newline add it as it not being there will cause a parse error
   // TODO: Remove once bug is fixed in Open WebIf
-  if (strTmp.back() != '\n')
+  if (!strTmp.empty() && strTmp.back() != '\n')
     strTmp += "\n";
 
   Logger::Log(LEVEL_INFO, "%s Got result. Length: %u", __func__, strTmp.length());

--- a/src/enigma2/utilities/WebUtils.cpp
+++ b/src/enigma2/utilities/WebUtils.cpp
@@ -73,14 +73,29 @@ std::string WebUtils::URLEncodeInline(const std::string& sSrc)
   return sResult;
 }
 
+std::string WebUtils::RedactUrl(const std::string& url)
+{
+  std::string redactedUrl = url;
+  static const std::regex regex("^(http:|https:)//[^@/]+:[^@/]+@.*$");
+  if (std::regex_match(url, regex))
+  {
+    std::string protocol = url.substr(0, url.find_first_of(":"));
+    std::string fullPrefix = url.substr(url.find_first_of("@") + 1);
+
+    redactedUrl = protocol + "://USERNAME:PASSWORD@" + fullPrefix;
+  }
+
+  return redactedUrl;
+}
+
 bool WebUtils::CheckHttp(const std::string& url)
 {
-  Logger::Log(LEVEL_TRACE, "%s Check webAPI with URL: '%s'", __func__, url.c_str());
+  Logger::Log(LEVEL_TRACE, "%s Check webAPI with URL: '%s'", __func__, RedactUrl(url).c_str());
 
   CurlFile http;
   if (!http.Check(url))
   {
-    Logger::Log(LEVEL_TRACE, "%s - Could not open webAPI.", __func__);
+    Logger::Log(LEVEL_DEBUG, "%s - Could not open webAPI.", __func__);
     return false;
   }
 
@@ -91,7 +106,7 @@ bool WebUtils::CheckHttp(const std::string& url)
 
 std::string WebUtils::GetHttp(const std::string& url)
 {
-  Logger::Log(LEVEL_DEBUG, "%s Open webAPI with URL: '%s'", __func__, url.c_str());
+  Logger::Log(LEVEL_DEBUG, "%s Open webAPI with URL: '%s'", __func__, RedactUrl(url).c_str());
 
   std::string strTmp;
 
@@ -121,7 +136,7 @@ std::string WebUtils::GetHttpXML(const std::string& url)
 
 std::string WebUtils::PostHttpJson(const std::string& url)
 {
-  Logger::Log(LEVEL_DEBUG, "%s Open webAPI with URL: '%s'", __func__, url.c_str());
+  Logger::Log(LEVEL_DEBUG, "%s Open webAPI with URL: '%s'", __func__, RedactUrl(url).c_str());
 
   std::string strTmp;
 
@@ -137,7 +152,7 @@ std::string WebUtils::PostHttpJson(const std::string& url)
   if (!strTmp.empty() && strTmp.back() != '\n')
     strTmp += "\n";
 
-  Logger::Log(LEVEL_INFO, "%s Got result. Length: %u", __func__, strTmp.length());
+  Logger::Log(LEVEL_DEBUG, "%s Got result. Length: %u", __func__, strTmp.length());
 
   return strTmp;
 }

--- a/src/enigma2/utilities/WebUtils.h
+++ b/src/enigma2/utilities/WebUtils.h
@@ -32,6 +32,7 @@ namespace enigma2
       static const std::string UrlEncode(const std::string& value);
       static std::string ReadFileContentsStartOnly(const std::string& url, int* httpCode);
       static bool IsHttpUrl(const std::string& url);
+      static std::string RedactUrl(const std::string& url);
     };
   } // namespace utilities
 } // namespace enigma2


### PR DESCRIPTION
v7.2.0
- Added: Support timespans for anyday auto timers
- Fixed: Fix illegal index access when reading empty string from XML
- Added: Redact URLs when logged
- Added: Support custom start/end padding for Autotimers
- Added: URL encode username and password
- Fixed: Only set backend recording padding/margin if device settings have been loaded
- Added: Help and README text for Global start/end recording padding backend settings
- Update: Replace square brackets with bold text in addon settings help text
- Added: Timeshift disk limit for native Enigma2 streams for devices with limited space
- Fixed: Fix incorrect type for recordings size in bytes