### PR TITLE
e2: Add missing radio service type 0x0A, fixes #353

### DIFF
--- a/src/enigma2/data/Channel.cpp
+++ b/src/enigma2/data/Channel.cpp
@@ -222,7 +222,7 @@ bool Channel::HasRadioServiceType()
   if (found != std::string::npos)
     radioServiceType = radioServiceType.substr(0, found);
 
-  return radioServiceType == RADIO_SERVICE_TYPE;
+  return std::find(RADIO_SERVICE_TYPES.begin(), RADIO_SERVICE_TYPES.end(), radioServiceType) != RADIO_SERVICE_TYPES.end();
 }
 
 void Channel::UpdateTo(kodi::addon::PVRChannel& left) const

--- a/src/enigma2/data/Channel.h
+++ b/src/enigma2/data/Channel.h
@@ -13,6 +13,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <array>
 
 #include <kodi/addon-instance/pvr/Channels.h>
 #include <tinyxml.h>
@@ -28,7 +29,8 @@ namespace enigma2
     public:
       const std::string SERVICE_REF_GENERIC_PREFIX = "1:0:1:";
       const std::string SERVICE_REF_GENERIC_POSTFIX = ":0:0:0";
-      const std::string RADIO_SERVICE_TYPE = "2";
+      // There are at least two different service types for radio, see EN300468 Table 87
+      const std::array<std::string, 3> RADIO_SERVICE_TYPES = {"2", "A", "a"};
 
       Channel() = default;
       Channel(const Channel &c) : BaseChannel(c), m_channelNumber(c.GetChannelNumber()), m_standardServiceReference(c.GetStandardServiceReference()),


### PR DESCRIPTION
This fixes the lack of "advanced format" radio channels in the list, as they are now getting correctly classified.
Can be tested with the new Astra 19.2 AAC offerings, e.g: SWR3 1:0:A:28CB:40F:1:C00000:0:0:0:
See Table 87 in https://www.etsi.org/deliver/etsi_en/300400_300499/300468/01.15.01_60/en_300468v011501p.pdf

This fixes #353