### PR TITLE
PVR API 7.1.0 - allow both epg max past and future days

### DIFF
--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="7.2.0"
+  version="7.3.0"
   name="Enigma2 Client"
   provider-name="Joerg Dembski and Ross Nicholson">
   <requires>
@@ -185,6 +185,11 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v7.3.0
+- Update: PVR API 7.1.0
+- Added: allow both epg max past and future days
+- Fixed: Default of 2 hours when a timer is created with an invalid end time
+
 v7.2.0
 - Added: Support timespans for anyday auto timers
 - Fixed: Fix illegal index access when reading empty string from XML

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,3 +1,8 @@
+v7.3.0
+- Update: PVR API 7.1.0
+- Added: allow both epg max past and future days
+- Fixed: Default of 2 hours when a timer is created with an invalid end time
+
 v7.2.0
 - Added: Support timespans for anyday auto timers
 - Fixed: Fix illegal index access when reading empty string from XML

--- a/src/Enigma2.cpp
+++ b/src/Enigma2.cpp
@@ -43,7 +43,8 @@ template<typename T> void SafeDelete(T*& p)
 
 Enigma2::Enigma2(KODI_HANDLE instance, const std::string& version)
   : enigma2::IConnectionListener(instance, version),
-    m_epgMaxDays(EpgMaxDays())
+    m_epgMaxPastDays(EpgMaxPastDays()),
+    m_epgMaxFutureDays(EpgMaxFutureDays())
 {
   m_timers.AddTimerChangeWatcher(&m_dueRecordingUpdate);
 
@@ -563,12 +564,21 @@ PVR_ERROR Enigma2::GetEPGForChannel(int channelUid, time_t start, time_t end, ko
   return m_epg.GetEPGForChannel(myChannel->GetServiceReference(), start, end, results);
 }
 
-PVR_ERROR Enigma2::SetEPGTimeFrame(int epgMaxDays)
+PVR_ERROR Enigma2::SetEPGMaxPastDays(int epgMaxPastDays)
 {
   if (!IsConnected())
     return PVR_ERROR_SERVER_ERROR;
 
-  m_epg.SetEPGTimeFrame(epgMaxDays);
+  m_epg.SetEPGMaxPastDays(epgMaxPastDays);
+  return PVR_ERROR_NO_ERROR;
+}
+
+PVR_ERROR Enigma2::SetEPGMaxFutureDays(int epgMaxFutureDays)
+{
+  if (!IsConnected())
+    return PVR_ERROR_SERVER_ERROR;
+
+  m_epg.SetEPGMaxFutureDays(epgMaxFutureDays);
   return PVR_ERROR_NO_ERROR;
 }
 

--- a/src/Enigma2.h
+++ b/src/Enigma2.h
@@ -70,7 +70,8 @@ public:
   PVR_ERROR GetChannels(bool radio, kodi::addon::PVRChannelsResultSet& results) override;
   PVR_ERROR GetChannelStreamProperties(const kodi::addon::PVRChannel& channel, std::vector<kodi::addon::PVRStreamProperty>& properties) override;
   PVR_ERROR GetEPGForChannel(int channelUid, time_t start, time_t end, kodi::addon::PVREPGTagsResultSet& results) override;
-  PVR_ERROR SetEPGTimeFrame(int epgMaxDays) override;
+  PVR_ERROR SetEPGMaxPastDays(int epgMaxPastDays) override;
+  PVR_ERROR SetEPGMaxFutureDays(int epgMaxFutureDays) override;
 
   //recordings and Timers
   PVR_ERROR GetRecordingsAmount(bool deleted, int& amount) override;
@@ -140,13 +141,14 @@ private:
   std::atomic_bool m_dueRecordingUpdate{true};
   time_t m_lastSignalStatusUpdateSeconds;
   bool m_skipInitialEpgLoad;
-  int m_epgMaxDays;
+  int m_epgMaxPastDays;
+  int m_epgMaxFutureDays;
 
   mutable enigma2::Channels m_channels;
   enigma2::ChannelGroups m_channelGroups;
   enigma2::Recordings m_recordings{*this, m_channels, m_entryExtractor};
   std::vector<std::string>& m_locations = m_recordings.GetLocations();
-  enigma2::Epg m_epg{*this, m_entryExtractor, m_epgMaxDays};
+  enigma2::Epg m_epg{*this, m_entryExtractor, m_epgMaxPastDays, m_epgMaxFutureDays};
   enigma2::Timers m_timers{*this, m_channels, m_channelGroups, m_locations, m_epg, m_entryExtractor};
   enigma2::Settings& m_settings = enigma2::Settings::GetInstance();
   enigma2::Admin m_admin;

--- a/src/enigma2/Epg.h
+++ b/src/enigma2/Epg.h
@@ -30,7 +30,7 @@ namespace enigma2
   class ATTRIBUTE_HIDDEN Epg
   {
   public:
-    Epg(IConnectionListener& connectionListener, enigma2::extract::EpgEntryExtractor& entryExtractor, int epgMaxDays);
+    Epg(IConnectionListener& connectionListener, enigma2::extract::EpgEntryExtractor& entryExtractor, int epgMaxPastDays, int epgMaxFutureDays);
     Epg(const enigma2::Epg& epg);
 
     bool Initialise(enigma2::Channels& channels, enigma2::ChannelGroups& channelGroups);
@@ -38,7 +38,8 @@ namespace enigma2
     void TriggerEpgUpdatesForChannels();
     void MarkChannelAsInitialEpgRead(const std::string& serviceReference);
     PVR_ERROR GetEPGForChannel(const std::string& serviceReference, time_t start, time_t end, kodi::addon::PVREPGTagsResultSet& results);
-    void SetEPGTimeFrame(int epgMaxDays);
+    void SetEPGMaxPastDays(int epgMaxPastDays);
+    void SetEPGMaxFutureDays(int epgMaxFutureDays);
     std::string LoadEPGEntryShortDescription(const std::string& serviceReference, unsigned int epgUid);
     data::EpgPartialEntry LoadEPGEntryPartialDetails(const std::string& serviceReference, time_t startTime);
     data::EpgPartialEntry LoadEPGEntryPartialDetails(const std::string& serviceReference, unsigned int epgUid);
@@ -59,8 +60,10 @@ namespace enigma2
     enigma2::extract::EpgEntryExtractor& m_entryExtractor;
 
     bool m_initialEpgReady = false;
-    int m_epgMaxDays;
-    long m_epgMaxDaysSeconds;
+    int m_epgMaxPastDays;
+    int m_epgMaxFutureDays;
+    long m_epgMaxPastDaysSeconds;
+    long m_epgMaxFutureDaysSeconds;
 
     std::vector<std::shared_ptr<data::EpgChannel>> m_epgChannels;
     std::map<std::string, std::shared_ptr<data::EpgChannel>> m_epgChannelsMap;

--- a/src/enigma2/Timers.cpp
+++ b/src/enigma2/Timers.cpp
@@ -503,6 +503,9 @@ PVR_ERROR Timers::AddTimer(const kodi::addon::PVRTimer& timer)
   }
   endTime = timer.GetEndTime() + (endPadding * 60);
 
+  if (endTime <= startTime)
+    endTime = timer.GetStartTime() + (60 * 60 * 2) + (endPadding * 60); // default to 2 hours for invalid end time
+
   tags.AddTag(TAG_FOR_PADDING, StringUtils::Format("%u,%u", startPadding, endPadding));
 
   std::string title = timer.GetTitle();


### PR DESCRIPTION
v7.3.0
- Update: PVR API 7.1.0
- Added: allow both epg max past and future days
- Fixed: Default of 2 hours when a timer is created with an invalid end time