### PR TITLE
Autotimer match from start - Matrix

### DIFF
--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="19.0.0"
+  version="19.0.1"
   name="Enigma2 Client"
   provider-name="Joerg Dembski and Ross Nicholson">
   <requires>@ADDON_DEPENDS@

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,3 +1,6 @@
+v19.0.1
+- Always match auto timers from start then when not doing a full text search. Then episodes like finals etc. will still be caught by the autotimer.
+
 v19.0.0
 - Translations updates from Weblate
   - ko_kr, uk_ua

--- a/src/enigma2/Timers.cpp
+++ b/src/enigma2/Timers.cpp
@@ -613,7 +613,7 @@ PVR_ERROR Timers::AddAutoTimer(const kodi::addon::PVRTimer& timer)
   if (timer.GetFullTextEpgSearch())
     strTmp += StringUtils::Format("&searchType=%s", WebUtils::URLEncodeInline(AUTOTIMER_SEARCH_TYPE_DESCRIPTION).c_str());
   else
-    strTmp += StringUtils::Format("&searchType=%s", WebUtils::URLEncodeInline(AUTOTIMER_SEARCH_TYPE_EXACT).c_str());
+    strTmp += StringUtils::Format("&searchType=%s", WebUtils::URLEncodeInline(AUTOTIMER_SEARCH_TYPE_START).c_str());
 
   std::underlying_type<AutoTimer::DeDup>::type deDup = static_cast<AutoTimer::DeDup>(timer.GetPreventDuplicateEpisodes());
   if (deDup == AutoTimer::DeDup::DISABLED)


### PR DESCRIPTION
Always match auto timers from start then when not doing a full text search. Then episodes like finals etc. will still be caught by the autotimer.

Example `The Masked Singer` and the and `The Masked Singer: Final`