### PR TITLE
inside addon.xml required depends defined two times

### DIFF
--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -1,14 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="7.3.0"
+  version="7.3.1"
   name="Enigma2 Client"
   provider-name="Joerg Dembski and Ross Nicholson">
-  <requires>
-    @ADDON_DEPENDS@
+  <requires>@ADDON_DEPENDS@
     <import addon="inputstream.ffmpegdirect" minversion="1.18.0" optional="true"/>
   </requires>
-  <requires>@ADDON_DEPENDS@</requires>
   <extension
     point="kodi.pvrclient"
     library_@PLATFORM@="@LIBRARY_FILENAME@"/>
@@ -185,6 +183,9 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v7.3.1
+- Fix: Depends inside addon.xml defined two times
+
 v7.3.0
 - Update: PVR API 7.1.0
 - Added: allow both epg max past and future days

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,3 +1,6 @@
+v7.3.1
+- Fix: Depends inside addon.xml defined two times
+
 v7.3.0
 - Update: PVR API 7.1.0
 - Added: allow both epg max past and future days


### PR DESCRIPTION
Fix and version increase to 7.3.1

Seen this on addons.xml.gz about binary repo:
```xml
<addon id="pvr.vuplus" version="7.3.0" name="Enigma2 Client" provider-name="Joerg Dembski and Ross Nicholson">
<requires>
<import addon="kodi.binary.global.main" minversion="1.2.0" version="1.3.0"/>
<import addon="kodi.binary.global.general" minversion="1.0.4" version="1.0.5"/>
<import addon="kodi.binary.global.filesystem" minversion="1.1.0" version="1.1.6"/>
<import addon="kodi.binary.global.network" minversion="1.0.0" version="1.0.4"/>
<import addon="kodi.binary.global.tools" minversion="1.0.0" version="1.0.4"/>
<import addon="kodi.binary.instance.pvr" minversion="7.1.0" version="7.1.0"/>
<import addon="inputstream.ffmpegdirect" minversion="1.18.0" optional="true"/>
</requires>
<requires>
<import addon="kodi.binary.global.main" minversion="1.2.0" version="1.3.0"/>
<import addon="kodi.binary.global.general" minversion="1.0.4" version="1.0.5"/>
<import addon="kodi.binary.global.filesystem" minversion="1.1.0" version="1.1.6"/>
<import addon="kodi.binary.global.network" minversion="1.0.0" version="1.0.4"/>
<import addon="kodi.binary.global.tools" minversion="1.0.0" version="1.0.4"/>
<import addon="kodi.binary.instance.pvr" minversion="7.1.0" version="7.1.0"/>
</requires>
<extension point="kodi.pvrclient" library_windows="pvr.vuplus.dll"/>
```