### PR TITLE
Support Kodi filesystem API 1.1.8, which fixes a buffer overrun

### DIFF
--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="20.4.1"
+  version="20.4.2"
   name="Enigma2 Client"
   provider-name="Joerg Dembski and Ross Nicholson">
   <requires>@ADDON_DEPENDS@

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,3 +1,6 @@
+v20.4.2
+- Support Kodi filesystem API 1.1.8, which fixes a buffer overrun (https://github.com/xbmc/xbmc/pull/22593)
+
 v20.4.1
 - Always match auto timers from start then when not doing a full text search. Then episodes like finals etc. will still be caught by the autotimer.
 


### PR DESCRIPTION
v20.4.2
- Support Kodi filesystem API 1.1.8, which fixes a buffer overrun (https://github.com/xbmc/xbmc/pull/22593)
