### PR TITLE
URL-encode spaces as %20 in picon HTTP request URLs

### DIFF
--- a/pvr.vuplus/addon.xml.in
+++ b/pvr.vuplus/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="22.3.5"
+  version="22.3.6"
   name="Enigma2 Client"
   provider-name="Joerg Dembski and Ross Nicholson">
   <requires>@ADDON_DEPENDS@

--- a/pvr.vuplus/changelog.txt
+++ b/pvr.vuplus/changelog.txt
@@ -1,3 +1,6 @@
+v22.3.6
+- Fix picon HTTP requests failing with 400 Bad Request when channel names contain spaces (URL-encode spaces as %20)
+
 v22.3.4
 - Translations updates from Weblate
 	- af_za, am_et, ar_sa, ast_es, az_az, be_by, bg_bg, bs_ba, ca_es, cs_cz, cy_gb, da_dk, de_de, el_gr, en_au, en_nz, en_us, eo, es_ar, es_es, es_mx, et_ee, eu_es, fa_af, fa_ir, fi_fi, fo_fo, fr_ca, fr_fr, gl_es, he_il, hi_in, hr_hr, hu_hu, hy_am, id_id, is_is, it_it, ja_jp, ko_kr, lt_lt, lv_lv, mi, mk_mk, ml_in, mn_mn, ms_my, mt_mt, my_mm, nb_no, nl_nl, pl_pl, prs, pt_br, pt_pt, ro_ro, ru_ru, si_lk, sk_sk, sl_si, sq_al, sr_rs, sr_rs@latin, sv_se, szl, ta_in, te_in, tg_tj, th_th, tr_tr, uk_ua, uz_uz, vi_vn, zh_cn, zh_tw

--- a/src/enigma2/Channels.cpp
+++ b/src/enigma2/Channels.cpp
@@ -345,7 +345,9 @@ int Channels::LoadChannelsExtraData(const std::shared_ptr<enigma2::data::Channel
               {
                 std::string connectionURL = m_settings->GetConnectionURL();
                 connectionURL = connectionURL.substr(0, connectionURL.size() - 1);
-                channel->SetIconPath(StringUtils::Format("%s%s", connectionURL.c_str(), jsonChannel["picon"].get<std::string>().c_str()));
+                std::string piconPath = jsonChannel["picon"].get<std::string>();
+                StringUtils::Replace(piconPath, " ", "%20");
+                channel->SetIconPath(StringUtils::Format("%s%s", connectionURL.c_str(), piconPath.c_str()));
 
                 Logger::Log(LEVEL_DEBUG, "%s For Channel %s, using OpenWebPiconPath: %s", __func__, jsonChannel["servicename"].get<std::string>().c_str(), channel->GetIconPath().c_str());
               }

--- a/src/enigma2/data/Channel.cpp
+++ b/src/enigma2/data/Channel.cpp
@@ -181,7 +181,11 @@ std::string Channel::CreateIconPath(const std::string& commonServiceReference)
   std::replace(iconPath.begin(), iconPath.end(), ':', '_');
 
   if (m_settings->UseOnlinePicons())
-    iconPath = StringUtils::Format("%spicon/%s.png", m_settings->GetConnectionURL().c_str(), iconPath.c_str());
+  {
+    std::string encodedPath = iconPath;
+    StringUtils::Replace(encodedPath, " ", "%20");
+    iconPath = StringUtils::Format("%spicon/%s.png", m_settings->GetConnectionURL().c_str(), encodedPath.c_str());
+  }
   else
     iconPath = m_settings->GetIconPath().c_str() + iconPath + ".png";
 


### PR DESCRIPTION
## Summary

Fix picon HTTP requests failing with 400 Bad Request when channel names contain spaces.

Closes #496

## Problem

When fetching picons from the web interface, the addon constructs HTTP URLs using the raw picon path without URL-encoding spaces. Web servers reject these malformed URLs with a 400 Bad Request error, leaving all channels with spaces in their name without an icon.

This affects both code paths:
- `Channel::CreateIconPath()` — used when **Use OpenWebIf picon path** is disabled
- `Channels::LoadChannelsExtraData()` — used when **Use OpenWebIf picon path** is enabled

## Fix

URL-encode spaces as `%20` before constructing the picon URL in both code paths.

### `src/enigma2/data/Channel.cpp`

```diff
  if (m_settings->UseOnlinePicons())
-   iconPath = StringUtils::Format("%spicon/%s.png", m_settings->GetConnectionURL().c_str(), iconPath.c_str());
+  {
+    std::string encodedPath = iconPath;
+    StringUtils::Replace(encodedPath, " ", "%20");
+    iconPath = StringUtils::Format("%spicon/%s.png", m_settings->GetConnectionURL().c_str(), encodedPath.c_str());
+  }
  else
    iconPath = m_settings->GetIconPath().c_str() + iconPath + ".png";
```

### `src/enigma2/Channels.cpp`

```diff
  std::string connectionURL = m_settings->GetConnectionURL();
  connectionURL = connectionURL.substr(0, connectionURL.size() - 1);
- channel->SetIconPath(StringUtils::Format("%s%s", connectionURL.c_str(), jsonChannel["picon"].get<std::string>().c_str()));
+ std::string piconPath = jsonChannel["picon"].get<std::string>();
+ StringUtils::Replace(piconPath, " ", "%20");
+ channel->SetIconPath(StringUtils::Format("%s%s", connectionURL.c_str(), piconPath.c_str()));
```