### PR TITLE
Timeshift path fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Timeshifting is also available IPTV streams via [inputstream.ffmpegdirect](#http
     - `Disabled` - No timeshifting
     - `On Pause` - Timeshifting starts when a live stream is paused. E.g. you want to continue from where you were at after pausing.
     - `On Playback` - Timeshifting starts when a live stream is opened. E.g. You can go to any point in the stream since it was opened.
-* **Timeshift buffer path**: The path used to store the timeshift buffer. The default is the `addon_data/pvr.vuplus` folder in userdata.
+* **Timeshift buffer path**: The path used to store the timeshift buffer. The default is the `addon_data/pvr.vuplus` folder in userdata. Note that if another directory is specified and it does not exist the default will be used instead.
 * **Enable timeshift disk limit**: For devices with limited disk space a limit in Gigabytes can be set whereby timeshift will be switched off and playback will return to the live stream. Note that for timeshift on playback it will not be possible to timeshift again until a stream is restarted once this limit is reached.
 * **Timeshift disk limit**: The disk space limit to use for the timeshift buffer in Gigabytes.
 * **Enable timeshift for IPTV streams**: Enable the timeshift feature for HTTP IPTV streams using `inputstream.ffmpegdirect`. Note that this feature only works `On playback` and will ignore the timeshift mode used for regular channel playback.

--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="21.1.2"
+  version="21.2.0"
   name="Enigma2 Client"
   provider-name="Joerg Dembski and Ross Nicholson">
   <requires>@ADDON_DEPENDS@

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,3 +1,7 @@
+v21.2.0
+- If a custom timeshift buffer path does not exist use the default instead
+- Fix special regex characters causing a crash for auto timers
+
 v21.1.2
 - Translations updates from Weblate
 	- ast_es, be_by, ca_es, cs_cz, da_dk, de_de, es_es, es_mx, et_ee, fi_fi, fr_fr, hr_hr, id_id, it_it, ja_jp, ko_kr, lt_lt, pl_pl, pt_br, ro_ro, ru_ru, sk_sk, sv_se, uk_ua, zh_cn, zh_tw

--- a/pvr.vuplus/resources/instance-settings.xml
+++ b/pvr.vuplus/resources/instance-settings.xml
@@ -842,7 +842,7 @@
           <default>false</default>
           <control type="toggle" />
         </setting>
-        <setting id="timeshiftdisklimit" type="number" label="30154" help="30628">
+        <setting id="timeshiftdisklimit" type="number" label="30154" help="30728">
           <level>0</level>
           <default>4.0</default>
           <constraints>

--- a/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.vuplus/resources/language/resource.language.en_gb/strings.po
@@ -1365,7 +1365,7 @@ msgstr ""
 
 #. help: Timeshift - timeshiftbufferpath
 msgctxt "#30722"
-msgid "The path used to store the timeshift buffer. The default is the `addon_data/pvr.vuplus` folder in userdata."
+msgid "The path used to store the timeshift buffer. The default is the `addon_data/pvr.vuplus` folder in userdata. Note that if another directory is specified and it does not exist the default will be used instead."
 msgstr ""
 
 #. help: Timeshift - timeshiftEnabled

--- a/src/enigma2/InstanceSettings.cpp
+++ b/src/enigma2/InstanceSettings.cpp
@@ -377,7 +377,7 @@ ADDON_STATUS InstanceSettings::SetSetting(const std::string& settingName, const 
 
 bool InstanceSettings::IsTimeshiftBufferPathValid() const
 {
-  return kodi::vfs::DirectoryExists(m_timeshiftBufferPath);
+  return kodi::vfs::DirectoryExists(m_timeshiftBufferPath) || kodi::vfs::DirectoryExists(ADDON_DATA_BASE_DIR);
 }
 
 bool InstanceSettings::LoadCustomChannelGroupFile(std::string& xmlFile, std::vector<std::string>& channelGroupNameList)

--- a/src/enigma2/Timers.cpp
+++ b/src/enigma2/Timers.cpp
@@ -164,7 +164,8 @@ void Timers::GenerateChildManualRepeatingTimers(std::vector<Timer>* timers, Time
 
 std::string Timers::ConvertToAutoTimerTag(std::string tag)
 {
-  static const std::regex regex(" ");
+  // Replace spaces and any special regex characters with underscores
+  static const std::regex regex(" |\\*|\\?|\\+|\\{");
   std::string replaceWith = "_";
 
   return std::regex_replace(tag, regex, replaceWith);

--- a/src/enigma2/TimeshiftBuffer.h
+++ b/src/enigma2/TimeshiftBuffer.h
@@ -43,7 +43,7 @@ namespace enigma2
     static const int DEFAULT_READ_TIMEOUT = 10;
     static const int READ_WAITTIME = 50;
 
-    std::string m_bufferPath;
+    std::string m_bufferFile;
     IStreamReader* m_streamReader;
     kodi::vfs::CFile m_filebufferReadHandle;
     kodi::vfs::CFile m_filebufferWriteHandle;


### PR DESCRIPTION
v21.2.0
- If a custom timeshift buffer path does not exist use the default instead
- Fix special regex characters causing a crash for auto timers