### PR TITLE
Use internal openwebif movielist to avoid memory leak on some images

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Some features are only available with at least certain OpenWebIf versions:
 * `1.3.5`: Embedded EPG Genres, Tuner Details, Provider Name, Picon URLs
 * `1.3.6`: Editing Recordings
 * `1.3.7`: Backend Channel Numbers
+* `1.3.9`: Recording Sizes
+* `1.4.4`: Recursive Movie listing
+* `1.4.6`: Use internal OWF MovieList (avoids memory leak on some images)
 
 The contents of this README.md file are as follows:
 

--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="7.4.2"
+  version="7.4.3"
   name="Enigma2 Client"
   provider-name="Joerg Dembski and Ross Nicholson">
   <requires>@ADDON_DEPENDS@
@@ -183,6 +183,9 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v7.4.3
+- Fixed: Use OpenWebIfs internal MovieList to avoid memory leak on some images
+
 v7.4.2
 - Update: Switch disk space logging to debug level
 

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,3 +1,6 @@
+v7.4.3
+- Fixed: Use OpenWebIfs internal MovieList to avoid memory leak on some images
+
 v7.4.2
 - Update: Switch disk space logging to debug level
 

--- a/src/enigma2/Settings.h
+++ b/src/enigma2/Settings.h
@@ -256,6 +256,8 @@ namespace enigma2
     bool SupportsProviderNumberAndPiconForChannels() const { return CheckOpenWebIfVersion(1, 3, 5); }
     bool SupportsChannelNumberGroupStartPos() const { return CheckOpenWebIfVersion(1, 3, 8); }
     bool SupportsRecordingSizes() const { return CheckOpenWebIfVersion(1, 3, 9); }
+    bool SupportsMovieListRecursive() const { return CheckOpenWebIfVersion(1, 4, 4); }
+    bool SupportsMovieListOWFInternal() const { return CheckOpenWebIfVersion(1, 4, 6); }
 
     bool UsesLastScannedChannelGroup() const { return m_usesLastScannedChannelGroup; }
     void SetUsesLastScannedChannelGroup(bool value) { m_usesLastScannedChannelGroup = value; }


### PR DESCRIPTION
v7.4.3
- Fixed: Use OpenWebIfs internal MovieList to avoid memory leak on some images