### PR TITLE
Automatically convert Stream Relay service references to Satellite service references

### DIFF
--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="19.0.0"
+  version="19.0.1"
   name="Enigma2 Client"
   provider-name="Joerg Dembski and Ross Nicholson">
   <requires>@ADDON_DEPENDS@

--- a/src/enigma2/data/Channel.h
+++ b/src/enigma2/data/Channel.h
@@ -28,6 +28,8 @@ namespace enigma2
     public:
       const std::string SERVICE_REF_GENERIC_PREFIX = "1:0:1:";
       const std::string SERVICE_REF_GENERIC_POSTFIX = ":0:0:0";
+      const std::string SAT_SERVICE_REFERENCE_POSTFIX = "C00000:0:0:0:";
+      const std::string STREAM_REPLAY_SERVICE_REFERENCE_POSTFIX = "21:0:0:0:";
       // There are at least two different service types for radio, see EN300468 Table 87
       const std::array<std::string, 3> RADIO_SERVICE_TYPES = {"2", "A", "a"};
 


### PR DESCRIPTION
How encryption is used in Germany (Sky) changed recently and the following workaround is required to decode channels
There should be no downstream impact to other providers

We'll default by converting any sRefs starting with `21:0:0:0:` to end with `C00000:0:0:0`